### PR TITLE
Joined barlines for groups. Squared bracket. Left barline in empty scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Default styles added to headings, paragraps and tables (issue #43).
 - New system tag now works again (issue #1).
 - MusicXML importer now supports part groups.
+- Added squared bracket for part groups (group symbol == line)
+- Left barline at start of sytems now also drawn in empty scores
 
 
 Version [0.19.0] (2/May/2016)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,13 @@
 ##### COMPATIBLE CHANGES
 
 - Names and brackets/braces for groups of instruments now supported and rendered.
+- Barlines for groups now can be joined. Also mensurstrich layout is supported.
+- Left barline at start of sytems now also drawn in empty scores
 - Whitespace in text now proprely managed in LMD files (issue #42).
 - Default styles added to headings, paragraps and tables (issue #43).
 - New system tag now works again (issue #1).
 - MusicXML importer now supports part groups.
 - Added squared bracket for part groups (group symbol == line)
-- Left barline at start of sytems now also drawn in empty scores
 
 
 Version [0.19.0] (2/May/2016)

--- a/include/lomse_engraving_options.h
+++ b/include/lomse_engraving_options.h
@@ -58,8 +58,11 @@ namespace lomse
 #define LOMSE_GRP_SPACE_AFTER_NAME      10.0f   //"InstrGroup/Space after name"
 #define LOMSE_GRP_BRACKET_WIDTH          5.0f   //"InstrGroup/Width of bracket"
 #define LOMSE_GRP_BRACKET_GAP            5.0f   //"InstrGroup/Space after bracket"
+#define LOMSE_GRP_BRACKET_HOOK          10.0f   //"InstrGroup/Length of hook for bracket"
 #define LOMSE_GRP_BRACE_WIDTH           12.5f   //"InstrGroup/Width of brace"
 #define LOMSE_GRP_BRACE_GAP              5.0f   //"InstrGroup/Space after brace"
+#define LOMSE_GRP_SQBRACKET_WIDTH        8.0f   //"InstrGroup/Width of squared bracket"
+#define LOMSE_GRP_SQBRACKET_LINE         2.0f   //"InstrGroup/line thickness for squared bracket"
 
 //Notes / accidentals
 #define LOMSE_STEM_THICKNESS             1.2f

--- a/include/lomse_gm_basic.h
+++ b/include/lomse_gm_basic.h
@@ -150,7 +150,8 @@ public:
                 k_shape_line, k_shape_note, k_shape_notehead,
                 k_shape_ornament,
                 k_shape_rectangle, k_shape_rest, k_shape_rest_glyph,
-                k_shape_slur, k_shape_stem, k_shape_staff,
+                k_shape_slur, k_shape_squared_bracket,
+                k_shape_stem, k_shape_staff,
                 k_shape_technical,
                 k_shape_text, k_shape_time_signature, k_shape_tie,
                 k_shape_time_signature_glyph, k_shape_tuplet, k_shape_word,
@@ -210,6 +211,7 @@ public:
     inline bool is_shape_rest() { return m_objtype == k_shape_rest; }
     inline bool is_shape_rest_glyph() { return m_objtype == k_shape_rest_glyph; }
     inline bool is_shape_slur() { return m_objtype == k_shape_slur; }
+    inline bool is_shape_squared_bracket() { return m_objtype == k_shape_squared_bracket; }
     inline bool is_shape_stem() { return m_objtype == k_shape_stem; }
     inline bool is_shape_staff() { return m_objtype == k_shape_staff; }
     inline bool is_shape_technical() { return m_objtype == k_shape_technical; }

--- a/include/lomse_instrument_engraver.h
+++ b/include/lomse_instrument_engraver.h
@@ -159,6 +159,9 @@ protected:
     std::vector<LUnits> m_staffTopLine;
     std::vector<LUnits> m_lineThickness;
 
+    //next instrument engraver
+    InstrumentEngraver* m_pNextInstrEngr;
+
 public:
     InstrumentEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
                        ImoInstrument* pInstr, ImoScore* pScore);
@@ -196,6 +199,10 @@ public:
     inline LUnits get_staves_left() { return m_stavesLeft; }
     inline LUnits get_staves_right() { return m_stavesLeft + m_stavesWidth; }
 
+    //barlines' segments
+    LUnits get_barline_top();
+    LUnits get_barline_bottom();
+
     //helper
     LUnits tenths_to_logical(Tenths value, int iStaff=0);
 
@@ -203,6 +210,11 @@ protected:
     void measure_name_abbrev();
     void measure_brace_or_bracket();
     bool has_brace_or_bracket();
+
+    friend class PartsEngraver;
+    void set_next_instrument_engraver(InstrumentEngraver* pNextEngrv) {
+        m_pNextInstrEngr = pNextEngrv;
+    }
 
 };
 

--- a/include/lomse_internal_model.h
+++ b/include/lomse_internal_model.h
@@ -3088,7 +3088,7 @@ protected:
 public:
     virtual ~ImoInstrGroup();
 
-    enum { k_none=0, k_default, k_brace, k_bracket, };
+    enum { k_none=0, k_brace, k_bracket, k_line, };
 
     //getters
     inline bool join_barlines() { return m_fJoinBarlines; }

--- a/include/lomse_internal_model.h
+++ b/include/lomse_internal_model.h
@@ -3106,7 +3106,7 @@ public:
     inline void set_join_barlines(int value) { m_joinBarlines = value; }
 
     //instruments
-    //ImoInstruments* get_instruments();
+    inline list<ImoInstrument*>& get_instruments() { return m_instruments; }
     void add_instrument(ImoInstrument* pInstr);
     ImoInstrument* get_instrument(int iInstr);   //0..n-1
     int get_num_instruments();
@@ -3131,6 +3131,7 @@ protected:
 //    ImoInstrGroup*  m_pGroup;
     string          m_partId;
     std::list<ImoStaffInfo*> m_staves;
+    int             m_barlineLayout;        //enum EBarlineLayout
 
     friend class ImFactory;
     ImoInstrument();
@@ -3141,6 +3142,8 @@ protected:
 
 public:
     virtual ~ImoInstrument();
+
+    enum EBarlineLayout { k_isolated=0, k_joined, k_mensurstrich, k_nothing, };
 
     //getters
     inline int get_num_staves() { return static_cast<int>(m_staves.size()); }
@@ -3154,6 +3157,7 @@ public:
     ImoStaffInfo* get_staff(int iStaff);
     LUnits get_line_spacing_for_staff(int iStaff);
     inline const string& get_instr_id() { return m_partId; }
+    inline int get_barline_layout() { return m_barlineLayout; }
 
     //setters
     ImoStaffInfo* add_staff();
@@ -3167,6 +3171,7 @@ public:
 //    inline void set_in_group(ImoInstrGroup* pGroup) { m_pGroup = pGroup; }
     void replace_staff_info(ImoStaffInfo* pInfo);
     inline void set_instr_id(const string& id) { m_partId = id; }
+    inline void set_barline_layout(int value) { m_barlineLayout = value; }
 
     //info
     inline bool has_name() { return m_name.get_text() != ""; }

--- a/include/lomse_internal_model.h
+++ b/include/lomse_internal_model.h
@@ -3073,7 +3073,7 @@ class ImoInstrGroup : public ImoSimpleObj
 {
 protected:
     ImoScore* m_pScore;
-    bool m_fJoinBarlines;
+    int m_joinBarlines;     // enum k_no, k_standard, k_mensurstrich
     int m_symbol;           // enum k_none, k_default, k_brace, k_bracket, ...
     ImoScoreText m_name;
     ImoScoreText m_abbrev;
@@ -3089,9 +3089,10 @@ public:
     virtual ~ImoInstrGroup();
 
     enum { k_none=0, k_brace, k_bracket, k_line, };
+    enum { k_no=0, k_standard, k_mensurstrich, };
 
     //getters
-    inline bool join_barlines() { return m_fJoinBarlines; }
+    inline int join_barlines() { return m_joinBarlines; }
     inline int get_symbol() { return m_symbol; }
     inline const std::string& get_name_string() { return m_name.get_text(); }
     inline const std::string& get_abbrev_string() { return m_abbrev.get_text(); }
@@ -3102,7 +3103,7 @@ public:
     void set_name(ImoScoreText* pText);
     void set_abbrev(ImoScoreText* pText);
     inline void set_symbol(int symbol) { m_symbol = symbol; }
-    inline void set_join_barlines(bool value) { m_fJoinBarlines = value; }
+    inline void set_join_barlines(int value) { m_joinBarlines = value; }
 
     //instruments
     //ImoInstruments* get_instruments();

--- a/include/lomse_mxl_analyser.h
+++ b/include/lomse_mxl_analyser.h
@@ -195,12 +195,13 @@ public:
 
     void add_instrument_to_groups(ImoInstrument* pInstr);
     void start_group(int number, ImoInstrGroup* pGrp);
-    void remove_group(int number);
+    void terminate_group(int number);
     bool group_exists(int number);
     ImoInstrGroup* get_group(int number);
     void check_if_all_groups_are_closed(ostream& reporter);
 
 protected:
+    void set_barline_layout_in_instruments(ImoInstrGroup* pGrp);
 
 };
 
@@ -284,7 +285,7 @@ public:
 
     //part-group
     ImoInstrGroup* start_part_group(int number);
-    void remove_part_group(int number);
+    void terminate_part_group(int number);
     ImoInstrGroup* get_part_group(int number);
     void check_if_all_groups_are_closed();
 

--- a/include/lomse_shape_brace_bracket.h
+++ b/include/lomse_shape_brace_bracket.h
@@ -113,6 +113,29 @@ protected:
 };
 
 
+//---------------------------------------------------------------------------------------
+class GmoShapeSquaredBracket : public GmoSimpleShape
+{
+protected:
+    LUnits m_lineThickness;
+
+    friend class InstrumentEngraver;
+    friend class GroupEngraver;
+    GmoShapeSquaredBracket(ImoObj* pCreatorImo, ShapeId idx, LUnits xLeft, LUnits yTop,
+                           LUnits xRight, LUnits yBottom, LUnits lineThickness,
+                           Color color);
+
+public:
+    ~GmoShapeSquaredBracket();
+
+	//implementation of pure virtual methods in base class
+    void on_draw(Drawer* pDrawer, RenderOptions& opt);
+
+protected:
+
+};
+
+
 }   //namespace lomse
 
 #endif    // __LOMSE_SHAPE_BRACE_BRACKET_H__

--- a/include/lomse_shape_staff.h
+++ b/include/lomse_shape_staff.h
@@ -55,7 +55,7 @@ public: //TO_FIX: constructor invoked from test
 public:
     ~GmoShapeStaff();
 
-//	//implementation of pure virtual methods in base class
+	//implementation of pure virtual methods in base class
     void on_draw(Drawer* pDrawer, RenderOptions& opt);
 //    void Shift(LUnits xIncr, LUnits yIncr);
 

--- a/src/graphic_model/engravers/lomse_instrument_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_instrument_engraver.cpp
@@ -41,8 +41,6 @@
 #include "lomse_score_layouter.h"
 #include "lomse_right_aligner.h"
 
-#include "lomse_shapes.h"
-
 namespace lomse
 {
 

--- a/src/graphic_model/engravers/lomse_instrument_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_instrument_engraver.cpp
@@ -41,6 +41,7 @@
 #include "lomse_score_layouter.h"
 #include "lomse_right_aligner.h"
 
+#include "lomse_shapes.h"
 
 namespace lomse
 {
@@ -408,11 +409,20 @@ void GroupEngraver::measure_brace_or_bracket()
 
         LUnits uBracketWidth;
         if (symbol == ImoInstrGroup::k_brace)
+        {
             uBracketWidth = tenths_to_logical(LOMSE_GRP_BRACE_WIDTH);
-        else
+            m_uBracketGap = tenths_to_logical(LOMSE_GRP_BRACKET_GAP);
+        }
+        else if  (symbol == ImoInstrGroup::k_bracket)
+        {
             uBracketWidth = tenths_to_logical(LOMSE_GRP_BRACKET_WIDTH);
-
-        m_uBracketGap = tenths_to_logical(LOMSE_GRP_BRACKET_GAP);
+            m_uBracketGap = tenths_to_logical(LOMSE_GRP_BRACKET_GAP);
+        }
+        else
+        {
+            uBracketWidth = tenths_to_logical(LOMSE_GRP_SQBRACKET_WIDTH);
+            m_uBracketGap = tenths_to_logical(1.0f);   //0.0f;
+        }
 
         m_bracketFirstBox.x = 0.0f;
         m_bracketFirstBox.y = m_stavesTop;
@@ -425,7 +435,7 @@ void GroupEngraver::measure_brace_or_bracket()
 bool GroupEngraver::has_brace_or_bracket()
 {
     int symbol = m_pGroup->get_symbol();
-    return (symbol == ImoInstrGroup::k_brace || symbol == ImoInstrGroup::k_bracket);
+    return (symbol != ImoInstrGroup::k_none);
 }
 
 //---------------------------------------------------------------------------------------
@@ -494,11 +504,17 @@ void GroupEngraver::add_brace_bracket(GmoBoxSystem* pBox, int iSystem)
         if (symbol == ImoInstrGroup::k_brace)
             pShape = LOMSE_NEW GmoShapeBrace(m_pGroup, idx, xLeft, yTop,
                                              xRight, yBottom, Color(0,0,0));
-        else
+        else if (symbol == ImoInstrGroup::k_bracket)
         {
-            LUnits dyHook = tenths_to_logical(6.0f);
+            LUnits dyHook = tenths_to_logical(LOMSE_GRP_BRACKET_HOOK);
             pShape = LOMSE_NEW GmoShapeBracket(m_pGroup, idx, xLeft, yTop, xRight,
                                                yBottom, dyHook, Color(0,0,0));
+        }
+        else
+        {
+            LUnits lineThickness = tenths_to_logical(LOMSE_GRP_SQBRACKET_LINE);
+            pShape = LOMSE_NEW GmoShapeSquaredBracket(m_pGroup, idx, xLeft, yTop, xRight,
+                                               yBottom, lineThickness, Color(0,0,0));
         }
         pBox->add_shape(pShape, GmoShape::k_layer_staff);
     }

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -1225,8 +1225,8 @@ GmoShape* ShapesCreator::create_staffobj_shape(ImoStaffObj* pSO, int iInstr, int
             ImoBarline* pImo = static_cast<ImoBarline*>(pSO);
             InstrumentEngraver* pInstrEngrv =
                 m_pPartsEngraver->get_engraver_for(iInstr);
-            LUnits yTop = pInstrEngrv->get_staves_top_line();
-            LUnits yBottom = pInstrEngrv->get_staves_bottom_line();
+            LUnits yTop = pInstrEngrv->get_barline_top();
+            LUnits yBottom = pInstrEngrv->get_barline_bottom();
             BarlineEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr);
             Color color = pImo->get_color();
             return engrv.create_shape(pImo, pos.x, yTop, yBottom, color);

--- a/src/graphic_model/layouters/lomse_system_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_system_layouter.cpp
@@ -202,10 +202,10 @@ void LineEntry::dump(int iEntry, ostream& outStream)
 //    }
 //    else
     {
-		outStream << "  pSO "
-					<< setw(4) << m_pSO->get_obj_type()
-					<< setw(4) << m_pSO->get_id()
-					<< (m_fProlog ? "   S  " : "      ");
+        string name = m_pSO->get_name();
+        name.resize(10, ' ');
+		outStream << name << setw(4) << m_pSO->get_id()
+                  << (m_fProlog ? "   S  " : "      ");
     }
 
     outStream << fixed << setprecision(2) << setfill(' ')
@@ -1367,15 +1367,13 @@ void SystemLayouter::redistribute_free_space()
 //---------------------------------------------------------------------------------------
 void SystemLayouter::add_initial_line_joining_all_staves_in_system()
 {
-    //TODO: In current code, the decision about joining staves depends only on first
-    //instrument. This should be changed and the line should go from first visible
-    //staff to last visible one.
-
+    //do not draw if 'hide staff lines' option enabled
     ImoOptionInfo* pOpt = m_pScore->get_option("StaffLines.Hide");
     bool fDrawStafflines = (pOpt == NULL || pOpt->get_bool_value() == false);
     if (!fDrawStafflines)
         return;
 
+    //do not draw if empty score with one instrument with one staff
     if (m_pScore->get_num_instruments() == 1)
     {
         ImoInstrument* pInstr = m_pScore->get_instrument(0);
@@ -1383,8 +1381,8 @@ void SystemLayouter::add_initial_line_joining_all_staves_in_system()
             return;
     }
 
-    //TODO: HideStaffLines option
-	if (m_pScoreMeter->must_draw_left_barline())    //&& !pVStaff->HideStaffLines() )
+    //do not draw if so asked when score meter was created (//TODO: what is this for?)
+	if (m_pScoreMeter->must_draw_left_barline())
 	{
         InstrumentEngraver* pInstrEngrv = m_pPartsEngraver->get_engraver_for(0);
         ImoObj* pCreator = m_pScore->get_instrument(0);

--- a/src/graphic_model/layouters/lomse_system_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_system_layouter.cpp
@@ -973,10 +973,7 @@ void SystemLayouter::engrave_system(LUnits indent, int iFirstCol, int iLastCol,
     engrave_instrument_details();
     add_instruments_info();
 
-    ImoOptionInfo* pOpt = m_pScore->get_option("StaffLines.Hide");
-    bool fDrawStafflines = (pOpt == NULL || pOpt->get_bool_value() == false);
-    if (!m_pScoreLyt->is_system_empty(m_iSystem) && fDrawStafflines)
-        add_initial_line_joining_all_staves_in_system();
+    add_initial_line_joining_all_staves_in_system();
 }
 
 //---------------------------------------------------------------------------------------
@@ -1374,8 +1371,17 @@ void SystemLayouter::add_initial_line_joining_all_staves_in_system()
     //instrument. This should be changed and the line should go from first visible
     //staff to last visible one.
 
-    if (m_pScoreMeter->is_empty_score())
+    ImoOptionInfo* pOpt = m_pScore->get_option("StaffLines.Hide");
+    bool fDrawStafflines = (pOpt == NULL || pOpt->get_bool_value() == false);
+    if (!fDrawStafflines)
         return;
+
+    if (m_pScore->get_num_instruments() == 1)
+    {
+        ImoInstrument* pInstr = m_pScore->get_instrument(0);
+        if (pInstr->get_num_staves() == 1 && m_pScoreMeter->is_empty_score())
+            return;
+    }
 
     //TODO: HideStaffLines option
 	if (m_pScoreMeter->must_draw_left_barline())    //&& !pVStaff->HideStaffLines() )

--- a/src/graphic_model/lomse_gm_basic.cpp
+++ b/src/graphic_model/lomse_gm_basic.cpp
@@ -201,6 +201,7 @@ const string& GmoObj::get_name(int objtype)
         m_typeToName[k_shape_rest_glyph]        = "rest-glyph     ";
         m_typeToName[k_shape_slur]              = "slur           ";
         m_typeToName[k_shape_stem]              = "stem           ";
+        m_typeToName[k_shape_squared_bracket]   = "squared-bracket";
         m_typeToName[k_shape_staff]             = "staff          ";
         m_typeToName[k_shape_technical]         = "technical      ";
         m_typeToName[k_shape_text]              = "text           ";

--- a/src/graphic_model/lomse_shape_brace_bracket.cpp
+++ b/src/graphic_model/lomse_shape_brace_bracket.cpp
@@ -323,4 +323,54 @@ unsigned GmoShapeBracket::vertex(double* px, double* py)
 }
 
 
+
+//---------------------------------------------------------------------------------------
+// Implementation of GmoShapeSquaredBracket
+//---------------------------------------------------------------------------------------
+GmoShapeSquaredBracket::GmoShapeSquaredBracket(ImoObj* pCreatorImo, ShapeId idx,
+                                               LUnits xLeft, LUnits yTop,
+                                               LUnits xRight, LUnits yBottom,
+                                               LUnits lineThickness, Color color)
+    : GmoSimpleShape(pCreatorImo, GmoObj::k_shape_squared_bracket, idx, color)
+    , m_lineThickness(lineThickness)
+{
+    set_origin(xLeft, yTop);
+	set_width(xRight - xLeft);
+	set_height(yBottom - yTop);
+
+}
+
+//---------------------------------------------------------------------------------------
+GmoShapeSquaredBracket::~GmoShapeSquaredBracket()
+{
+}
+
+//---------------------------------------------------------------------------------------
+void GmoShapeSquaredBracket::on_draw(Drawer* pDrawer, RenderOptions& opt)
+{
+    Color color = determine_color_to_use(opt);
+    pDrawer->begin_path();
+    pDrawer->stroke(color);
+    pDrawer->fill(Color(0,0,0,0));  //transparent
+    pDrawer->stroke_width(m_lineThickness);
+
+    //top hook
+    double yPos = m_origin.y;
+    pDrawer->move_to(m_origin.x + m_size.width, yPos);
+    pDrawer->hline_to(m_origin.x);
+
+    //vertical line
+    yPos += m_size.height;
+    pDrawer->vline_to(yPos);
+
+    //bottom hook
+    pDrawer->hline_to(m_origin.x + m_size.width);
+
+    pDrawer->end_path();
+    pDrawer->render();
+
+    GmoSimpleShape::on_draw(pDrawer, opt);
+}
+
+
 }  //namespace lomse

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -2385,7 +2385,7 @@ list<ImoStaffObj*> ImoInstrument::insert_staff_objects_at(ImoStaffObj* pAt,
 ImoInstrGroup::ImoInstrGroup()
     : ImoSimpleObj(k_imo_instr_group)
     , m_pScore(NULL)
-    , m_fJoinBarlines(true)
+    , m_joinBarlines(k_standard)
     , m_symbol(k_none)
     , m_name()
     , m_abbrev()

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -2059,6 +2059,7 @@ ImoInstrument::ImoInstrument()
     , m_midi()
 //    , m_pGroup(NULL)
     , m_partId("")
+    , m_barlineLayout(k_isolated)
 {
     add_staff();
 //	m_midiChannel = g_pMidi->DefaultVoiceChannel();

--- a/src/parser/ldp/lomse_ldp_analyser.cpp
+++ b/src/parser/ldp/lomse_ldp_analyser.cpp
@@ -2448,6 +2448,8 @@ protected:
             pGrp->set_symbol(ImoInstrGroup::k_brace);
         else if (symbol == "bracket")
             pGrp->set_symbol(ImoInstrGroup::k_bracket);
+        else if (symbol == "line")
+            pGrp->set_symbol(ImoInstrGroup::k_line);
         else if (symbol == "none")
             pGrp->set_symbol(ImoInstrGroup::k_none);
         else

--- a/src/parser/ldp/lomse_ldp_analyser.cpp
+++ b/src/parser/ldp/lomse_ldp_analyser.cpp
@@ -2382,7 +2382,7 @@ public:
 //@ <grpName> = <textString>
 //@ <grpAbbrev> = <textString>
 //@ <grpSymbol> = (symbol {none | brace | bracket} )
-//@ <joinBarlines> = (joinBarlines {yes | no} )
+//@ <joinBarlines> = (joinBarlines {yes | no | mensurstrich } )
 
 class GroupAnalyser : public ElementAnalyser
 {
@@ -2461,7 +2461,19 @@ protected:
     void set_join_barlines(ImoInstrGroup* pGrp)
     {
         m_pParamToAnalyse = m_pParamToAnalyse->get_parameter(1);
-        pGrp->set_join_barlines( get_bool_value(true) );
+        string value = get_string_value();
+        if (value == "yes")
+            pGrp->set_join_barlines(ImoInstrGroup::k_standard);
+        else if (value == "no")
+            pGrp->set_join_barlines(ImoInstrGroup::k_no);
+        else if (value == "mensurstrich")
+            pGrp->set_join_barlines(ImoInstrGroup::k_mensurstrich);
+        else
+        {
+            pGrp->set_join_barlines(ImoInstrGroup::k_standard);
+            error_msg("Invalid value for joinBarlines. Must be "
+                      "'yes', 'no' or 'mensurstrich'. 'yes' assumed.");
+        }
     }
 
 };

--- a/src/parser/lmd/lomse_lmd_analyser.cpp
+++ b/src/parser/lmd/lomse_lmd_analyser.cpp
@@ -2365,7 +2365,7 @@ public:
 //@ <!ELEMENT grpAbbrev (#PCDATA) >
 //@ <!ELEMENT grpSymbol (#PCDATA) >
 //@ <grpSymbol> = (symbol {none | brace | bracket} )
-//@ <!ELEMENT joinBarlines EMPTY >
+//@ <!ELEMENT joinBarlines (#PCDATA) >
 //@
 
 class GroupLmdAnalyser : public LmdElementAnalyser

--- a/src/parser/lmd/lomse_lmd_analyser.cpp
+++ b/src/parser/lmd/lomse_lmd_analyser.cpp
@@ -2452,11 +2452,13 @@ protected:
             pGrp->set_symbol(ImoInstrGroup::k_brace);
         else if (symbol == "bracket")
             pGrp->set_symbol(ImoInstrGroup::k_bracket);
+        else if (symbol == "line")
+            pGrp->set_symbol(ImoInstrGroup::k_line);
         else if (symbol == "none")
             pGrp->set_symbol(ImoInstrGroup::k_none);
         else
-            error_msg("Invalid value for <grpSymbol>. Must be 'none', 'brace' or "
-                      "'bracket'. 'none' assumed.");
+            error_msg("Invalid value for <grpSymbol>. Must be 'none', 'brace', "
+                      "'bracket' or 'line'. 'none' assumed.");
     }
 
     ImoScoreText* get_name_abbrev()

--- a/src/parser/lmd/lomse_lmd_analyser.cpp
+++ b/src/parser/lmd/lomse_lmd_analyser.cpp
@@ -2435,7 +2435,7 @@ public:
 
 //        // joinBarlines?
 //        if (get_optional("joinBarlines"))
-//            pGrp->set_join_barlines(true);
+//            pGrp->set_join_barlines(ImoInstrGroup::k_standard);
 //
         error_if_more_elements();
 

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -3688,18 +3688,14 @@ protected:
     {
         string value = m_childToAnalyse.value();
         if (value == "yes")
-            pGrp->set_join_barlines(true);
+            pGrp->set_join_barlines(ImoInstrGroup::k_standard);
         else if (value == "no")
-            pGrp->set_join_barlines(false);
+            pGrp->set_join_barlines(ImoInstrGroup::k_no);
         else if (value == "Mensurstrich")
-        {
-            pGrp->set_join_barlines(true);
-            error_msg("Value 'Mensurstrich' for <group-barline> not yet "
-                      "supported. Replaced by 'yes'.");
-        }
+            pGrp->set_join_barlines(ImoInstrGroup::k_mensurstrich);
         else
         {
-            pGrp->set_join_barlines(true);
+            pGrp->set_join_barlines(ImoInstrGroup::k_standard);
             error_msg("Invalid value for <group-barline>. Must be "
                       "'yes', 'no' or 'Mensurstrich'. 'yes' assumed.");
         }

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -3675,6 +3675,8 @@ protected:
             pGrp->set_symbol(ImoInstrGroup::k_brace);
         else if (symbol == "bracket")
             pGrp->set_symbol(ImoInstrGroup::k_bracket);
+        else if (symbol == "line")
+            pGrp->set_symbol(ImoInstrGroup::k_line);
         else if (symbol == "none")
             pGrp->set_symbol(ImoInstrGroup::k_none);
         else

--- a/src/tests/lomse_test_document_layouter.cpp
+++ b/src/tests/lomse_test_document_layouter.cpp
@@ -407,7 +407,7 @@ SUITE(DocLayouterTest)
         GmoBox* pBSP = pBDPC->get_child_box(0);     //ScorePage
         CHECK( pBSP->get_num_boxes() == 1 );
         GmoBoxSystem* pBSys = dynamic_cast<GmoBoxSystem*>( pBSP->get_child_box(0) );
-        CHECK( pBSys->get_num_shapes() == 3 );  // two staves + bracket
+        CHECK( pBSys->get_num_shapes() == 4 );  // two staves + bracket + left barline
         GmoShape* pShape = pBSys->get_staff_shape(0);
         CHECK( pShape != NULL );
         CHECK( pShape->is_shape_staff() == true );
@@ -439,7 +439,7 @@ SUITE(DocLayouterTest)
         GmoBox* pBSP = pBDPC->get_child_box(0);     //ScorePage
         CHECK( pBSP->get_num_boxes() == 1 );
         GmoBoxSystem* pBSys = dynamic_cast<GmoBoxSystem*>( pBSP->get_child_box(0) );
-        CHECK( pBSys->get_num_shapes() == 2 );
+        CHECK( pBSys->get_num_shapes() == 3 );
         GmoShape* pShape = pBSys->get_staff_shape(0);
         CHECK( pShape != NULL );
         CHECK( pShape->is_shape_staff() == true );

--- a/src/tests/lomse_test_ldp_analyser.cpp
+++ b/src/tests/lomse_test_ldp_analyser.cpp
@@ -6327,7 +6327,7 @@ SUITE(LdpAnalyserTest)
         CHECK( pGrp != NULL );
         CHECK( pGrp->get_name_string() == "Group" );
         CHECK( pGrp->get_abbrev_string() == "G." );
-        CHECK( pGrp->join_barlines() == false );
+        CHECK( pGrp->join_barlines() == ImoInstrGroup::k_no );
         CHECK( pGrp->get_symbol() == ImoInstrGroup::k_bracket );
         CHECK( pGrp->get_num_instruments() == 3 );
 
@@ -6364,7 +6364,7 @@ SUITE(LdpAnalyserTest)
         CHECK( pGrp != NULL );
         CHECK( pGrp->get_name_string() == "" );
         CHECK( pGrp->get_abbrev_string() == "G." );
-        CHECK( pGrp->join_barlines() == false );
+        CHECK( pGrp->join_barlines() == ImoInstrGroup::k_no );
         CHECK( pGrp->get_symbol() == ImoInstrGroup::k_bracket );
         CHECK( pGrp->get_num_instruments() == 3 );
 
@@ -6401,7 +6401,7 @@ SUITE(LdpAnalyserTest)
         CHECK( pGrp != NULL );
         CHECK( pGrp->get_name_string() == "Group" );
         CHECK( pGrp->get_abbrev_string() == "" );
-        CHECK( pGrp->join_barlines() == false );
+        CHECK( pGrp->join_barlines() == ImoInstrGroup::k_no );
         CHECK( pGrp->get_symbol() == ImoInstrGroup::k_bracket );
         CHECK( pGrp->get_num_instruments() == 3 );
 
@@ -6437,7 +6437,7 @@ SUITE(LdpAnalyserTest)
         CHECK( pGrp != NULL );
         CHECK( pGrp->get_name_string() == "" );
         CHECK( pGrp->get_abbrev_string() == "" );
-        CHECK( pGrp->join_barlines() == false );
+        CHECK( pGrp->join_barlines() == ImoInstrGroup::k_no );
         CHECK( pGrp->get_symbol() == ImoInstrGroup::k_bracket );
         CHECK( pGrp->get_num_instruments() == 3 );
 
@@ -6481,7 +6481,8 @@ SUITE(LdpAnalyserTest)
         Document doc(m_libraryScope);
         LdpParser parser(errormsg, m_libraryScope.ldp_factory());
         stringstream expected;
-        expected << "Line 0. Invalid boolean value 'perhaps'. Replaced by '1'." << endl;
+        expected << "Line 0. Invalid value for joinBarlines. Must be "
+                    "'yes', 'no' or 'mensurstrich'. 'yes' assumed." << endl;
         parser.parse_text("(group (symbol brace)(joinBarlines perhaps)"
                 "(instrument (name \"Soprano\")(abbrev \"S\")(musicData))"
                 "(instrument (name \"Tenor\")(abbrev \"T\")(musicData))"
@@ -6498,7 +6499,7 @@ SUITE(LdpAnalyserTest)
         CHECK( pGrp != NULL );
         CHECK( pGrp->get_name_string() == "" );
         CHECK( pGrp->get_abbrev_string() == "" );
-        CHECK( pGrp->join_barlines() == true );
+        CHECK( pGrp->join_barlines() == ImoInstrGroup::k_standard );
         CHECK( pGrp->get_symbol() == ImoInstrGroup::k_brace );
         CHECK( pGrp->get_num_instruments() == 3 );
 
@@ -6518,7 +6519,7 @@ SUITE(LdpAnalyserTest)
         LdpParser parser(errormsg, m_libraryScope.ldp_factory());
         stringstream expected;
         expected << "Line 0. Missing instruments in group!. Group ignored." << endl;
-        parser.parse_text("(group (symbol brace)(joinBarlines true))");
+        parser.parse_text("(group (symbol brace)(joinBarlines yes))");
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         InternalModel* pIModel = a.analyse_tree(tree, "string:");
@@ -6555,7 +6556,7 @@ SUITE(LdpAnalyserTest)
         CHECK( pGrp != NULL );
         CHECK( pGrp->get_name_string() == "" );
         CHECK( pGrp->get_abbrev_string() == "" );
-        CHECK( pGrp->join_barlines() == false );
+        CHECK( pGrp->join_barlines() == ImoInstrGroup::k_no );
         CHECK( pGrp->get_symbol() == ImoInstrGroup::k_brace );
         CHECK( pGrp->get_num_instruments() == 2 );
 

--- a/src/tests/lomse_test_lmd_analyser.cpp
+++ b/src/tests/lomse_test_lmd_analyser.cpp
@@ -108,6 +108,7 @@ public:
 
 SUITE(LmdAnalyserTest)
 {
+    // preliminary-tests ----------------------------------------------------------------
 
     TEST_FIXTURE(LmdAnalyserTestFixture, analyse_node)
     {
@@ -2371,7 +2372,7 @@ SUITE(LmdAnalyserTest)
 //        delete pIModel;
 //    }
 
-    // clef -----------------------------------------------------------------------------
+    //@ clef ----------------------------------------------------------------------------
 
     TEST_FIXTURE(LmdAnalyserTestFixture, Analyser_Clef)
     {
@@ -5253,7 +5254,7 @@ SUITE(LmdAnalyserTest)
 //        delete pIModel;
 //    }
 
-    // color ----------------------------------------------------------------------------
+    //@ color ---------------------------------------------------------------------------
 
     TEST_FIXTURE(LmdAnalyserTestFixture, ImoColorDto)
     {
@@ -5893,7 +5894,7 @@ SUITE(LmdAnalyserTest)
 //        delete pIModel;
 //    }
 
-    // defineStyle ----------------------------------------------------------------------
+    //@ defineStyle ---------------------------------------------------------------------
 
 //    TEST_FIXTURE(LmdAnalyserTestFixture, Analyser_DefineStyle)
 //    {
@@ -6896,7 +6897,7 @@ SUITE(LmdAnalyserTest)
 //        delete pIModel;
 //    }
 
-    // textItem -------------------------------------------------------------------------
+    //@ textItem ------------------------------------------------------------------------
 
     TEST_FIXTURE(LmdAnalyserTestFixture, TextItem)
     {
@@ -7552,7 +7553,7 @@ SUITE(LmdAnalyserTest)
 //        delete pIModel;
 //    }
 
-    // styles ---------------------------------------------------------------------------
+    //@ styles --------------------------------------------------------------------------
 
     TEST_FIXTURE(LmdAnalyserTestFixture, Styles)
     {
@@ -7778,7 +7779,7 @@ SUITE(LmdAnalyserTest)
 //        delete pIModel;
 //    }
 
-    // param ----------------------------------------------------------------------------
+    //@ param ---------------------------------------------------------------------------
 
     TEST_FIXTURE(LmdAnalyserTestFixture, ParamInfo_Ok)
     {
@@ -8063,7 +8064,7 @@ SUITE(LmdAnalyserTest)
 ////        delete pIModel;
 ////    }
 
-    // list -----------------------------------------------------------------------------
+    //@ list ----------------------------------------------------------------------------
 
     TEST_FIXTURE(LmdAnalyserTestFixture, Listitem_created)
     {
@@ -8268,7 +8269,7 @@ SUITE(LmdAnalyserTest)
 //    }
 
 
-    // scorePlayer ----------------------------------------------------------------------
+    //@ scorePlayer ---------------------------------------------------------------------
 
     TEST_FIXTURE(LmdAnalyserTestFixture, scorePlayer_Creation)
     {

--- a/src/tests/lomse_test_lmd_analyser.cpp
+++ b/src/tests/lomse_test_lmd_analyser.cpp
@@ -5411,7 +5411,7 @@ SUITE(LmdAnalyserTest)
 //        CHECK( pGrp != NULL );
 //        CHECK( pGrp->get_name_string() == "Group" );
 //        CHECK( pGrp->get_abbrev_string() == "G." );
-//        CHECK( pGrp->join_barlines() == false );
+//        CHECK( pGrp->join_barlines() == ImoInstrGroup::k_no );
 //        CHECK( pGrp->get_symbol() == ImoInstrGroup::k_bracket );
 //        CHECK( pGrp->get_num_instruments() == 3 );
 //
@@ -5447,7 +5447,7 @@ SUITE(LmdAnalyserTest)
 //        CHECK( pGrp != NULL );
 //        CHECK( pGrp->get_name_string() == "" );
 //        CHECK( pGrp->get_abbrev_string() == "G." );
-//        CHECK( pGrp->join_barlines() == false );
+//        CHECK( pGrp->join_barlines() == ImoInstrGroup::k_no );
 //        CHECK( pGrp->get_symbol() == ImoInstrGroup::k_bracket );
 //        CHECK( pGrp->get_num_instruments() == 3 );
 //
@@ -5483,7 +5483,7 @@ SUITE(LmdAnalyserTest)
 //        CHECK( pGrp != NULL );
 //        CHECK( pGrp->get_name_string() == "Group" );
 //        CHECK( pGrp->get_abbrev_string() == "" );
-//        CHECK( pGrp->join_barlines() == false );
+//        CHECK( pGrp->join_barlines() == ImoInstrGroup::k_no );
 //        CHECK( pGrp->get_symbol() == ImoInstrGroup::k_bracket );
 //        CHECK( pGrp->get_num_instruments() == 3 );
 //
@@ -5518,7 +5518,7 @@ SUITE(LmdAnalyserTest)
 //        CHECK( pGrp != NULL );
 //        CHECK( pGrp->get_name_string() == "" );
 //        CHECK( pGrp->get_abbrev_string() == "" );
-//        CHECK( pGrp->join_barlines() == false );
+//        CHECK( pGrp->join_barlines() == ImoInstrGroup::k_no );
 //        CHECK( pGrp->get_symbol() == ImoInstrGroup::k_bracket );
 //        CHECK( pGrp->get_num_instruments() == 3 );
 //
@@ -5577,7 +5577,7 @@ SUITE(LmdAnalyserTest)
 //        CHECK( pGrp != NULL );
 //        CHECK( pGrp->get_name_string() == "" );
 //        CHECK( pGrp->get_abbrev_string() == "" );
-//        CHECK( pGrp->join_barlines() == true );
+//        CHECK( pGrp->join_barlines() == ImoInstrGroup::k_standard );
 //        CHECK( pGrp->get_symbol() == ImoInstrGroup::k_brace );
 //        CHECK( pGrp->get_num_instruments() == 3 );
 //
@@ -5632,7 +5632,7 @@ SUITE(LmdAnalyserTest)
 //        CHECK( pGrp != NULL );
 //        CHECK( pGrp->get_name_string() == "" );
 //        CHECK( pGrp->get_abbrev_string() == "" );
-//        CHECK( pGrp->join_barlines() == false );
+//        CHECK( pGrp->join_barlines() == ImoInstrGroup::k_no );
 //        CHECK( pGrp->get_symbol() == ImoInstrGroup::k_brace );
 //        CHECK( pGrp->get_num_instruments() == 2 );
 //

--- a/src/tests/lomse_test_mxl_analyser.cpp
+++ b/src/tests/lomse_test_mxl_analyser.cpp
@@ -1022,6 +1022,10 @@ SUITE(MxlAnalyserTest)
         CHECK( pScore->get_num_instruments() == 2 );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         CHECK( pInstr != NULL );
+        CHECK( pInstr->get_barline_layout() == ImoInstrument::k_mensurstrich );
+        pInstr = pScore->get_instrument(1);
+        CHECK( pInstr != NULL );
+        CHECK( pInstr->get_barline_layout() == ImoInstrument::k_nothing );
 
         ImoInstrGroups* pGroups = pScore->get_instrument_groups();
         CHECK( pGroups != NULL );

--- a/src/tests/lomse_test_mxl_analyser.cpp
+++ b/src/tests/lomse_test_mxl_analyser.cpp
@@ -922,7 +922,7 @@ SUITE(MxlAnalyserTest)
         CHECK( pGroup->get_abbrev_string() == "" );
         CHECK( pGroup->get_name_string() == "Group" );
         CHECK( pGroup->get_symbol() == ImoInstrGroup::k_none );
-        CHECK( pGroup->join_barlines() == true );
+        CHECK( pGroup->join_barlines() == ImoInstrGroup::k_standard );
 
         a.do_not_delete_instruments_in_destructor();
         delete pIModel;
@@ -930,7 +930,7 @@ SUITE(MxlAnalyserTest)
 
     TEST_FIXTURE(MxlAnalyserTestFixture, MxlAnalyser_score_partwise_120)
     {
-        //@00120 <part-group> group symbol: invalid value
+        //@00120 <part-group> group-barline ok
         stringstream errormsg;
         Document doc(m_libraryScope);
         XmlParser parser;
@@ -977,7 +977,62 @@ SUITE(MxlAnalyserTest)
         CHECK( pGroup->get_abbrev_string() == "" );
         CHECK( pGroup->get_name_string() == "Group" );
         CHECK( pGroup->get_symbol() == ImoInstrGroup::k_bracket );
-        CHECK( pGroup->join_barlines() == false );
+        CHECK( pGroup->join_barlines() == ImoInstrGroup::k_no );
+
+        a.do_not_delete_instruments_in_destructor();
+        delete pIModel;
+    }
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, MxlAnalyser_score_partwise_121)
+    {
+        //@00121 <part-group> group-barline mensurstrich ok
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        //expected << "" << endl;
+        parser.parse_text("<score-partwise version='3.0'><part-list>"
+            "<part-group number='1' type='start'>"
+                "<group-name>Group</group-name>"
+                "<group-symbol>bracket</group-symbol>"
+                "<group-barline>Mensurstrich</group-barline>"
+            "</part-group>"
+            "<score-part id='P1'><part-name>Voice</part-name></score-part>"
+            "<score-part id='P2'><part-name>Piano</part-name></score-part>"
+            "<part-group number='1' type='stop'></part-group>"
+            "</part-list>"
+            "<part id='P1'></part>"
+            "<part id='P2'></part>"
+            "</score-partwise>");
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+
+//        cout << UnitTest::CurrentTest::Details()->testName << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pIModel->get_root() != NULL);
+        CHECK( pIModel->get_root()->is_document() == true );
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pIModel->get_root() );
+        CHECK( pDoc != NULL );
+        CHECK( pDoc->get_num_content_items() == 1 );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore != NULL );
+        CHECK( pScore->get_num_instruments() == 2 );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        CHECK( pInstr != NULL );
+
+        ImoInstrGroups* pGroups = pScore->get_instrument_groups();
+        CHECK( pGroups != NULL );
+        ImoInstrGroup* pGroup = dynamic_cast<ImoInstrGroup*>( pGroups->get_first_child() );
+        CHECK( pGroup != NULL );
+        CHECK( pGroup->get_instrument(0) != NULL );
+        CHECK( pGroup->get_instrument(1) != NULL );
+        CHECK( pGroup->get_abbrev_string() == "" );
+        CHECK( pGroup->get_name_string() == "Group" );
+        CHECK( pGroup->get_symbol() == ImoInstrGroup::k_bracket );
+        CHECK( pGroup->join_barlines() == ImoInstrGroup::k_mensurstrich );
 
         a.do_not_delete_instruments_in_destructor();
         delete pIModel;
@@ -5897,7 +5952,7 @@ SUITE(MxlAnalyserTest)
 ////        CHECK( pGrp != NULL );
 ////        CHECK( pGrp->get_name() == "Group" );
 ////        CHECK( pGrp->get_abbrev() == "G." );
-////        CHECK( pGrp->join_barlines() == false );
+////        CHECK( pGrp->join_barlines() == ImoInstrGroup::k_no );
 ////        CHECK( pGrp->get_symbol() == ImoInstrGroup::k_bracket );
 ////        CHECK( pGrp->get_num_instruments() == 3 );
 ////
@@ -5933,7 +5988,7 @@ SUITE(MxlAnalyserTest)
 ////        CHECK( pGrp != NULL );
 ////        CHECK( pGrp->get_name() == "" );
 ////        CHECK( pGrp->get_abbrev() == "G." );
-////        CHECK( pGrp->join_barlines() == false );
+////        CHECK( pGrp->join_barlines() == ImoInstrGroup::k_no );
 ////        CHECK( pGrp->get_symbol() == ImoInstrGroup::k_bracket );
 ////        CHECK( pGrp->get_num_instruments() == 3 );
 ////
@@ -5969,7 +6024,7 @@ SUITE(MxlAnalyserTest)
 ////        CHECK( pGrp != NULL );
 ////        CHECK( pGrp->get_name() == "Group" );
 ////        CHECK( pGrp->get_abbrev() == "" );
-////        CHECK( pGrp->join_barlines() == false );
+////        CHECK( pGrp->join_barlines() == ImoInstrGroup::k_no );
 ////        CHECK( pGrp->get_symbol() == ImoInstrGroup::k_bracket );
 ////        CHECK( pGrp->get_num_instruments() == 3 );
 ////
@@ -6004,7 +6059,7 @@ SUITE(MxlAnalyserTest)
 ////        CHECK( pGrp != NULL );
 ////        CHECK( pGrp->get_name() == "" );
 ////        CHECK( pGrp->get_abbrev() == "" );
-////        CHECK( pGrp->join_barlines() == false );
+////        CHECK( pGrp->join_barlines() == ImoInstrGroup::k_no );
 ////        CHECK( pGrp->get_symbol() == ImoInstrGroup::k_bracket );
 ////        CHECK( pGrp->get_num_instruments() == 3 );
 ////
@@ -6063,7 +6118,7 @@ SUITE(MxlAnalyserTest)
 ////        CHECK( pGrp != NULL );
 ////        CHECK( pGrp->get_name() == "" );
 ////        CHECK( pGrp->get_abbrev() == "" );
-////        CHECK( pGrp->join_barlines() == true );
+////        CHECK( pGrp->join_barlines() == ImoInstrGroup::k_standard );
 ////        CHECK( pGrp->get_symbol() == ImoInstrGroup::k_brace );
 ////        CHECK( pGrp->get_num_instruments() == 3 );
 ////
@@ -6118,7 +6173,7 @@ SUITE(MxlAnalyserTest)
 ////        CHECK( pGrp != NULL );
 ////        CHECK( pGrp->get_name() == "" );
 ////        CHECK( pGrp->get_abbrev() == "" );
-////        CHECK( pGrp->join_barlines() == false );
+////        CHECK( pGrp->join_barlines() == ImoInstrGroup::k_no );
 ////        CHECK( pGrp->get_symbol() == ImoInstrGroup::k_brace );
 ////        CHECK( pGrp->get_num_instruments() == 2 );
 ////

--- a/test-scores/00224-all-group-styles.lmd
+++ b/test-scores/00224-all-group-styles.lmd
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE lenmusdoc PUBLIC
+    "-//LenMus//DTD LenMus Document 0.0//EN" 
+    "https://raw.githubusercontent.com/lenmus/lomse/master/dtd/lenmusdoc-0.1.dtd" >
+<lenmusdoc vers='0.0'>
+    <content>
+        <score>
+            <parts>
+                <instrId>P1</instrId>
+                <instrId>P2</instrId>
+                <instrId>P3</instrId>
+                <instrId>P4</instrId>
+                <instrId>P5</instrId>
+                <instrId>P6</instrId>
+                <instrId>P7</instrId>
+                <instrId>P8</instrId>
+                <group>
+                    <firstInstr>P1</firstInstr>
+                    <lastInstr>P2</lastInstr>
+                    <grpName>Brace</grpName>
+                    <grpSymbol>brace</grpSymbol>
+                </group>
+                <group>
+                    <firstInstr>P3</firstInstr>
+                    <lastInstr>P4</lastInstr>
+                    <grpName>Bracket</grpName>
+                    <grpSymbol>bracket</grpSymbol>
+                </group>
+                <group>
+                    <firstInstr>P5</firstInstr>
+                    <lastInstr>P6</lastInstr>
+                    <grpName>Line</grpName>
+                    <grpSymbol>line</grpSymbol>
+                </group>
+                <group>
+                    <firstInstr>P7</firstInstr>
+                    <lastInstr>P8</lastInstr>
+                    <grpName>None</grpName>
+                    <grpSymbol>none</grpSymbol>
+                </group>
+            </parts>
+            <instrument><instrId>P1</instrId><instrName>P1</instrName><musicData/></instrument>
+            <instrument><instrId>P2</instrId><instrName>P2</instrName><musicData/></instrument>
+            <instrument><instrId>P3</instrId><instrName>P3</instrName><musicData/></instrument>
+            <instrument><instrId>P4</instrId><instrName>P4</instrName><musicData/></instrument>
+            <instrument><instrId>P5</instrId><instrName>P5</instrName><musicData/></instrument>
+            <instrument><instrId>P6</instrId><instrName>P6</instrName><musicData/></instrument>
+            <instrument><instrId>P7</instrId><instrName>P7</instrName><musicData/></instrument>
+            <instrument><instrId>P8</instrId><instrName>P8</instrName><musicData/></instrument>
+        </score>
+    </content>
+</lenmusdoc>


### PR DESCRIPTION
Several changes for improving the layout of groups of instruments:
- Barlines now can be joined. Mensurstrich layout also supported.
- Draw left barline at start of systems also in empty scores
- Added squared bracket for part groups (group symbol == line)

Whith this PR groups of instruments should be now fully supported.