### PR TITLE
Improve score layout algorithm to deal with systems with variable height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ##### COMPATIBLE CHANGES
 
+- Improve score layout algorithm to deal with systems with variable height.
 - Names and brackets/braces for groups of instruments now supported and rendered.
 - Barlines for groups now can be joined. Also mensurstrich layout is supported.
 - Added support for groups in LDP, including exporter.

--- a/include/lomse_beam_engraver.h
+++ b/include/lomse_beam_engraver.h
@@ -104,6 +104,7 @@ protected:
     void compute_beam_segments();
 	void add_segment(LUnits uxStart, LUnits uyStart, LUnits uxEnd, LUnits uyEnd);
     void update_bounds(LUnits uxStart, LUnits uyStart, LUnits uxEnd, LUnits uyEnd);
+    void make_segments_relative();
 
     bool m_fStemForced;     //at least one stem forced
     bool m_fStemMixed;      //not all stems in the same direction

--- a/include/lomse_gm_basic.h
+++ b/include/lomse_gm_basic.h
@@ -410,7 +410,7 @@ public:
     LUnits get_content_height();
 
     //position
-    void shift_origin(const USize& shift);
+    void shift_origin_and_content(const USize& shift);
     inline void new_left(LUnits xLeft) { m_origin.x = xLeft; }
     inline void new_top(LUnits yTop) { m_origin.y = yTop; }
     inline void new_origin(UPoint& pos) { m_origin = pos; }

--- a/include/lomse_lyrics_engraver.h
+++ b/include/lomse_lyrics_engraver.h
@@ -61,7 +61,7 @@ protected:
     ImoLyrics* m_pLyrics;
     list< pair<ImoNote*, GmoShape*> > m_notes;
     vector<ShapeBoxInfo*> m_shapesInfo;
-    vector<LUnits> m_staffTops;
+    vector<LUnits> m_staffTops;     //relative to StaffObj shape
     UPoint m_origin;
     USize m_size;
     bool m_fLyricsAbove;

--- a/include/lomse_score_layouter.h
+++ b/include/lomse_score_layouter.h
@@ -121,6 +121,8 @@ protected:
     //temporary data about current system being laid out
     int m_iCurSystem;   //[0..n-1] Current system (-1 if no system yet created!)
     SystemLayouter* m_pCurSysLyt;
+    int m_iSysPage;     //value of m_iCurPage when system was engraved
+    UPoint m_sysCursor; //value of m_cursor when system was engraved
 
     int m_iCurColumn;   //[0..n-1] current column. (-1 if no column yet created!)
 
@@ -136,7 +138,6 @@ protected:
     ScoreStub*          m_pStub;
     GmoBoxScorePage*    m_pCurBoxPage;
     GmoBoxSystem*       m_pCurBoxSystem;
-    UPoint              m_PageOrg;      //BoxPage origin when system was engraved
 
     //support for debug and unit test
     int                 m_iColumnToTrace;
@@ -221,7 +222,7 @@ protected:
     void create_empty_system();
     void engrave_empty_system();
 
-    void reposition_system_if_page_box_origin_has_changed();
+    void reposition_system_if_page_has_changed();
     void move_paper_cursor_to_bottom_of_added_system();
     LUnits get_first_system_staves_size();
     LUnits get_other_systems_staves_size();

--- a/include/lomse_score_layouter.h
+++ b/include/lomse_score_layouter.h
@@ -136,6 +136,7 @@ protected:
     ScoreStub*          m_pStub;
     GmoBoxScorePage*    m_pCurBoxPage;
     GmoBoxSystem*       m_pCurBoxSystem;
+    UPoint              m_PageOrg;      //BoxPage origin when system was engraved
 
     //support for debug and unit test
     int                 m_iColumnToTrace;
@@ -189,7 +190,7 @@ protected:
     void split_content_in_columns();
     void create_stub();
     void add_score_titles();
-    bool enough_space_in_page();
+    bool enough_space_for_empty_system();
     void create_system();
     void add_system_to_page();
     void decide_line_breaks();
@@ -197,6 +198,7 @@ protected:
     void decide_line_sizes();
     void fill_page_with_empty_systems_if_required();
     bool score_page_is_the_only_content_of_parent_box();
+    void remove_unused_space();
 
     void delete_system_layouters();
     void get_score_renderization_options();
@@ -204,6 +206,10 @@ protected:
     bool m_fFirstSystemInPage;
     inline void is_first_system_in_page(bool value) { m_fFirstSystemInPage = value; }
     inline bool is_first_system_in_page() { return m_fFirstSystemInPage; }
+
+    bool system_created();
+    bool enough_space_in_page_for_system();
+    void delete_system();
 
     //---------------------------------------------------------------
     void move_cursor_to_top_left_corner();
@@ -215,7 +221,8 @@ protected:
     void create_empty_system();
     void engrave_empty_system();
 
-    void advance_paper_cursor_to_bottom_of_added_system();
+    void reposition_system_if_page_box_origin_has_changed();
+    void move_paper_cursor_to_bottom_of_added_system();
     LUnits get_first_system_staves_size();
     LUnits get_other_systems_staves_size();
 

--- a/include/lomse_shape_tie.h
+++ b/include/lomse_shape_tie.h
@@ -49,7 +49,7 @@ class ImoObj;
 
 
 //---------------------------------------------------------------------------------------
-class GmoShapeTie : public GmoSimpleShape, public VertexSource, public VoiceRelatedShape
+class GmoShapeSlurTie : public GmoSimpleShape, public VertexSource
 {
 protected:
     LUnits m_thickness;
@@ -60,9 +60,9 @@ protected:
     int m_nContour;                 //current countour
 
 public:
-    GmoShapeTie(ImoObj* pCreatorImo, ShapeId idx, UPoint points[], LUnits tickness,
-                Color color = Color(0,0,0));
-    ~GmoShapeTie();
+    GmoShapeSlurTie(ImoObj* pCreatorImo, int objtype, ShapeId idx, UPoint points[],
+                    LUnits tickness, Color color);
+    virtual ~GmoShapeSlurTie();
 
     void on_draw(Drawer* pDrawer, RenderOptions& opt);
 
@@ -80,34 +80,27 @@ protected:
     void save_points(UPoint* points);
     void compute_vertices();
     void compute_bounds();
+    void make_points_and_vertices_relative_to_origin();
+
+};
+
+
+//---------------------------------------------------------------------------------------
+class GmoShapeTie : public GmoShapeSlurTie, public VoiceRelatedShape
+{
+public:
+    GmoShapeTie(ImoObj* pCreatorImo, ShapeId idx, UPoint points[], LUnits thickness,
+                Color color = Color(0,0,0));
+    virtual ~GmoShapeTie() {}
 };
 
 //---------------------------------------------------------------------------------------
-class GmoShapeSlur : public GmoSimpleShape, public VertexSource
+class GmoShapeSlur : public GmoShapeSlurTie
 {
-protected:
-    LUnits m_thickness;
-    UPoint m_points[4];
-
-    UPoint m_vertices[7];
-    int m_nCurVertex;               //index to current vertex
-    int m_nContour;                 //current countour
-
 public:
-    GmoShapeSlur(ImoObj* pCreatorImo, ShapeId idx, UPoint points[], LUnits tickness,
-                Color color = Color(0,0,0));
-    ~GmoShapeSlur();
-
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
-
-    //VertexSource
-    void rewind(int UNUSED(pathId) = 0) { m_nCurVertex = 0; }
-    unsigned vertex(double* px, double* py);
-
-protected:
-    void save_points(UPoint* points);
-    void compute_vertices();
-    void compute_bounds();
+    GmoShapeSlur(ImoObj* pCreatorImo, ShapeId idx, UPoint points[], LUnits thickness,
+                 Color color = Color(0,0,0));
+    virtual ~GmoShapeSlur() {}
 };
 
 

--- a/include/lomse_shape_tuplet.h
+++ b/include/lomse_shape_tuplet.h
@@ -86,6 +86,7 @@ protected:
     void draw_horizontal_line(Drawer* pDrawer);
     void draw_vertical_borders(Drawer* pDrawer);
     void compute_bounds();
+    void make_points_relative_to_origin();
 
     //reference positions
     LUnits m_uxStart, m_uyStart;

--- a/include/lomse_slur_engraver.h
+++ b/include/lomse_slur_engraver.h
@@ -51,8 +51,8 @@ class SlurEngraver : public RelAuxObjEngraver
 {
 protected:
     InstrumentEngraver* m_pInstrEngrv;
-    LUnits m_uStaffTopStart;    //top line of start system
-    LUnits m_uStaffTopEnd;      //top line of end system
+    LUnits m_uStaffTopStart;    //top line of start system, relative to start note top
+    LUnits m_uStaffTopEnd;      //top line of end system, relative to end note top
 
     int m_numShapes;
     ImoSlur* m_pSlur;

--- a/include/lomse_system_layouter.h
+++ b/include/lomse_system_layouter.h
@@ -510,6 +510,7 @@ public:
 
     GmoBoxSystem* create_system_box(LUnits left, LUnits top, LUnits width, LUnits height);
     void engrave_system(LUnits indent, int iFirstCol, int iLastCol, UPoint pos);
+    void on_origin_shift(LUnits yShift);
 
         //Access to information
     inline void set_prolog_width(LUnits width) { m_uPrologWidth = width; }

--- a/src/graphic_model/engravers/lomse_beam_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_beam_engraver.cpp
@@ -383,13 +383,16 @@ void BeamEngraver::compute_beam_segments()
             }
         }
 
-        // displace y coordinate for next beamline
+        // displace y coordinate for next beam line
         uyShift += (m_fBeamAbove ? uBeamSpacing : - uBeamSpacing);
     }
 
-    //take beam thickness into accoun for boundaries
+    //take beam thickness into account for boundaries
     m_origin.y -= uHalfBeam;
     m_size.height += m_uBeamThickness;
+
+    //adjust segments to make them relative to m_origin
+    make_segments_relative();
 }
 
 //---------------------------------------------------------------------------------------
@@ -415,6 +418,23 @@ void BeamEngraver::update_bounds(LUnits uxStart, LUnits uyStart,
 
     m_size.width = max(m_size.width, right - m_origin.x);
     m_size.height = max(m_size.height, bottom - m_origin.y);
+}
+
+//---------------------------------------------------------------------------------------
+void BeamEngraver::make_segments_relative()
+{
+    list<LUnits>::iterator it = m_segments.begin();
+    while (it != m_segments.end())
+    {
+        *it -= m_origin.x;
+        ++it;
+        *it -= m_origin.y;
+        ++it;
+        *it -= m_origin.x;
+        ++it;
+        *it -= m_origin.y;
+        ++it;
+    }
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/engravers/lomse_lyrics_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_lyrics_engraver.cpp
@@ -97,7 +97,7 @@ void LyricsEngraver::set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
 
     ShapeBoxInfo* pInfo = LOMSE_NEW ShapeBoxInfo(NULL, iSystem, iCol, iInstr);
     m_shapesInfo.push_back(pInfo);
-    m_staffTops.push_back(yTop);
+    m_staffTops.push_back(yTop - pStaffObjShape->get_top());
 }
 
 //---------------------------------------------------------------------------------------
@@ -112,7 +112,7 @@ void LyricsEngraver::set_middle_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* pS
 
     ShapeBoxInfo* pInfo = LOMSE_NEW ShapeBoxInfo(NULL, iSystem, iCol, iInstr);
     m_shapesInfo.push_back(pInfo);
-    m_staffTops.push_back(yTop);
+    m_staffTops.push_back(yTop - pStaffObjShape->get_top());
 }
 
 //---------------------------------------------------------------------------------------
@@ -127,7 +127,7 @@ void LyricsEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* pSO,
 
     ShapeBoxInfo* pInfo = LOMSE_NEW ShapeBoxInfo(NULL, iSystem, iCol, iInstr);
     m_shapesInfo.push_back(pInfo);
-    m_staffTops.push_back(yTop);
+    m_staffTops.push_back(yTop - pStaffObjShape->get_top());
 }
 
 //---------------------------------------------------------------------------------------
@@ -166,7 +166,7 @@ void LyricsEngraver::create_shape(int iNote, GmoShapeNote* pNoteShape, ImoNote* 
     //      amount (23.0f)
     int lineNum = m_pLyrics->get_number();
     int tenths = 60.0f + 23.0f * float(lineNum);
-    LUnits y = m_staffTops[iNote] + tenths_to_logical(tenths);
+    LUnits y = m_staffTops[iNote] + pNoteShape->get_top() + tenths_to_logical(tenths);
 
     //get text
     ImoLyricsData* pData = static_cast<ImoLyricsData*>(m_pLyrics->get_data_for(pNote));

--- a/src/graphic_model/engravers/lomse_slur_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_slur_engraver.cpp
@@ -57,7 +57,7 @@ SlurEngraver::SlurEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
 void SlurEngraver::set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
                                       GmoShape* pStaffObjShape, int iInstr, int iStaff,
                                       int iSystem, int iCol, LUnits UNUSED(xRight),
-                                      LUnits UNUSED(xLeft), LUnits UNUSED(yTop))
+                                      LUnits UNUSED(xLeft), LUnits yTop)
 {
     m_iInstr = iInstr;
     m_iStaff = iStaff;
@@ -70,7 +70,7 @@ void SlurEngraver::set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
     m_shapesInfo[0].iInstr = iInstr;
     m_shapesInfo[0].iSystem = iSystem;
 
-    m_uStaffTopStart = m_pInstrEngrv->get_top_line_of_staff(iStaff);
+    m_uStaffTopStart = yTop - m_pStartNoteShape->get_top();     //relative to note top
 }
 
 //---------------------------------------------------------------------------------------
@@ -78,7 +78,7 @@ void SlurEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* pSO,
                                     GmoShape* pStaffObjShape, int iInstr,
                                     int iStaff, int iSystem, int iCol,
                                     LUnits UNUSED(xRight), LUnits UNUSED(xLeft),
-                                    LUnits UNUSED(yTop))
+                                    LUnits yTop)
 {
     m_pEndNote = dynamic_cast<ImoNote*>(pSO);
     m_pEndNoteShape = dynamic_cast<GmoShapeNote*>(pStaffObjShape);
@@ -87,7 +87,7 @@ void SlurEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* pSO,
     m_shapesInfo[1].iInstr = iInstr;
     m_shapesInfo[1].iSystem = iSystem;
 
-    m_uStaffTopEnd = m_pInstrEngrv->get_top_line_of_staff(iStaff);
+    m_uStaffTopEnd = yTop - m_pEndNoteShape->get_top();     //relative to note top;
 }
 
 //---------------------------------------------------------------------------------------
@@ -216,21 +216,22 @@ void SlurEngraver::compute_start_of_staff_point()
 
     if (m_fSlurBelow)
         m_points2[ImoBezierInfo::k_start].y =
-            m_uStaffTopEnd + tenths_to_logical(60.0f);
+            m_uStaffTopEnd + m_pEndNoteShape->get_top() + tenths_to_logical(60.0f);
     else
         m_points2[ImoBezierInfo::k_start].y =
-            m_uStaffTopEnd - tenths_to_logical(20.0f);
+            m_uStaffTopEnd + m_pEndNoteShape->get_top() - tenths_to_logical(20.0f);
 }
 
 //---------------------------------------------------------------------------------------
 void SlurEngraver::compute_end_of_staff_point()
 {
     m_points1[ImoBezierInfo::k_end].x = m_pInstrEngrv->get_staves_right();
+    LUnits yTop = m_uStaffTopStart + m_pStartNoteShape->get_top();
 
     if (m_fSlurBelow)
-        m_points1[ImoBezierInfo::k_end].y = m_uStaffTopStart + tenths_to_logical(60.0f);
+        m_points1[ImoBezierInfo::k_end].y = yTop + tenths_to_logical(60.0f);
     else
-        m_points1[ImoBezierInfo::k_end].y = m_uStaffTopStart - tenths_to_logical(20.0f);
+        m_points1[ImoBezierInfo::k_end].y = yTop - tenths_to_logical(20.0f);
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/layouters/lomse_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_layouter.cpp
@@ -94,12 +94,6 @@ void Layouter::layout_item(ImoContentObj* pItem, GmoBox* pParentBox)
 
     m_pCurLayouter = create_layouter(pItem);
 
-//    //set trace options, for debugging
-//    if (pItem->is_score() && m_libraryScope.dump_column_tables())
-//    {
-//        static_cast<ScoreLayouter*>(m_pCurLayouter)->trace_column(0, k_trace_spacing);
-//    }
-
     m_pCurLayouter->prepare_to_start_layout();
     while (!m_pCurLayouter->is_item_layouted())
     {

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -157,15 +157,20 @@ void ScoreLayouter::layout_in_box()
     }
 
 
-    if (!enough_space_in_page())
+    //loop for creating and adding systems
+    bool fSystemsAdded = false;
+    while(m_iCurColumn < get_num_columns())
     {
-        // AWARE: For documents containing not only a single score but texts, paragraphs, etc.,
-        // ScorePage is like a paragraph: a portion of parent box. When having to render a
-        // score and current parent box (probably a DocPageContent box) is nearly full,
-        // ScorePage will have insufficient height. Before assuming that paper height is smaller
-        // that system height, it is then necessary to ask parent layouter for allocating
-        // a empty page.
-        if (score_page_is_the_only_content_of_parent_box())
+        if (!system_created())
+            create_system();
+
+        if (enough_space_in_page_for_system())
+        {
+            add_system_to_page();
+            fSystemsAdded = true;
+        }
+
+        else if (!fSystemsAdded && score_page_is_the_only_content_of_parent_box())
         {
             //TODO: ScoreLayouter::layout_in_box()
             //  If paper height is smaller than system height it is impossible to fit
@@ -178,6 +183,7 @@ void ScoreLayouter::layout_in_box()
                 << " instruments.";
             add_error_message(msg.str());
             set_layout_is_finished(true);
+            delete_system();
             return;
         }
         else
@@ -188,32 +194,17 @@ void ScoreLayouter::layout_in_box()
         }
     }
 
-    while(enough_space_in_page() && m_iCurColumn < get_num_columns())
-    {
-        create_system();
-        add_system_to_page();
-    }
 
+    //add empty systems to fill the page, if option enabled, and
+    //remove unused space
     bool fMoreColumns = m_iCurColumn < get_num_columns();
     if (!fMoreColumns)
+    {
         fill_page_with_empty_systems_if_required();
+        remove_unused_space();
+    }
 
     set_layout_is_finished( !fMoreColumns );
-
-    //if layout finished adjust height of last page (remove unused space)
-    if (!fMoreColumns)
-    {
-        LUnits yBottom = m_pCurSysLyt->get_y_max();
-        ImoStyle* pStyle = m_pScore->get_style();
-        if (pStyle)
-        {
-            yBottom += pStyle->margin_bottom();
-            yBottom += pStyle->border_width_bottom();
-            yBottom += pStyle->padding_bottom();
-        }
-        m_pCurBoxPage->set_height( yBottom - m_pCurBoxPage->get_top());
-        m_cursor.y = m_pCurBoxPage->get_bottom();
-    }
     m_pageCursor = m_cursor;
 }
 
@@ -257,6 +248,43 @@ void ScoreLayouter::create_system()
 }
 
 //---------------------------------------------------------------------------------------
+void ScoreLayouter::remove_unused_space()
+{
+    //adjust height of last page (remove unused space)
+
+    LUnits yBottom = m_pCurSysLyt->get_y_max();
+    ImoStyle* pStyle = m_pScore->get_style();
+    if (pStyle)
+    {
+        yBottom += pStyle->margin_bottom();
+        yBottom += pStyle->border_width_bottom();
+        yBottom += pStyle->padding_bottom();
+    }
+    m_pCurBoxPage->set_height( yBottom - m_pCurBoxPage->get_top());
+    m_cursor.y = m_pCurBoxPage->get_bottom();
+}
+
+//---------------------------------------------------------------------------------------
+bool ScoreLayouter::system_created()
+{
+    return m_pCurBoxSystem != NULL;
+}
+
+//---------------------------------------------------------------------------------------
+bool ScoreLayouter::enough_space_in_page_for_system()
+{
+    LUnits height = m_pCurBoxSystem->get_height();
+    return remaining_height() >= height;
+}
+
+//---------------------------------------------------------------------------------------
+void ScoreLayouter::delete_system()
+{
+    delete m_pCurBoxSystem;
+    m_pCurBoxSystem = NULL;
+}
+
+//---------------------------------------------------------------------------------------
 void ScoreLayouter::create_system_layouter()
 {
     m_pCurSysLyt = LOMSE_NEW SystemLayouter(this, m_libraryScope, m_pScoreMeter,
@@ -287,6 +315,7 @@ void ScoreLayouter::engrave_system()
 void ScoreLayouter::create_system_box()
 {
     m_iCurSystem++;
+    m_PageOrg = m_pCurBoxPage->get_origin();
 
     LUnits width = m_pCurBoxPage->get_width();
     LUnits top = m_cursor.y
@@ -305,15 +334,33 @@ void ScoreLayouter::create_system_box()
 //---------------------------------------------------------------------------------------
 void ScoreLayouter::add_system_to_page()
 {
+    reposition_system_if_page_box_origin_has_changed();
+
     m_pCurBoxPage->add_system(m_pCurBoxSystem, m_iCurSystem);
     m_pCurBoxSystem->add_shapes_to_tables();
 
-    advance_paper_cursor_to_bottom_of_added_system();
+    move_paper_cursor_to_bottom_of_added_system();
     is_first_system_in_page(false);
+    m_pCurBoxSystem = NULL;
 }
 
 //---------------------------------------------------------------------------------------
-void ScoreLayouter::advance_paper_cursor_to_bottom_of_added_system()
+void ScoreLayouter::reposition_system_if_page_box_origin_has_changed()
+{
+    //if the parent box used when engraving the system has changed (because not
+    //enough space in parent box to add the system and a new page has been added)
+    //it is necessary to reposition all content of the engraved system.
+
+    if (m_PageOrg != m_pCurBoxPage->get_origin())
+    {
+        USize shift(m_pCurBoxPage->get_origin().x - m_PageOrg.x,
+                    m_pCurBoxPage->get_origin().y - m_PageOrg.y );
+        m_pCurBoxSystem->shift_origin_and_content(shift);
+    }
+}
+
+//---------------------------------------------------------------------------------------
+void ScoreLayouter::move_paper_cursor_to_bottom_of_added_system()
 {
     m_cursor.x = m_pCurBoxPage->get_left();
     m_cursor.y = m_pCurBoxSystem->get_bottom();
@@ -381,7 +428,7 @@ void ScoreLayouter::create_main_box(GmoBox* pParentBox, UPoint pos, LUnits width
 }
 
 //---------------------------------------------------------------------------------------
-bool ScoreLayouter::enough_space_in_page()
+bool ScoreLayouter::enough_space_for_empty_system()
 {
     LUnits height = m_pColsBuilder->get_staves_height();
     height += distance_to_top_of_system(m_iCurSystem+1, m_fFirstSystemInPage);
@@ -620,7 +667,7 @@ void ScoreLayouter::fill_page_with_empty_systems_if_required()
         bool fFillPage = pOpt->get_bool_value();
         if (fFillPage)
         {
-            while(enough_space_in_page())
+            while(enough_space_for_empty_system())
             {
                 create_empty_system();
                 add_system_to_page();

--- a/src/graphic_model/layouters/lomse_system_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_system_layouter.cpp
@@ -991,6 +991,13 @@ void SystemLayouter::reposition_staves(LUnits indent)
 }
 
 //---------------------------------------------------------------------------------------
+void SystemLayouter::on_origin_shift(LUnits yShift)
+{
+    m_yMax += yShift;
+    m_yMin += yShift;
+}
+
+//---------------------------------------------------------------------------------------
 void SystemLayouter::fill_current_system_with_columns()
 {
     m_pScoreLyt->m_iCurColumn = 0;

--- a/src/graphic_model/lomse_gm_basic.cpp
+++ b/src/graphic_model/lomse_gm_basic.cpp
@@ -577,7 +577,7 @@ GmoBox* GmoBox::find_inner_box_at(LUnits x, LUnits y)
 }
 
 //---------------------------------------------------------------------------------------
-void GmoBox::shift_origin(const USize& shift)
+void GmoBox::shift_origin_and_content(const USize& shift)
 {
     if (shift.width == 0.0f && shift.height == 0.0f) return;
 
@@ -587,7 +587,7 @@ void GmoBox::shift_origin(const USize& shift)
     //shift contained boxes
     std::vector<GmoBox*>::iterator itB;
     for (itB=m_childBoxes.begin(); itB != m_childBoxes.end(); ++itB)
-        (*itB)->shift_origin(shift);
+        (*itB)->shift_origin_and_content(shift);
 
     //shift contained shapes
     std::list<GmoShape*>::iterator itS;

--- a/src/graphic_model/lomse_shape_beam.cpp
+++ b/src/graphic_model/lomse_shape_beam.cpp
@@ -71,13 +71,13 @@ void GmoShapeBeam::on_draw(Drawer* pDrawer, RenderOptions& opt)
     std::list<LUnits>::iterator it = m_segments.begin();
     while (it != m_segments.end())
     {
-        LUnits uxStart = *it;
+        LUnits uxStart = *it + m_origin.x;
         ++it;
-        LUnits uyStart = *it;
+        LUnits uyStart = *it + m_origin.y;
         ++it;
-        LUnits uxEnd = *it;
+        LUnits uxEnd = *it + m_origin.x;
         ++it;
-        LUnits uyEnd = *it;
+        LUnits uyEnd = *it + m_origin.y;
         ++it;
 
         draw_beam_segment(pDrawer, uxStart, uyStart, uxEnd, uyEnd, color);
@@ -89,7 +89,7 @@ void GmoShapeBeam::on_draw(Drawer* pDrawer, RenderOptions& opt)
 void GmoShapeBeam::draw_beam_segment(Drawer* pDrawer, LUnits uxStart, LUnits uyStart,
                              LUnits uxEnd, LUnits uyEnd, Color color)
 {
-//    //check to see if the beam segment has to be splitted in two systems
+//    //check to see if the beam segment has to be split in two systems
 //    //if (pStartNote && pEndNote) {
 //    //    lmUPoint paperPosStart = pStartNote->GetReferencePaperPos();
 //    //    lmUPoint paperPosEnd = pEndNote->GetReferencePaperPos();
@@ -103,8 +103,8 @@ void GmoShapeBeam::draw_beam_segment(Drawer* pDrawer, LUnits uxStart, LUnits uyS
 //    //        return; //to avoid rendering bad lines across the score. It is less noticeable
 //    //    }
 //    //}
-//
-//    //draw the segment
+
+    //draw the segment
     pDrawer->begin_path();
     pDrawer->fill(color);
     pDrawer->line(uxStart, uyStart, uxEnd, uyEnd, m_uBeamThickness, k_edge_vertical);

--- a/src/graphic_model/lomse_shape_brace_bracket.cpp
+++ b/src/graphic_model/lomse_shape_brace_bracket.cpp
@@ -175,25 +175,11 @@ GmoShapeBracketBrace::~GmoShapeBracketBrace()
 {
 }
 
-////---------------------------------------------------------------------------------------
-//void GmoShapeBracketBrace::Shift(LUnits xIncr, LUnits yIncr)
-//{
-//    get_left() += xIncr;
-//	get_top() += yIncr;
-//    get_right() += xIncr;
-//	get_bottom() += yIncr;
-//
-//    ShiftBoundsAndSelRec(xIncr, yIncr);
-//    set_affine_transform();
-//
-//	//if included in a composite shape update parent bounding and selection rectangles
-//	if (this->IsChildShape())
-//		((lmCompositeShape*)GetParentShape())->RecomputeBounds();
-//}
-
 //---------------------------------------------------------------------------------------
 void GmoShapeBracketBrace::on_draw(Drawer* pDrawer, RenderOptions& opt)
 {
+    set_affine_transform();
+
     Color color = determine_color_to_use(opt);
     pDrawer->begin_path();
     pDrawer->fill(color);
@@ -214,9 +200,6 @@ GmoShapeBrace::GmoShapeBrace(ImoObj* pCreatorImo, ShapeId idx, LUnits xLeft, LUn
     set_origin(xLeft, yTop);
 	set_width(xRight - xLeft);
 	set_height(yBottom - yTop);
-
-    //set scaling and translation
-    set_affine_transform();
 }
 
 //---------------------------------------------------------------------------------------
@@ -263,8 +246,6 @@ GmoShapeBracket::GmoShapeBracket(ImoObj* pCreatorImo, ShapeId idx, LUnits xLeft,
 
     m_udyHook = dyHook;
     m_rBracketBarHeight = (double)(yBottom - yTop);
-
-    set_affine_transform();
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/lomse_shape_line.cpp
+++ b/src/graphic_model/lomse_shape_line.cpp
@@ -54,26 +54,27 @@ GmoShapeLine::GmoShapeLine(ImoObj* pCreatorImo, ShapeId idx,
     , m_nStartCap(nStartCap)
     , m_nEndCap(nEndCap)
 {
-    m_uPoint[k_start].x = xStart;
-    m_uPoint[k_start].y = yStart;
-    m_uPoint[k_end].x = xEnd;
-    m_uPoint[k_end].y = yEnd;
+    //origin
+    m_origin.x = xStart;
+    m_origin.y = yStart;
 
-    // store boundling rectangle position and size
+    //points (relative to origin)
+    m_uPoint[k_start].x = 0.0;
+    m_uPoint[k_start].y = 0.0;
+    m_uPoint[k_end].x = xEnd - xStart;
+    m_uPoint[k_end].y = yEnd - yStart;
+
+    // bounding rectangle size
 	//TODO: For now it is assumed that the line is either vertical or horizontal
 	if (xStart == xEnd)
 	{
 		//vertical line
-		m_origin.x = xStart;    //- uWidth / 2.0f;
-		m_origin.y = yStart;
         m_size.width = uWidth + uBoundsExtraWidth;
         m_size.height = yEnd - yStart + uBoundsExtraWidth;
 	}
 	else
 	{
 		//Horizontal line
-		m_origin.x = xStart;
-		m_origin.y = yStart;    // - uWidth / 2.0f;
 		m_size.width = xEnd - xStart + uBoundsExtraWidth;
         m_size.height = uWidth + uBoundsExtraWidth;
 	}
@@ -88,13 +89,14 @@ GmoShapeLine::~GmoShapeLine()
 void GmoShapeLine::on_draw(Drawer* pDrawer, RenderOptions& opt)
 {
     Color color = determine_color_to_use(opt);
+    UPoint start = m_uPoint[k_start] + m_origin;
+    UPoint end = m_uPoint[k_end] + m_origin;
 
     pDrawer->begin_path();
     pDrawer->fill(color);
     pDrawer->stroke(color);
     pDrawer->stroke_width(10.0);  //0.1 mm
-    pDrawer->line_with_markers(m_uPoint[k_start], m_uPoint[k_end], m_uWidth,
-                               m_nStartCap, m_nEndCap);
+    pDrawer->line_with_markers(start, end, m_uWidth, m_nStartCap, m_nEndCap);
     pDrawer->end_path();
 
     GmoSimpleShape::on_draw(pDrawer, opt);

--- a/src/graphic_model/lomse_shape_tuplet.cpp
+++ b/src/graphic_model/lomse_shape_tuplet.cpp
@@ -235,9 +235,11 @@ void GmoShapeTuplet::draw_horizontal_line(Drawer* pDrawer)
             //broken line
             float rTanAlpha = (m_yLineEnd - m_yLineStart) / (m_uxEnd - m_uxStart);
             LUnits x1 = m_xNumber + m_origin.x - m_uSpaceToNumber;
-            LUnits y1 = m_yLineStart + m_origin.y + (x1 - m_uxStart) * rTanAlpha;
+            LUnits y1 = m_yLineStart + m_origin.y
+                        + ((x1 - m_uxStart - m_origin.x) * rTanAlpha);
             LUnits x2 = m_xNumber + m_origin.x + m_uNumberWidth + m_uSpaceToNumber;
-            LUnits y2 = m_yLineStart + m_origin.y + (x2 - m_uxStart) * rTanAlpha;
+            LUnits y2 = m_yLineStart + m_origin.y
+                        + ((x2 - m_uxStart - m_origin.x) * rTanAlpha);
             pDrawer->line(m_uxStart + m_origin.x, m_yLineStart + m_origin.y,
                           x1, y1, m_uLineThick, k_edge_vertical);
             pDrawer->line(x2, y2, m_uxEnd + m_origin.x, m_yLineEnd + m_origin.y,

--- a/src/graphic_model/lomse_shape_tuplet.cpp
+++ b/src/graphic_model/lomse_shape_tuplet.cpp
@@ -80,6 +80,7 @@ void GmoShapeTuplet::set_layout_data(bool fAbove, bool fDrawBracket, LUnits ySta
 
     compute_position();
     compute_bounds();
+    make_points_relative_to_origin();
 }
 
 //---------------------------------------------------------------------------------------
@@ -175,6 +176,23 @@ void GmoShapeTuplet::compute_bounds()
 }
 
 //---------------------------------------------------------------------------------------
+void GmoShapeTuplet::make_points_relative_to_origin()
+{
+    //reference positions
+    m_uxStart -= m_origin.x;
+    m_uyStart -= m_origin.y;
+    m_uxEnd -= m_origin.x;
+    m_uyEnd -= m_origin.y;
+
+	m_yLineStart -= m_origin.y;
+    m_yLineEnd -= m_origin.y;
+    m_yStartBorder -= m_origin.y;
+    m_yEndBorder -= m_origin.y;
+    m_xNumber -= m_origin.x;
+    m_yNumber -= m_origin.y;
+}
+
+//---------------------------------------------------------------------------------------
 void GmoShapeTuplet::compute_horizontal_position()
 {
     bool fUp = true;
@@ -216,17 +234,21 @@ void GmoShapeTuplet::draw_horizontal_line(Drawer* pDrawer)
         {
             //broken line
             float rTanAlpha = (m_yLineEnd - m_yLineStart) / (m_uxEnd - m_uxStart);
-            LUnits x1 = m_xNumber - m_uSpaceToNumber;
-            LUnits y1 = m_yLineStart + (x1 - m_uxStart) * rTanAlpha;
-            LUnits x2 = m_xNumber + m_uNumberWidth + m_uSpaceToNumber;
-            LUnits y2 = m_yLineStart + (x2 - m_uxStart) * rTanAlpha;
-            pDrawer->line(m_uxStart, m_yLineStart, x1, y1, m_uLineThick, k_edge_vertical);
-            pDrawer->line(x2, y2, m_uxEnd, m_yLineEnd, m_uLineThick, k_edge_vertical);
+            LUnits x1 = m_xNumber + m_origin.x - m_uSpaceToNumber;
+            LUnits y1 = m_yLineStart + m_origin.y + (x1 - m_uxStart) * rTanAlpha;
+            LUnits x2 = m_xNumber + m_origin.x + m_uNumberWidth + m_uSpaceToNumber;
+            LUnits y2 = m_yLineStart + m_origin.y + (x2 - m_uxStart) * rTanAlpha;
+            pDrawer->line(m_uxStart + m_origin.x, m_yLineStart + m_origin.y,
+                          x1, y1, m_uLineThick, k_edge_vertical);
+            pDrawer->line(x2, y2, m_uxEnd + m_origin.x, m_yLineEnd + m_origin.y,
+                          m_uLineThick, k_edge_vertical);
         }
         else
         {
             //full line
-            pDrawer->line(m_uxStart, m_yLineStart, m_uxEnd, m_yLineEnd, m_uLineThick, k_edge_vertical);
+            pDrawer->line(m_uxStart + m_origin.x, m_yLineStart + m_origin.y,
+                          m_uxEnd + m_origin.x, m_yLineEnd + m_origin.y,
+                          m_uLineThick, k_edge_vertical);
         }
         pDrawer->end_path();
     }
@@ -239,10 +261,12 @@ void GmoShapeTuplet::draw_vertical_borders(Drawer* pDrawer)
     {
         pDrawer->begin_path();
         pDrawer->fill(m_color);
-        LUnits x1 = m_uxStart + m_uLineThick / 2;
-        LUnits x2 = m_uxEnd - m_uLineThick / 2;
-        pDrawer->line(x1, m_yLineStart, x1, m_yStartBorder, m_uLineThick, k_edge_horizontal);
-        pDrawer->line(x2, m_yLineEnd, x2, m_yEndBorder, m_uLineThick, k_edge_horizontal);
+        LUnits x1 = m_uxStart + m_origin.x + m_uLineThick / 2;
+        LUnits x2 = m_uxEnd + m_origin.x - m_uLineThick / 2;
+        pDrawer->line(x1, m_yLineStart + m_origin.y, x1, m_yStartBorder + m_origin.y,
+                      m_uLineThick, k_edge_horizontal);
+        pDrawer->line(x2, m_yLineEnd + m_origin.y, x2, m_yEndBorder + m_origin.y,
+                      m_uLineThick, k_edge_horizontal);
         pDrawer->end_path();
     }
 }

--- a/src/tests/lomse_test_score_layouter.cpp
+++ b/src/tests/lomse_test_score_layouter.cpp
@@ -96,7 +96,7 @@ public:
     LUnits my_distance_to_top_of_system(int iSystem, bool fFirstInPage) {
         return distance_to_top_of_system(iSystem, fFirstInPage);
     }
-    bool my_enough_space_in_page() { return enough_space_in_page(); }
+    bool my_enough_space_in_page() { return enough_space_for_empty_system(); }
     ScoreMeter* my_get_score_meter() { return m_pScoreMeter; }
     GmoBoxSystem* my_get_current_system_box() { return m_pCurBoxSystem; }
     ColumnsBuilder* my_get_columns_builder() { return m_pColsBuilder; }


### PR DESCRIPTION
Currently, for deciding whether to include a system in current page or to place it in a new page, an estimated system height is used because the real height is not yet known. This PR changes the approach: first the system is engraved and once the real height is known the decision to place it in current page or to start a new one is taken.

Apart from changing the laying out algorithm, this PR fixes some engravers and some shapes so that a system can be relocated to a new page or to a new position without having to engrave it again in the new position.