### PR TITLE
LDP Exporter improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@
 [Since last version] 0.20.0
 =============================
 
+##### BACKWARDS INCOMPATIBLE CHANGES WITH 0.20.0
+
 - none
+
+##### COMPATIBLE CHANGES
+
+- Blank space in LDP exporter has been normalized.
+- LDP exporter reviewed for following the same syntax rules than LDP 
+  Analyser, thus ensuring a round trip in LDP export-import.
+- Some fixes in LDP exporter.
+
 
 Version [0.20.0] (1/Sep/2016)
 =============================

--- a/src/exporters/lomse_ldp_exporter.cpp
+++ b/src/exporters/lomse_ldp_exporter.cpp
@@ -61,9 +61,14 @@ class LdpGenerator
 protected:
     LdpExporter* m_pExporter;
     stringstream m_source;
+    bool m_fAddSpace;           //add space when opening new element
 
 public:
-    LdpGenerator(LdpExporter* pExporter) : m_pExporter(pExporter) {}
+    LdpGenerator(LdpExporter* pExporter, bool fSpaceNeeded=false)
+        : m_pExporter(pExporter)
+        , m_fAddSpace(fSpaceNeeded)
+    {
+    }
     virtual ~LdpGenerator() {}
 
     virtual string generate_source(ImoObj* pParent=NULL) = 0;
@@ -96,6 +101,13 @@ protected:
     void add_style(ImoStyle* pStyle);
     void add_placement(int placement);
 
+    inline void space_needed() { m_fAddSpace = true; }
+    inline void add_space_if_needed() {
+        if (m_fAddSpace)
+            m_source << " ";
+        m_fAddSpace = false;
+    }
+    inline bool is_space_needed() { return m_fAddSpace; }
 };
 
 const bool k_in_same_line = false;
@@ -280,22 +292,22 @@ protected:
         switch(m_pObj->get_symbol())
         {
             case ImoFermata::k_short:
-                m_source << "short";
+                m_source << " short";
                 break;
             case ImoFermata::k_long:
-                m_source << "long";
+                m_source << " long";
                 break;
             case ImoFermata::k_henze_short:
-                m_source << "henze-short";
+                m_source << " henze-short";
                 break;
             case ImoFermata::k_henze_long:
-                m_source << "henze-long";
+                m_source << " henze-long";
                 break;
             case ImoFermata::k_very_short:
-                m_source << "very-short";
+                m_source << " very-short";
                 break;
             case ImoFermata::k_very_long:
-                m_source << "very-long";
+                m_source << " very-long";
                 break;
 
             case ImoFermata::k_normal:
@@ -335,16 +347,16 @@ protected:
         string name = LdpExporter::barline_type_to_ldp(type);
         if (name == "undefined")
         {
-            m_source << "simple";
+            m_source << " simple";
             stringstream s;
             s << "Invalid barline. Type=" << type;
             LOMSE_LOG_ERROR(s.str());
         }
         else
-            m_source << name;
+            m_source << " " << name;
 
         if (m_pObj->is_middle())
-            m_source << " middle";
+            m_source << "  middle";
     }
 
 };
@@ -409,7 +421,7 @@ protected:
 
     void add_beam_number()
     {
-        m_source << m_pRO->get_id();
+        m_source << " " << m_pRO->get_id();
     }
 
     void add_segments_info()
@@ -460,7 +472,7 @@ protected:
 
     void add_type()
     {
-        m_source << LdpExporter::clef_type_to_ldp( m_pObj->get_clef_type() );
+        m_source << " " << LdpExporter::clef_type_to_ldp( m_pObj->get_clef_type() );
     }
 
 };
@@ -473,7 +485,8 @@ protected:
     ImoContentObj* m_pObj;
 
 public:
-    ContentObjLdpGenerator(ImoObj* pImo, LdpExporter* pExporter) : LdpGenerator(pExporter)
+    ContentObjLdpGenerator(ImoObj* pImo, LdpExporter* pExporter, bool fSpaceNeeded)
+        : LdpGenerator(pExporter, fSpaceNeeded)
     {
         m_pObj = static_cast<ImoContentObj*>(pImo);
     }
@@ -492,11 +505,17 @@ protected:
     {
         Tenths ux = m_pObj->get_user_location_x();
         if (ux != 0.0f)
-            m_source << " (dx " << LdpExporter::float_to_string(ux) << ")";
+        {
+            add_space_if_needed();
+            m_source << "(dx " << LdpExporter::float_to_string(ux) << ")";
+        }
 
         Tenths uy = m_pObj->get_user_location_y();
         if (uy != 0.0f)
-            m_source << " (dy " << LdpExporter::float_to_string(uy) << ")";
+        {
+            add_space_if_needed();
+            m_source << "(dy " << LdpExporter::float_to_string(uy) << ")";
+        }
     }
 
     void add_attachments()
@@ -542,7 +561,8 @@ protected:
     ImoStyle* m_pObj;
 
 public:
-    DefineStyleLdpGenerator(ImoObj* pImo, LdpExporter* pExporter) : LdpGenerator(pExporter)
+    DefineStyleLdpGenerator(ImoObj* pImo, LdpExporter* pExporter, bool fSpaceNeeded)
+        : LdpGenerator(pExporter, fSpaceNeeded)
     {
         m_pObj = static_cast<ImoStyle*>(pImo);
     }
@@ -560,7 +580,7 @@ protected:
 
     void add_name()
     {
-        m_source << "\"" << m_pObj->get_name() << "\" ";
+        m_source << " \"" << m_pObj->get_name() << "\" ";
     }
 
     void add_properties()
@@ -584,7 +604,7 @@ protected:
         if (m_pObj->get_float_property(ImoStyle::k_font_size, &rValue))
         {
             start_element("font-size", k_no_imoid);
-            m_source << rValue << "pt";
+            m_source << " " << rValue << "pt";
             end_element(k_in_same_line);
         }
 
@@ -689,35 +709,35 @@ protected:
     void create_string_element(const string& tag, const string& value)
     {
         start_element(tag, k_no_imoid);
-        m_source << "\"" << value << "\"";
+        m_source << " \"" << value << "\"";
         end_element(k_in_same_line);
     }
 
     void create_float_element(const string& tag, float value)
     {
         start_element(tag, k_no_imoid);
-        m_source << value;
+        m_source << " " << value;
         end_element(k_in_same_line);
     }
 
     void create_lunits_element(const string& tag, LUnits value)
     {
         start_element(tag, k_no_imoid);
-        m_source << value;
+        m_source << " " << value;
         end_element(k_in_same_line);
     }
 
     void create_int_element(const string& tag, int value)
     {
         start_element(tag, k_no_imoid);
-        m_source << value;
+        m_source << " " << value;
         end_element(k_in_same_line);
     }
 
     void create_color_element(const string& tag, Color color)
     {
         start_element(tag, k_no_imoid);
-        m_source << LdpExporter::color_to_ldp(color);
+        m_source << " " << LdpExporter::color_to_ldp(color);
         end_element(k_in_same_line);
     }
 
@@ -726,11 +746,11 @@ protected:
         start_element("font-style", k_no_imoid);
 
         if (value == ImoStyle::k_font_style_normal)
-            m_source << "normal";
+            m_source << " normal";
         else if (value == ImoStyle::k_font_style_italic)
-            m_source << "italic";
+            m_source << " italic";
         else
-            m_source << "invalid value " << value;
+            m_source << " invalid value " << value;
 
         end_element(k_in_same_line);
     }
@@ -740,11 +760,11 @@ protected:
         start_element("font-weight", k_no_imoid);
 
         if (value == ImoStyle::k_font_weight_normal)
-            m_source << "normal";
+            m_source << " normal";
         else if (value == ImoStyle::k_font_weight_bold)
-            m_source << "bold";
+            m_source << " bold";
         else
-            m_source << "invalid value " << value;
+            m_source << " invalid value " << value;
 
         end_element(k_in_same_line);
     }
@@ -754,15 +774,15 @@ protected:
         start_element("text-decoration", k_no_imoid);
 
         if (value == ImoStyle::k_decoration_none)
-            m_source << "none";
+            m_source << " none";
         else if (value == ImoStyle::k_decoration_underline)
-            m_source << "underline";
+            m_source << " underline";
         else if (value == ImoStyle::k_decoration_overline)
-            m_source << "overline";
+            m_source << " overline";
         else if (value == ImoStyle::k_decoration_line_through)
-            m_source << "line-through";
+            m_source << " line-through";
         else
-            m_source << "invalid value " << value;
+            m_source << " invalid value " << value;
 
         end_element(k_in_same_line);
     }
@@ -772,23 +792,23 @@ protected:
         start_element("vertical-align", k_no_imoid);
 
         if (value == ImoStyle::k_valign_baseline)
-            m_source << "baseline";
+            m_source << " baseline";
         else if (value == ImoStyle::k_valign_sub)
-            m_source << "sub";
+            m_source << " sub";
         else if (value == ImoStyle::k_valign_super)
-            m_source << "super";
+            m_source << " super";
         else if (value == ImoStyle::k_valign_top)
-            m_source << "top";
+            m_source << " top";
         else if (value == ImoStyle::k_valign_text_top)
-            m_source << "text-top";
+            m_source << " text-top";
         else if (value == ImoStyle::k_valign_middle)
-            m_source << "middle";
+            m_source << " middle";
         else if (value == ImoStyle::k_valign_bottom)
-            m_source << "bottom";
+            m_source << " bottom";
         else if (value == ImoStyle::k_valign_text_bottom)
-            m_source << "text-bottom";
+            m_source << " text-bottom";
         else
-            m_source << "invalid value " << value;
+            m_source << " invalid value " << value;
 
         end_element(k_in_same_line);
     }
@@ -798,15 +818,15 @@ protected:
         start_element("text-align", k_no_imoid);
 
         if (value == ImoStyle::k_align_left)
-            m_source << "left";
+            m_source << " left";
         else if (value == ImoStyle::k_align_right)
-            m_source << "right";
+            m_source << " right";
         else if (value == ImoStyle::k_align_center)
-            m_source << "center";
+            m_source << " center";
         else if (value == ImoStyle::k_align_justify)
-            m_source << "justify";
+            m_source << " justify";
         else
-            m_source << "invalid value " << value;
+            m_source << " invalid value " << value;
 
         end_element(k_in_same_line);
     }
@@ -829,6 +849,7 @@ public:
     {
         start_element("dyn", m_pObj->get_id());
         add_dynamics_string();
+        space_needed();
         add_placement( m_pObj->get_placement() );
         source_for_base_scoreobj(m_pObj);
         end_element(k_in_same_line);
@@ -839,7 +860,7 @@ protected:
 
     void add_dynamics_string()
     {
-        m_source << "\"" << m_pObj->get_mark_type() << "\"";
+        m_source << " \"" << m_pObj->get_mark_type() << "\"";
     }
 };
 
@@ -860,7 +881,7 @@ public:
     string generate_source(ImoObj* UNUSED(pParent) =NULL)
     {
         start_element("TODO: ", m_pImo->get_id());
-        m_source << "No LdpGenerator for Imo. Imo name=" << m_pImo->get_name()
+        m_source << " No LdpGenerator for Imo. Imo name=" << m_pImo->get_name()
                  << ", Imo type=" << m_pImo->get_obj_type()
                  << ", id=" << m_pImo->get_id();
         end_element(k_in_same_line);
@@ -929,7 +950,8 @@ protected:
     ImoObj* m_pObj;
 
 public:
-    ImObjLdpGenerator(ImoObj* pImo, LdpExporter* pExporter) : LdpGenerator(pExporter)
+    ImObjLdpGenerator(ImoObj* pImo, LdpExporter* pExporter, bool fSpaceNeeded)
+        : LdpGenerator(pExporter, fSpaceNeeded)
     {
         m_pObj = pImo;
     }
@@ -968,15 +990,15 @@ protected:
     void add_time(bool fFwd)
     {
         if (m_pObj->is_to_start())
-            m_source << "start";
+            m_source << " start";
         else if (m_pObj->is_to_end())
-            m_source << "end";
+            m_source << " end";
         else
         {
             if (fFwd)
-                m_source << m_pObj->get_time_shift();
+                m_source << " " <<  m_pObj->get_time_shift();
             else
-                m_source << - m_pObj->get_time_shift();
+                m_source << " " << - m_pObj->get_time_shift();
 
         }
     }
@@ -1012,7 +1034,7 @@ protected:
     {
         start_element("staves", k_no_imoid);
         int staves = m_pObj->get_num_staves();
-        m_source << staves;
+        m_source << " " << staves;
         end_element(k_in_same_line);
 
         for (int i=1; i <= staves; ++i)
@@ -1038,7 +1060,7 @@ protected:
         if (instr != 0 || channel != 0)
         {
             start_element("infoMIDI", k_no_imoid);
-            m_source << instr << " " << channel;
+            m_source << " " << instr << " " << channel;
             end_element(k_in_same_line);
         }
     }
@@ -1047,7 +1069,8 @@ protected:
     {
         string partId = m_pObj->get_instr_id();
         if (!partId.empty())
-            m_source << partId;
+            m_source << " " << partId;
+        space_needed();
     }
 
     void add_name_abbreviation()
@@ -1057,7 +1080,8 @@ protected:
         {
             start_element("name", k_no_imoid);
             ImoScoreText& txt = m_pObj->get_name();
-            m_source << "\"" << txt.get_text() << "\"";
+            m_source << " \"" << txt.get_text() << "\"";
+            space_needed();
             add_style( txt.get_style() );
             end_element(k_in_same_line);
         }
@@ -1065,7 +1089,8 @@ protected:
         {
             start_element("abbrev", k_no_imoid);
             ImoScoreText& txt = m_pObj->get_abbrev();
-            m_source << "\"" << txt.get_text() << "\"";
+            m_source << " \"" << txt.get_text() << "\"";
+            space_needed();
             add_style( txt.get_style() );
             end_element(k_in_same_line);
         }
@@ -1096,13 +1121,13 @@ protected:
         start_element("staffType", k_no_imoid);
         switch (type)
         {
-            case ImoStaffInfo::k_staff_ossia:       m_source << "ossia";        break;
-            case ImoStaffInfo::k_staff_cue:         m_source << "cue";          break;
-            case ImoStaffInfo::k_staff_editorial:   m_source << "editorial";    break;
-            case ImoStaffInfo::k_staff_regular:     m_source << "regular";      break;
-            case ImoStaffInfo::k_staff_alternate:   m_source << "alternate";    break;
+            case ImoStaffInfo::k_staff_ossia:       m_source << " ossia";        break;
+            case ImoStaffInfo::k_staff_cue:         m_source << " cue";          break;
+            case ImoStaffInfo::k_staff_editorial:   m_source << " editorial";    break;
+            case ImoStaffInfo::k_staff_regular:     m_source << " regular";      break;
+            case ImoStaffInfo::k_staff_alternate:   m_source << " alternate";    break;
             default:
-                m_source << "regular";
+                m_source << " regular";
                 stringstream ss;
                 ss << "Invalid staff type " << type;
                 LOMSE_LOG_ERROR(ss.str());
@@ -1113,35 +1138,35 @@ protected:
     void add_staff_lines(ImoStaffInfo* pStaff)
     {
         start_element("staffLines", k_no_imoid);
-        m_source << pStaff->get_num_lines();
+        m_source << " " << pStaff->get_num_lines();
         end_element(k_in_same_line);
     }
 
     void add_staff_spacing(ImoStaffInfo* pStaff)
     {
         start_element("staffSpacing", k_no_imoid);
-        m_source << pStaff->get_line_spacing();
+        m_source << " " << pStaff->get_line_spacing();
         end_element(k_in_same_line);
     }
 
     void add_staff_distance(ImoStaffInfo* pStaff)
     {
         start_element("staffDistance", k_no_imoid);
-        m_source << pStaff->get_staff_margin();
+        m_source << " " << pStaff->get_staff_margin();
         end_element(k_in_same_line);
     }
 
     void add_line_thickness(ImoStaffInfo* pStaff)
     {
         start_element("lineThickness", k_no_imoid);
-        m_source << pStaff->get_line_thickness();
+        m_source << " " << pStaff->get_line_thickness();
         end_element(k_in_same_line);
     }
 
     void open_staff_element(int i)
     {
         start_element("staff", k_no_imoid);
-        m_source << i << " ";
+        m_source << " " << i << " ";
     }
 
     void close_staff_element()
@@ -1178,7 +1203,7 @@ protected:
 
     void add_key_type()
     {
-        m_source << LdpExporter::key_type_to_ldp( m_pObj->get_key_type() );
+        m_source << " " << LdpExporter::key_type_to_ldp( m_pObj->get_key_type() );
     }
 
 };
@@ -1199,6 +1224,7 @@ public:
     string generate_source(ImoObj* UNUSED(pParent) =NULL)
     {
         start_element("lenmusdoc", m_pObj->get_id());
+        m_source << " ";
         add_version();
         add_comment();
         add_content();
@@ -1211,7 +1237,7 @@ protected:
     void add_version()
     {
         start_element("vers", k_no_imoid);
-        m_source << m_pObj->get_version();
+        m_source << " " << m_pObj->get_version();
         end_element(k_in_same_line);
     }
 
@@ -1279,7 +1305,7 @@ protected:
 
     void add_lyric_number()
     {
-        m_source << m_pObj->get_number();
+        m_source << " " << m_pObj->get_number();
     }
 
     void add_lyric_text()
@@ -1322,6 +1348,7 @@ public:
     string generate_source(ImoObj* UNUSED(pParent) =NULL)
     {
         start_element("musicData", m_pObj->get_id());
+        space_needed();
         add_staffobjs();
         end_element();
         return m_source.str();
@@ -1366,7 +1393,7 @@ protected:
                     int staff = pSO->get_staff() + 1;
 
                     start_element("goFwd", k_no_imoid);
-                    m_source << shift << " v" << voice << " p" << staff;
+                    m_source << " " << shift << " v" << voice << " p" << staff;
                     end_element(k_in_same_line);
 
                     m_rCurTime[voice] = pEntry->time();
@@ -1663,6 +1690,7 @@ public:
     string generate_source(ImoObj* UNUSED(pParent) =NULL)
     {
         start_element("metronome", m_pImo->get_id());
+        m_source << " ";
         add_marks();
         source_for_base_staffobj(m_pImo);
         end_element(k_in_same_line);
@@ -1728,10 +1756,12 @@ public:
         if (m_pObj->is_start_of_chord())
         {
             start_element("chord", k_no_imoid);
+            m_source << " ";
             m_pExporter->set_processing_chord(true);
         }
 
         start_element("n", m_pObj->get_id());
+        m_source << " ";
         add_pitch();
         add_duration(m_source, m_pObj->get_note_type(), m_pObj->get_dots());
         add_voice();
@@ -1759,7 +1789,7 @@ protected:
 
         if (m_pObj->get_step() == k_no_pitch)
         {
-            m_source << "* ";
+            m_source << "*";
             return;
         }
 
@@ -1769,7 +1799,6 @@ protected:
 
         m_source << sNoteName[m_pObj->get_step()];
         m_source << sOctave[m_pObj->get_octave()];
-        m_source << " ";
     }
 
     void add_stem()
@@ -1802,7 +1831,8 @@ protected:
 
     void add_voice()
     {
-        m_source << " v" << m_pObj->get_voice() << " ";
+        m_source << " v" << m_pObj->get_voice();
+        space_needed();
     }
 
     void add_time_modifier()
@@ -1811,8 +1841,8 @@ protected:
             || m_pObj->get_time_modifier_bottom() != 1)
         {
             start_element("tm", k_no_imoid, k_in_same_line);
-            m_source << m_pObj->get_time_modifier_top() << " "
-                     << m_pObj->get_time_modifier_bottom();
+            m_source << " " << m_pObj->get_time_modifier_top()
+                     << " "<< m_pObj->get_time_modifier_bottom();
             end_element(k_in_same_line);
         }
     }
@@ -1853,7 +1883,8 @@ protected:
 
     void add_voice()
     {
-        m_source << " v" << m_pObj->get_voice() << " ";
+        m_source << " v" << m_pObj->get_voice();
+        space_needed();
     }
 
     void generate_rest()
@@ -1870,6 +1901,7 @@ protected:
         start_element("goFwd", m_pObj->get_id());
         add_duration(m_source, m_pObj->get_note_type(), m_pObj->get_dots());
         add_voice();
+        add_space_if_needed();
         m_source << "p" << (m_pObj->get_staff() + 1);
         end_element(k_in_same_line);
     }
@@ -1996,8 +2028,8 @@ protected:
     ImoScoreObj* m_pObj;
 
 public:
-    ScoreObjLdpGenerator(ImoObj* pImo, LdpExporter* pExporter)
-        : LdpGenerator(pExporter)
+    ScoreObjLdpGenerator(ImoObj* pImo, LdpExporter* pExporter, bool fSpaceNeeded)
+        : LdpGenerator(pExporter, fSpaceNeeded)
     {
         m_pObj = static_cast<ImoScoreObj*>(pImo);
     }
@@ -2039,7 +2071,8 @@ protected:
 
     void add_text()
     {
-        m_source << "\"" << m_pObj->get_text() << "\"";
+        m_source << " \"" << m_pObj->get_text() << "\"";
+        space_needed();
     }
 
 };
@@ -2080,7 +2113,7 @@ protected:
 
     void add_slur_number()
     {
-        m_source << m_pObj->get_slur_number();
+        m_source << " " << m_pObj->get_slur_number();
     }
 
     void add_slur_type(bool fStart)
@@ -2110,13 +2143,13 @@ protected:
                     if (pt.x != 0.0f)
                     {
                         start_element( sPointNames[i] + "-x", k_no_imoid, k_in_same_line);
-                        m_source << pt.x;
+                        m_source << " " << pt.x;
                         end_element(k_in_same_line);
                     }
                     if (pt.y != 0.0f)
                     {
                         start_element( sPointNames[i] + "-y", k_no_imoid, k_in_same_line);
-                        m_source << pt.y;
+                        m_source << " " << pt.y;
                         end_element(k_in_same_line);
                     }
                 }
@@ -2134,7 +2167,8 @@ protected:
     ImoStaffObj* m_pObj;
 
 public:
-    StaffObjLdpGenerator(ImoObj* pImo, LdpExporter* pExporter) : LdpGenerator(pExporter)
+    StaffObjLdpGenerator(ImoObj* pImo, LdpExporter* pExporter, bool fSpaceNeeded)
+        : LdpGenerator(pExporter, fSpaceNeeded)
     {
         m_pObj = static_cast<ImoStaffObj*>(pImo);
     }
@@ -2157,7 +2191,8 @@ protected:
             && !m_pObj->is_go_back_fwd() )
         {
 #if 1       // 1= px  0- (staffNum x)
-            m_source << " p" << (m_pObj->get_staff() + 1) << " ";
+            m_source << " p" << (m_pObj->get_staff() + 1);
+            space_needed();
 #else
             m_source << " ";
             start_element("staffNum", k_no_imoid, k_in_same_line);
@@ -2234,7 +2269,7 @@ protected:
 
     void add_space_width()
     {
-        m_source << m_pObj->get_width();
+        m_source << " " << m_pObj->get_width();
     }
 
 };
@@ -2269,7 +2304,7 @@ protected:
 
     void add_tie_number()
     {
-        m_source << m_pTie->get_tie_number();
+        m_source << " " << m_pTie->get_tie_number();
     }
 
     void add_tie_type(bool fStart)
@@ -2346,13 +2381,14 @@ protected:
     void add_content()
     {
         if (m_pObj->is_normal())
-            m_source << m_pObj->get_top_number() << " " << m_pObj->get_bottom_number();
+            m_source << " " << m_pObj->get_top_number() << " "
+                     << m_pObj->get_bottom_number();
         else if (m_pObj->is_common())
-            m_source << "common";
+            m_source << " common";
         else if (m_pObj->is_cut())
-            m_source << "cut";
+            m_source << " cut";
         else if (m_pObj->is_single_number())
-            m_source << "single-number " << m_pObj->get_top_number();
+            m_source << " single-number " << m_pObj->get_top_number();
     }
 
 };
@@ -2364,8 +2400,8 @@ protected:
     ImoScoreTitle* m_pObj;
 
 public:
-    TitleLdpGenerator(ImoObj* pImo, LdpExporter* pExporter)
-        : LdpGenerator(pExporter)
+    TitleLdpGenerator(ImoObj* pImo, LdpExporter* pExporter, bool fSpaceNeeded)
+        : LdpGenerator(pExporter, fSpaceNeeded)
     {
         m_pObj = static_cast<ImoScoreTitle*>(pImo);
     }
@@ -2440,7 +2476,7 @@ protected:
 
     inline void add_tuplet_type(bool fStart)
     {
-        m_source << (fStart ? "+" : "-");
+        m_source << (fStart ? " +" : " -");
     }
 
     inline void add_actual_notes()
@@ -2468,7 +2504,10 @@ protected:
     {
         int opt = m_pTuplet->get_show_bracket();
         if (opt == k_yesno_no)
+        {
             m_source << " noBracket";
+            space_needed();
+        }
     }
 
     void add_display_number()
@@ -2477,16 +2516,15 @@ protected:
         if (number == ImoTuplet::k_number_actual)
             return;     //default option
 
-        m_source << " ";
         start_element("displayNumber", k_no_imoid, k_in_same_line);
 
         if (number == ImoTuplet::k_number_both)
-            m_source << "both";
+            m_source << " both";
         else if (number == ImoTuplet::k_number_none)
-            m_source << "none";
+            m_source << " none";
         else
         {
-            m_source << "both";
+            m_source << " both";
             stringstream s;
             s << "Invalid option. Value=" << number;
             LOMSE_LOG_ERROR(s.str());
@@ -2536,7 +2574,7 @@ protected:
 
     void add_version()
     {
-        m_source << "(vers 2.0)";
+        m_source << " (vers 2.0)";
     }
 
     void add_undo_data()
@@ -2571,7 +2609,7 @@ protected:
 //                  || it->first == "Tuplet numbers"
 //                ))
             {
-                DefineStyleLdpGenerator gen(it->second, m_pExporter);
+                DefineStyleLdpGenerator gen(it->second, m_pExporter, is_space_needed());
                 m_source << gen.generate_source();
             }
         }
@@ -2583,7 +2621,7 @@ protected:
         list<ImoScoreTitle*>::iterator it;
         for (it = titles.begin(); it != titles.end(); ++it)
         {
-            TitleLdpGenerator gen(*it, m_pExporter);
+            TitleLdpGenerator gen(*it, m_pExporter, is_space_needed());
             m_source << gen.generate_source();
         }
     }
@@ -2623,9 +2661,9 @@ protected:
     void add_system_info(ImoSystemInfo* pInfo)
     {
         start_element("systemLayout", pInfo->get_id(), k_in_new_line);
-        m_source << (pInfo->is_first() ? "first" : "other") << " ";
+        m_source << (pInfo->is_first() ? " first" : " other") << " ";
         start_element("systemMargins", k_no_imoid);
-        m_source << pInfo->get_left_margin() << " "
+        m_source << " " << pInfo->get_left_margin() << " "
                  << pInfo->get_right_margin() << " "
                  << pInfo->get_system_distance() << " "
                  << pInfo->get_top_system_distance();
@@ -2643,7 +2681,7 @@ protected:
             if (!m_pObj->has_default_value(pOpt))
             {
                 start_element("opt", pOpt->get_id(), k_in_new_line);
-                m_source << pOpt->get_name() << " ";
+                m_source << " " << pOpt->get_name() << " ";
                 if (pOpt->is_bool_option())
                     m_source << (pOpt->get_bool_value() ? "true" : "false");
                 else if (pOpt->is_long_option())
@@ -2761,13 +2799,13 @@ protected:
                 switch (pGrp->join_barlines())
                 {
                     case ImoInstrGroup::k_standard:
-                        m_source << "yes";
+                        m_source << " yes";
                         break;
                     case ImoInstrGroup::k_mensurstrich:
-                        m_source << "mensurstrich";
+                        m_source << " mensurstrich";
                         break;
                     default:
-                        m_source << "no";
+                        m_source << " no";
                 }
                 end_element(k_in_same_line);
             }
@@ -2795,11 +2833,13 @@ void LdpGenerator::start_element(const string& name, ImoId id, bool fInNewLine)
     if (fInNewLine)
         new_line_and_indent_spaces();
 
+    if (m_fAddSpace)
+        m_source << " ";
     m_source << "(" << name;
     if (m_pExporter->get_add_id() && id != k_no_imoid)
         m_source << "#" << std::dec << id;
-    m_source << " ";
     increment_indent();
+    m_fAddSpace = false;
 }
 
 //---------------------------------------------------------------------------------------
@@ -2809,6 +2849,7 @@ void LdpGenerator::end_element(bool fStartLine)
     if (fStartLine)
         new_line_and_indent_spaces(fStartLine);
     m_source << ")";
+    m_fAddSpace = false;
 }
 
 //---------------------------------------------------------------------------------------
@@ -2858,27 +2899,28 @@ void LdpGenerator::new_line()
 //---------------------------------------------------------------------------------------
 void LdpGenerator::add_source_for(ImoObj* pImo)
 {
+    add_space_if_needed();
     m_source << m_pExporter->get_source(pImo);
 }
 
 //---------------------------------------------------------------------------------------
 void LdpGenerator::source_for_base_staffobj(ImoObj* pImo)
 {
-    StaffObjLdpGenerator gen(pImo, m_pExporter);
+    StaffObjLdpGenerator gen(pImo, m_pExporter, is_space_needed());
     m_source << gen.generate_source();
 }
 
 //---------------------------------------------------------------------------------------
 void LdpGenerator::source_for_base_scoreobj(ImoObj* pImo)
 {
-    ScoreObjLdpGenerator gen(pImo, m_pExporter);
+    ScoreObjLdpGenerator gen(pImo, m_pExporter, is_space_needed());
     m_source << gen.generate_source();
 }
 
 //---------------------------------------------------------------------------------------
 void LdpGenerator::source_for_base_contentobj(ImoObj* pImo)
 {
-    ContentObjLdpGenerator gen(pImo, m_pExporter);
+    ContentObjLdpGenerator gen(pImo, m_pExporter, is_space_needed());
     m_source << gen.generate_source();
 }
 
@@ -2886,7 +2928,7 @@ void LdpGenerator::source_for_base_contentobj(ImoObj* pImo)
 void LdpGenerator::source_for_base_imobj(ImoObj* pImo)
 {
     increment_indent();
-    ImObjLdpGenerator gen(pImo, m_pExporter);
+    ImObjLdpGenerator gen(pImo, m_pExporter, is_space_needed());
     m_source << gen.generate_source();
     decrement_indent();
 }
@@ -2894,13 +2936,23 @@ void LdpGenerator::source_for_base_imobj(ImoObj* pImo)
 //---------------------------------------------------------------------------------------
 void LdpGenerator::source_for_auxobj(ImoObj* pImo)
 {
-    m_source <<  m_pExporter->get_source(pImo);
+    string src = m_pExporter->get_source(pImo);
+    if (!src.empty())
+    {
+        add_space_if_needed();
+        m_source << src;
+    }
 }
 
 //---------------------------------------------------------------------------------------
 void LdpGenerator::source_for_relobj(ImoObj* pRO, ImoObj* pParent)
 {
-    m_source <<  m_pExporter->get_source(pRO, pParent);
+    string src = m_pExporter->get_source(pRO, pParent);
+    if (!src.empty())
+    {
+        add_space_if_needed();
+        m_source << src;
+    }
 }
 
 //---------------------------------------------------------------------------------------
@@ -2918,21 +2970,27 @@ void LdpGenerator::decrement_indent()
 //---------------------------------------------------------------------------------------
 void LdpGenerator::add_duration(stringstream& source, int noteType, int dots)
 {
-    source << LdpExporter::notetype_to_string(noteType, dots);
+    source << " " << LdpExporter::notetype_to_string(noteType, dots);
 }
 
 //---------------------------------------------------------------------------------------
 void LdpGenerator::add_visible(bool fVisible)
 {
     if (!fVisible)
-        m_source << " (visible no)";
+    {
+        add_space_if_needed();
+        m_source << "(visible no)";
+    }
 }
 
 //---------------------------------------------------------------------------------------
 void LdpGenerator::add_color_if_not_black(Color color)
 {
     if (color.r != 0 || color.g != 0  || color.b != 0 || color.a != 255)
+    {
+        add_space_if_needed();
         m_source << "(color " << LdpExporter::color_to_ldp(color) << ")";
+    }
 }
 
 //---------------------------------------------------------------------------------------
@@ -2941,7 +2999,7 @@ void LdpGenerator::add_width_if_not_default(Tenths width, Tenths def)
     if (width != def)
     {
         start_element("width", k_no_imoid, k_in_same_line);
-        m_source << width;
+        m_source << " " << width;
         end_element(k_in_same_line);
     }
 }
@@ -2954,13 +3012,13 @@ void LdpGenerator::add_location_if_not_zero(Tenths x, Tenths y)
         if (x != 0.0f)
         {
             start_element("dx", k_no_imoid, k_in_same_line);
-            m_source << x;
+            m_source << " " << x;
             end_element(k_in_same_line);
         }
         if (y != 0.0f)
         {
             start_element("dy", k_no_imoid, k_in_same_line);
-            m_source << y;
+            m_source << " " << y;
             end_element(k_in_same_line);
         }
     }
@@ -2970,11 +3028,11 @@ void LdpGenerator::add_location_if_not_zero(Tenths x, Tenths y)
 void LdpGenerator::add_location(TPoint pt)
 {
     start_element("dx", k_no_imoid, k_in_same_line);
-    m_source << pt.x;
+    m_source << " " << pt.x;
     end_element(k_in_same_line);
 
     start_element("dy", k_no_imoid, k_in_same_line);
-    m_source << pt.y;
+    m_source << " " << pt.y;
     end_element(k_in_same_line);
 }
 
@@ -2994,9 +3052,8 @@ void LdpGenerator::add_style(ImoStyle* pStyle)
 {
     if (pStyle && pStyle->get_name() != "Default style")
     {
-        m_source << " ";
         start_element("style", k_no_imoid);
-        m_source << "\"" << pStyle->get_name() << "\"";
+        m_source << " \"" << pStyle->get_name() << "\"";
         end_element(k_in_same_line);
     }
 }
@@ -3072,7 +3129,7 @@ LdpGenerator* LdpExporter::new_generator(ImoObj* pImo)
         case k_imo_score:           return LOMSE_NEW ScoreLdpGenerator(pImo, this);
         case k_imo_score_text:      return LOMSE_NEW ScoreTextLdpGenerator(pImo, this);
         case k_imo_score_line:      return LOMSE_NEW ScoreLineLdpGenerator(pImo, this);
-        case k_imo_score_title:     return LOMSE_NEW TitleLdpGenerator(pImo, this);
+//        case k_imo_score_title:     return LOMSE_NEW TitleLdpGenerator(pImo, this);
         case k_imo_slur:            return LOMSE_NEW SlurLdpGenerator(pImo, this);
         case k_imo_spacer:          return LOMSE_NEW SpacerLdpGenerator(pImo, this);
         case k_imo_time_signature:  return LOMSE_NEW TimeSignatureLdpGenerator(pImo, this);

--- a/src/tests/lomse_test_command.cpp
+++ b/src/tests/lomse_test_command.cpp
@@ -127,6 +127,11 @@ public:
         m_pDoc->clear_dirty();
     }
 
+    inline const char* test_name()
+    {
+        return UnitTest::CurrentTest::Details()->testName;
+    }
+
     LibraryScope m_libraryScope;
     std::string m_scores_path;
     Document* m_pDoc;
@@ -176,7 +181,7 @@ SUITE(DocCommandTest)
 
         cursor.move_prev();         //prev note is the inserted one
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n a4 e v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n a4 e v1 p1)" );
     }
 
     TEST_FIXTURE(DocCommandTestFixture, add_noterest_0101_ur)
@@ -215,7 +220,7 @@ SUITE(DocCommandTest)
 
         cursor.move_prev();         //prev note is the inserted one
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n a4 e v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n a4 e v1 p1)" );
     }
 
     TEST_FIXTURE(DocCommandTestFixture, add_noterest_0201)
@@ -255,13 +260,13 @@ SUITE(DocCommandTest)
         CHECK( doc.is_dirty() == true );
         //cursor points after inserted note
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n f4 e v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n f4 e v1 p1)" );
         CHECK( is_equal_time(pSC->time(), 32.0) );
         CHECK( pScore->get_staffobjs_table()->num_entries() == 4 );
 
         cursor.move_prev();         //prev note is the inserted one
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n a4 e v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n a4 e v1 p1)" );
     }
 
     TEST_FIXTURE(DocCommandTestFixture, add_noterest_0201_ur)
@@ -295,12 +300,12 @@ SUITE(DocCommandTest)
         CHECK( doc.is_dirty() == true );
         //cursor points after inserted note
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n f4 e v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n f4 e v1 p1)" );
         CHECK( pScore->get_staffobjs_table()->num_entries() == 4 );
 
         cursor.move_prev();         //prev note is the inserted one
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n a4 e v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n a4 e v1 p1)" );
     }
 
 //    TEST_FIXTURE(DocCommandTestFixture, add_noterest_0202)
@@ -341,17 +346,17 @@ SUITE(DocCommandTest)
 //        CHECK( doc.is_dirty() == true );
 //        //cursor points after inserted note
 //        CHECK( (*cursor)->is_note() == true );
-//        CHECK( (*cursor)->to_string() == "(n f4 q v1  p1 )" );
+//        CHECK( (*cursor)->to_string() == "(n f4 q v1 p1)" );
 //        CHECK( is_equal_time(pSC->time(), 64.0) );
 //        CHECK( pScore->get_staffobjs_table()->num_entries() == 5 );
 //
 //        cursor.move_prev();         //prev note is the inserted one
 //        CHECK( (*cursor)->is_note() == true );
-//        CHECK( (*cursor)->to_string() == "(n a4 s v1  p1 )" );
+//        CHECK( (*cursor)->to_string() == "(n a4 s v1 p1)" );
 //
 //        cursor.move_prev();         //prev note is the original one, shortened
 //        CHECK( (*cursor)->is_note() == true );
-//        CHECK( (*cursor)->to_string() == "(n e4 e. v1  p1 )" );
+//        CHECK( (*cursor)->to_string() == "(n e4 e. v1 p1)" );
 //    }
 //
 //    TEST_FIXTURE(DocCommandTestFixture, add_noterest_0202_ur)
@@ -385,16 +390,16 @@ SUITE(DocCommandTest)
 //        CHECK( doc.is_dirty() == true );
 //        //cursor points after inserted note
 //        CHECK( (*cursor)->is_note() == true );
-//        CHECK( (*cursor)->to_string() == "(n f4 q v1  p1 )" );
+//        CHECK( (*cursor)->to_string() == "(n f4 q v1 p1)" );
 //        CHECK( pScore->get_staffobjs_table()->num_entries() == 5 );
 //
 //        cursor.move_prev();         //prev note is the inserted one
 //        CHECK( (*cursor)->is_note() == true );
-//        CHECK( (*cursor)->to_string() == "(n a4 s v1  p1 )" );
+//        CHECK( (*cursor)->to_string() == "(n a4 s v1 p1)" );
 //
 //        cursor.move_prev();         //prev note is the original one, shortened
 //        CHECK( (*cursor)->is_note() == true );
-//        CHECK( (*cursor)->to_string() == "(n e4 e. v1  p1 )" );
+//        CHECK( (*cursor)->to_string() == "(n e4 e. v1 p1)" );
 //    }
 
     TEST_FIXTURE(DocCommandTestFixture, add_noterest_0203)
@@ -435,13 +440,13 @@ SUITE(DocCommandTest)
         CHECK( doc.is_dirty() == true );
         //cursor points after inserted note
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n e4 e. v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n e4 e. v1 p1)" );
         CHECK( is_equal_time(pSC->time(), 16.0) );
         CHECK( pScore->get_staffobjs_table()->num_entries() == 5 );
 
         cursor.move_prev();         //prev note is the inserted one
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n a4 s v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n a4 s v1 p1)" );
     }
 
     TEST_FIXTURE(DocCommandTestFixture, add_noterest_0203_ur)
@@ -476,12 +481,12 @@ SUITE(DocCommandTest)
         CHECK( doc.is_dirty() == true );
         //cursor points after inserted note
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n e4 e. v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n e4 e. v1 p1)" );
         CHECK( pScore->get_staffobjs_table()->num_entries() == 5 );
 
         cursor.move_prev();         //prev note is the inserted one
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n a4 s v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n a4 s v1 p1)" );
     }
 
     TEST_FIXTURE(DocCommandTestFixture, add_noterest_0204)
@@ -522,13 +527,13 @@ SUITE(DocCommandTest)
         CHECK( doc.is_dirty() == true );
         //cursor points after inserted note
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n f4 s v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n f4 s v1 p1)" );
         CHECK( is_equal_time(pSC->time(), 48.0) );
         CHECK( pScore->get_staffobjs_table()->num_entries() == 4 );
 
         cursor.move_prev();         //prev note is the inserted one
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n a4 e. v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n a4 e. v1 p1)" );
     }
 
     TEST_FIXTURE(DocCommandTestFixture, add_noterest_0204_ur)
@@ -563,12 +568,12 @@ SUITE(DocCommandTest)
         CHECK( doc.is_dirty() == true );
         //cursor points after inserted note
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n f4 s v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n f4 s v1 p1)" );
         CHECK( pScore->get_staffobjs_table()->num_entries() == 4 );
 
         cursor.move_prev();         //prev note is the inserted one
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n a4 e. v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n a4 e. v1 p1)" );
     }
 
 //    TEST_FIXTURE(DocCommandTestFixture, add_noterest_0205)
@@ -608,17 +613,17 @@ SUITE(DocCommandTest)
 //        CHECK( doc.is_dirty() == true );
 //        //cursor points after inserted note
 //        CHECK( (*cursor)->is_note() == true );
-//        CHECK( (*cursor)->to_string() == "(n b4 e. v1  p1 )" );
+//        CHECK( (*cursor)->to_string() == "(n b4 e. v1 p1)" );
 //        CHECK( is_equal_time(pSC->time(), 144.0) );
 //        CHECK( pScore->get_staffobjs_table()->num_entries() == 4 );
 //
 //        cursor.move_prev();         //prev note is the inserted one
 //        CHECK( (*cursor)->is_note() == true );
-//        CHECK( (*cursor)->to_string() == "(n a4 h v1  p1 )" );
+//        CHECK( (*cursor)->to_string() == "(n a4 h v1 p1)" );
 //
 //        cursor.move_prev();         //prev note is the original one, shortened
 //        CHECK( (*cursor)->is_note() == true );
-//        CHECK( (*cursor)->to_string() == "(n e4 s v1  p1 )" );
+//        CHECK( (*cursor)->to_string() == "(n e4 s v1 p1)" );
 //    }
 //
 //    TEST_FIXTURE(DocCommandTestFixture, add_noterest_0205_ur)
@@ -651,16 +656,16 @@ SUITE(DocCommandTest)
 //        CHECK( doc.is_dirty() == true );
 //        //cursor points after inserted note
 //        CHECK( (*cursor)->is_note() == true );
-//        CHECK( (*cursor)->to_string() == "(n b4 e. v1  p1 )" );
+//        CHECK( (*cursor)->to_string() == "(n b4 e. v1 p1)" );
 //        CHECK( pScore->get_staffobjs_table()->num_entries() == 4 );
 //
 //        cursor.move_prev();         //prev note is the inserted one
 //        CHECK( (*cursor)->is_note() == true );
-//        CHECK( (*cursor)->to_string() == "(n a4 h v1  p1 )" );
+//        CHECK( (*cursor)->to_string() == "(n a4 h v1 p1)" );
 //
 //        cursor.move_prev();         //prev note is the original one, shortened
 //        CHECK( (*cursor)->is_note() == true );
-//        CHECK( (*cursor)->to_string() == "(n e4 s v1  p1 )" );
+//        CHECK( (*cursor)->to_string() == "(n e4 s v1 p1)" );
 //    }
 
     TEST_FIXTURE(DocCommandTestFixture, add_noterest_0301)
@@ -702,19 +707,19 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v1 p1)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,     1, "(goFwd e v2 p1)" );
-        CHECK_ENTRY0(it, 0,    0,      0,  32,     1, "(n a4 e v2  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n f4 e v1  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n g4 e v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,  32,     1, "(n a4 e v2 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n f4 e v1 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n g4 e v1 p1)" );
         //cout << pTable->dump() << endl;
 
         CHECK( pCmd->get_name() == "Add note" );
         CHECK( doc.is_dirty() == true );
         //cursor points after inserted note
         CHECK( pSC->is_at_empty_place() == false );
-        CHECK( pSC->staffobj_internal()->to_string() == "(n g4 e v1  p1 )" );
+        CHECK( pSC->staffobj_internal()->to_string() == "(n g4 e v1 p1)" );
         CHECK( is_equal_time(pSC->time(), 64.0) );
     }
 
@@ -751,19 +756,19 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v1 p1)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,     1, "(goFwd e v2 p1)" );
-        CHECK_ENTRY0(it, 0,    0,      0,  32,     1, "(n a4 e v2  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n f4 e v1  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n g4 e v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,  32,     1, "(n a4 e v2 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n f4 e v1 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n g4 e v1 p1)" );
         //cout << pTable->dump() << endl;
 
         CHECK( pCmd->get_name() == "Add note" );
         CHECK( doc.is_dirty() == true );
         //cursor points after inserted note
         CHECK( pSC->is_at_empty_place() == false );
-        CHECK( pSC->staffobj_internal()->to_string() == "(n g4 e v1  p1 )" );
+        CHECK( pSC->staffobj_internal()->to_string() == "(n g4 e v1 p1)" );
         CHECK( is_equal_time(pSC->time(), 64.0) );
     }
 
@@ -807,13 +812,13 @@ SUITE(DocCommandTest)
 //
 //        ColStaffObjsIterator it = pTable->begin();
 //        //              instr, staff, meas. time, line, scr
-//        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-//        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v1  p1 )" );
+//        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+//        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v1 p1)" );
 //        CHECK_ENTRY0(it, 0,    0,      0,   0,     1, "(n c5 e v2 p1)" );
-//        CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n f4 e v1  p1 )" );
+//        CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n f4 e v1 p1)" );
 //        CHECK_ENTRY0(it, 0,    0,      0,  32,     1, "(goFwd q v2 p1)" );
-//        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n g4 e v1  p1 )" );
-//        CHECK_ENTRY0(it, 0,    0,      0,  64,     1, "(n g4 e v1  p1 )" );
+//        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n g4 e v1 p1)" );
+//        CHECK_ENTRY0(it, 0,    0,      0,  64,     1, "(n g4 e v1 p1)" );
 //        cout << pTable->dump() << endl;
 //
 //
@@ -825,7 +830,7 @@ SUITE(DocCommandTest)
 //
 //        cursor.move_prev();
 //        CHECK( (*cursor)->is_note() == true );
-//        CHECK( (*cursor)->to_string() == "(n g4 e v1  p1 )" );
+//        CHECK( (*cursor)->to_string() == "(n g4 e v1 p1)" );
 //    }
 //
 //    TEST_FIXTURE(DocCommandTestFixture, add_noterest_0302_ur)
@@ -859,13 +864,13 @@ SUITE(DocCommandTest)
 //
 //        ColStaffObjsIterator it = pTable->begin();
 //        //              instr, staff, meas. time, line, scr
-//        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-//        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v1  p1 )" );
+//        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+//        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v1 p1)" );
 //        CHECK_ENTRY0(it, 0,    0,      0,   0,     1, "(n c5 e v2 p1)" );
-//        CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n f4 e v1  p1 )" );
+//        CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n f4 e v1 p1)" );
 //        CHECK_ENTRY0(it, 0,    0,      0,  32,     1, "(goFwd e v2 p1)" );
-//        CHECK_ENTRY0(it, 0,    0,      0,  64,     1, "(n a4 e v2  p1 )" );
-//        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n g4 e v1  p1 )" );
+//        CHECK_ENTRY0(it, 0,    0,      0,  64,     1, "(n a4 e v2 p1)" );
+//        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n g4 e v1 p1)" );
 //        cout << pTable->dump() << endl;
 //
 //
@@ -875,7 +880,7 @@ SUITE(DocCommandTest)
 //
 //        cursor.move_prev();
 //        CHECK( (*cursor)->is_note() == true );
-//        CHECK( (*cursor)->to_string() == "(n g4 e v1  p1 )" );
+//        CHECK( (*cursor)->to_string() == "(n g4 e v1 p1)" );
 //    }
 //
 //    TEST_FIXTURE(DocCommandTestFixture, add_noterest_0303)
@@ -918,15 +923,15 @@ SUITE(DocCommandTest)
 //        CHECK( doc.is_dirty() == true );
 //        //cursor points after inserted note
 ////        CHECK( (*cursor)->is_note() == true );
-////        CHECK( (*cursor)->to_string() == "(n g4 e v1  p1 )" );
+////        CHECK( (*cursor)->to_string() == "(n g4 e v1 p1)" );
 //        CHECK( pSC->is_at_empty_place() == true );
-//        CHECK( pSC->staffobj_internal()->to_string() == "(n g4 e v1  p1 )" );
+//        CHECK( pSC->staffobj_internal()->to_string() == "(n g4 e v1 p1)" );
 //        CHECK( is_equal_time(pSC->time(), 128.0) );
 //        CHECK( pScore->get_staffobjs_table()->num_entries() == 7 );
 //
 //        cursor.move_prev();         //prev note is the inserted one
 //        CHECK( (*cursor)->is_note() == true );
-//        CHECK( (*cursor)->to_string() == "(n a4 e v2  p1 )" );
+//        CHECK( (*cursor)->to_string() == "(n a4 e v2 p1)" );
 //
 //        cursor.move_prev();         //prev note is the goFwd
 //        CHECK( (*cursor)->is_gap() == true );
@@ -966,12 +971,12 @@ SUITE(DocCommandTest)
 //        CHECK( doc.is_dirty() == true );
 //        //cursor points after inserted note
 //        CHECK( (*cursor)->is_note() == true );
-//        CHECK( (*cursor)->to_string() == "(n g4 e v1  p1 )" );
+//        CHECK( (*cursor)->to_string() == "(n g4 e v1 p1)" );
 //        CHECK( pScore->get_staffobjs_table()->num_entries() == 7 );
 //
 //        cursor.move_prev();         //prev note is the inserted one
 //        CHECK( (*cursor)->is_note() == true );
-//        CHECK( (*cursor)->to_string() == "(n a4 e v2  p1 )" );
+//        CHECK( (*cursor)->to_string() == "(n a4 e v2 p1)" );
 //
 //        cursor.move_prev();         //prev note is the goFwd
 //        CHECK( (*cursor)->is_gap() == true );
@@ -1011,15 +1016,15 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(key C)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(time 6 8)" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 e. v1  p1 (beam 150 +))" );
-        CHECK_ENTRY0(it, 0,    0,      0,  48,     0, "(n g4 s v1  p1 (beam 150 =b))" );
-        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n c5 e v1  p1 (beam 150 -))" );
-        CHECK_ENTRY0(it, 0,    0,      0,  96,     0, "(n c4 e v1  p1 (beam 139 +))" );
-        CHECK_ENTRY0(it, 0,    0,      0, 128,     0, "(n e4 e v1  p1 (beam 139 =))" );
-        CHECK_ENTRY0(it, 0,    0,      0, 160,     0, "(n g4 e v1  p1 (beam 139 -))" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 e. v1 p1 (beam 150 +))" );
+        CHECK_ENTRY0(it, 0,    0,      0,  48,     0, "(n g4 s v1 p1 (beam 150 =b))" );
+        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n c5 e v1 p1 (beam 150 -))" );
+        CHECK_ENTRY0(it, 0,    0,      0,  96,     0, "(n c4 e v1 p1 (beam 139 +))" );
+        CHECK_ENTRY0(it, 0,    0,      0, 128,     0, "(n e4 e v1 p1 (beam 139 =))" );
+        CHECK_ENTRY0(it, 0,    0,      0, 160,     0, "(n g4 e v1 p1 (beam 139 -))" );
         CHECK_ENTRY0(it, 0,    0,      0, 192,     0, "(barline simple)" );
         //cout << pTable->dump() << endl;
      }
@@ -1056,12 +1061,12 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(key C)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(time 2 4)" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 q v1  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n c5 e v1  p1 (beam 130 +))" );
-        CHECK_ENTRY0(it, 0,    0,      0,  96,     0, "(n e5 e v1  p1 (beam 130 -))" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 q v1 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n c5 e v1 p1 (beam 130 +))" );
+        CHECK_ENTRY0(it, 0,    0,      0,  96,     0, "(n e5 e v1 p1 (beam 130 -))" );
         CHECK_ENTRY0(it, 0,    0,      0, 128,     0, "(barline simple)" );
         //cout << pTable->dump() << endl;
      }
@@ -1098,14 +1103,14 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(key C)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(time 6 8)" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 q v1  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n c5 e v1  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,  96,     0, "(n c4 e v1  p1 (beam 139 +))" );
-        CHECK_ENTRY0(it, 0,    0,      0, 128,     0, "(n e4 e v1  p1 (beam 139 =))" );
-        CHECK_ENTRY0(it, 0,    0,      0, 160,     0, "(n g4 e v1  p1 (beam 139 -))" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 q v1 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n c5 e v1 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,  96,     0, "(n c4 e v1 p1 (beam 139 +))" );
+        CHECK_ENTRY0(it, 0,    0,      0, 128,     0, "(n e4 e v1 p1 (beam 139 =))" );
+        CHECK_ENTRY0(it, 0,    0,      0, 160,     0, "(n g4 e v1 p1 (beam 139 -))" );
         CHECK_ENTRY0(it, 0,    0,      0, 192,     0, "(barline simple)" );
         //cout << pTable->dump() << endl;
      }
@@ -1143,15 +1148,15 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(key C)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(time 6 8)" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v1  p1 (beam 129 +))" );
-        CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n g4 e v1  p1 (beam 129 =))" );
-        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n c5 e v1  p1 (beam 129 -))" );
-        CHECK_ENTRY0(it, 0,    0,      0,  96,     0, "(n d4 e. v1  p1 (beam 150 +))" );
-        CHECK_ENTRY0(it, 0,    0,      0, 144,     0, "(n e4 s v1  p1 (beam 150 =b))" );
-        CHECK_ENTRY0(it, 0,    0,      0, 160,     0, "(n g4 e v1  p1 (beam 150 -))" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v1 p1 (beam 129 +))" );
+        CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n g4 e v1 p1 (beam 129 =))" );
+        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n c5 e v1 p1 (beam 129 -))" );
+        CHECK_ENTRY0(it, 0,    0,      0,  96,     0, "(n d4 e. v1 p1 (beam 150 +))" );
+        CHECK_ENTRY0(it, 0,    0,      0, 144,     0, "(n e4 s v1 p1 (beam 150 =b))" );
+        CHECK_ENTRY0(it, 0,    0,      0, 160,     0, "(n g4 e v1 p1 (beam 150 -))" );
         CHECK_ENTRY0(it, 0,    0,      0, 192,     0, "(barline simple)" );
         //cout << pTable->dump() << endl;
      }
@@ -2306,11 +2311,11 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n g4 q v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n g4 q v1 p1)" );
 
         //cursor pointing to right place
-        CHECK( (*cursor)->to_string() == "(n g4 q v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n g4 q v1 p1)" );
     }
 
     TEST_FIXTURE(DocCommandTestFixture, delete_selection_1902)
@@ -2346,11 +2351,11 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n f4 e v1  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   32,     0, "(n g4 q v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n f4 e v1 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   32,     0, "(n g4 q v1 p1)" );
 
         //cursor pointing to right place
-        CHECK( (*cursor)->to_string() == "(n f4 e v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n f4 e v1 p1)" );
     }
 
     TEST_FIXTURE(DocCommandTestFixture, delete_selection_1903)
@@ -2385,11 +2390,11 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
         ImoStaffObj* pSO = (*it)->imo_object();     //it points to next: n e4
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v1  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n f4 e v1  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n g4 q v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v1 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n f4 e v1 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n g4 q v1 p1)" );
 
         CHECK( static_cast<ImoStaffObj*>(*cursor) == pSO );    //cursor points to n g4
 
@@ -2429,11 +2434,11 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
         ImoStaffObj* pSO = (*it)->imo_object();     //it points to next: n e4
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v1  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n f4 e v1  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n g4 q v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v1 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n f4 e v1 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n g4 q v1 p1)" );
 
         CHECK( static_cast<ImoStaffObj*>(*cursor) == pSO );    //cursor points to n e4
 
@@ -2515,7 +2520,7 @@ SUITE(DocCommandTest)
 
         CHECK( *cursor != NULL );
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n e4 e v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n e4 e v1 p1)" );
 //        cout << "cursor: " << (*cursor)->to_string() << endl;
 
         ScoreCursor* pSC = static_cast<ScoreCursor*>( cursor.get_inner_cursor() );
@@ -2530,8 +2535,8 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v1 p1)" );
 //        cout << pTable->dump();
 //        cout << doc.to_string() << endl;
     }
@@ -2558,7 +2563,7 @@ SUITE(DocCommandTest)
 
         CHECK( *cursor != NULL );
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n c4 e v1  p1 (beam 126 +))" );
+        CHECK( (*cursor)->to_string() == "(n c4 e v1 p1 (beam 126 +))" );
 //        cout << "cursor: " << (*cursor)->to_string() << endl;
 
         ScoreCursor* pSC = static_cast<ScoreCursor*>( cursor.get_inner_cursor() );
@@ -2573,9 +2578,9 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 e v1  p1 (beam 126 +))" );
-        CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n e4 e v1  p1 (beam 126 -))" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 e v1 p1 (beam 126 +))" );
+        CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n e4 e v1 p1 (beam 126 -))" );
 //        cout << pTable->dump();
 //        cout << doc.to_string() << endl;
     }
@@ -2601,7 +2606,7 @@ SUITE(DocCommandTest)
 
         CHECK( *cursor != NULL );
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n f5 s v1  p1 (beam 127 +f))" );
+        CHECK( (*cursor)->to_string() == "(n f5 s v1 p1 (beam 127 +f))" );
 //        cout << "cursor: " << (*cursor)->to_string() << endl;
 
         ScoreCursor* pSC = static_cast<ScoreCursor*>( cursor.get_inner_cursor() );
@@ -2616,9 +2621,9 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n f5 s v1  p1 (beam 127 +f))" );
-        CHECK_ENTRY0(it, 0,    0,      0,  16,     0, "(n g5 e v1  p1 (beam 127 -))" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n f5 s v1 p1 (beam 127 +f))" );
+        CHECK_ENTRY0(it, 0,    0,      0,  16,     0, "(n g5 e v1 p1 (beam 127 -))" );
 //        cout << pTable->dump();
 //        cout << doc.to_string() << endl;
     }
@@ -2645,7 +2650,7 @@ SUITE(DocCommandTest)
 
         CHECK( *cursor != NULL );
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n g5 s v1  p1 (beam 127 ++))" );
+        CHECK( (*cursor)->to_string() == "(n g5 s v1 p1 (beam 127 ++))" );
 //        cout << "cursor: " << (*cursor)->to_string() << endl;
 
         ScoreCursor* pSC = static_cast<ScoreCursor*>( cursor.get_inner_cursor() );
@@ -2660,10 +2665,10 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n g5 s v1  p1 (beam 127 ++))" );
-        CHECK_ENTRY0(it, 0,    0,      0,  16,     0, "(n f5 s v1  p1 (beam 127 =-))" );
-        CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n g5 e v1  p1 (beam 127 -))" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n g5 s v1 p1 (beam 127 ++))" );
+        CHECK_ENTRY0(it, 0,    0,      0,  16,     0, "(n f5 s v1 p1 (beam 127 =-))" );
+        CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n g5 e v1 p1 (beam 127 -))" );
 //        cout << pTable->dump();
 //        cout << doc.to_string() << endl;
     }
@@ -2689,7 +2694,7 @@ SUITE(DocCommandTest)
 
         CHECK( *cursor != NULL );
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(chord (n e4 s v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(chord (n e4 s v1 p1)" );
 //        cout << "cursor: " << (*cursor)->to_string() << endl;
 
         ScoreCursor* pSC = static_cast<ScoreCursor*>( cursor.get_inner_cursor() );
@@ -2704,9 +2709,9 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(chord (n e4 s v1  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n g4 s v1  p1 ))" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(chord (n e4 s v1 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n g4 s v1 p1))" );
 //        cout << pTable->dump();
 //        cout << doc.to_string() << endl;
     }
@@ -2732,7 +2737,7 @@ SUITE(DocCommandTest)
 
         CHECK( *cursor != NULL );
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n g4 s v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n g4 s v1 p1)" );
 //        cout << "cursor: " << (*cursor)->to_string() << endl;
         ImoNote* pNote = static_cast<ImoNote*>( *cursor );
         CHECK( pNote->is_in_chord() == false );
@@ -2749,8 +2754,8 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n g4 s v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n g4 s v1 p1)" );
 //        cout << pTable->dump();
 //        cout << doc.to_string() << endl;
     }
@@ -2776,7 +2781,7 @@ SUITE(DocCommandTest)
 
         CHECK( *cursor != NULL );
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n g4 s v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n g4 s v1 p1)" );
 //        cout << "cursor: " << (*cursor)->to_string() << endl;
         ImoNote* pNote = static_cast<ImoNote*>( *cursor );
         CHECK( pNote->is_tied_next() == false );
@@ -2794,8 +2799,8 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n g4 s v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n g4 s v1 p1)" );
 //        cout << pTable->dump();
 //        cout << doc.to_string() << endl;
     }
@@ -2823,7 +2828,7 @@ SUITE(DocCommandTest)
 
         CHECK( *cursor != NULL );
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n e4 s v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n e4 s v1 p1)" );
 //        cout << "cursor: " << (*cursor)->to_string() << endl;
         pNote = static_cast<ImoNote*>( *cursor );
         CHECK( pNote->is_in_tuplet() == false );
@@ -2840,8 +2845,8 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 s v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 s v1 p1)" );
 //        cout << pTable->dump();
 //        cout << doc.to_string() << endl;
     }
@@ -2875,7 +2880,7 @@ SUITE(DocCommandTest)
         cursor.move_prev();         //points to n e4 s
         CHECK( *cursor != NULL );
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n e4 s v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n e4 s v1 p1)" );
 //        cout << "cursor: " << (*cursor)->to_string() << endl;
         pNote = static_cast<ImoNote*>( *cursor );
         CHECK( pNote->is_in_tuplet() == false );
@@ -2888,8 +2893,8 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 s v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 s v1 p1)" );
 //        cout << pTable->dump();
 //        cout << doc.to_string() << endl;
     }
@@ -2919,11 +2924,11 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n f4 e v1  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   32,     0, "(n g4 q v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n f4 e v1 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   32,     0, "(n g4 q v1 p1)" );
 
         //cursor pointing to right place
-        CHECK( (*cursor)->to_string() == "(n f4 e v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n f4 e v1 p1)" );
     }
 
     TEST_FIXTURE(DocCommandTestFixture, delete_staffobj_2013)
@@ -3095,7 +3100,7 @@ SUITE(DocCommandTest)
     {
         //objects inserted and cursor updated
         Document doc(m_libraryScope);
-        doc.from_string("(score (vers 1.6)(instrument#121 (musicData )))");
+        doc.from_string("(score (vers 1.6)(instrument#121 (musicData)))");
         doc.clear_dirty();
         DocCommandExecuter executer(&doc);
         DocCommand* pCmd = LOMSE_NEW CmdInsertManyStaffObjs("(clef G)(n e4 e g+)(n c4 e g-)");
@@ -3119,7 +3124,9 @@ SUITE(DocCommandTest)
         CHECK( pSC->is_at_end_of_staff() == true );
         CHECK( pSC->time() == 64 );
 
-        CHECK( doc.to_string() == "(lenmusdoc (vers 0.0)(content  (score (vers 2.0)(instrument (staves 1)(musicData (clef G p1 )(n e4 e v1  p1 (beam 127 +))(n c4 e v1  p1 (beam 127 -)))))))" );
+        CHECK( doc.to_string() == "(lenmusdoc (vers 0.0)(content (score (vers 2.0)"
+              "(instrument (staves 1)(musicData (clef G p1)(n e4 e v1 p1 (beam 127 +))"
+              "(n c4 e v1 p1 (beam 127 -)))))))" );
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
         CHECK( pScore->get_staffobjs_table()->num_entries() == 3 );
 //        cout << doc.to_string() << endl;
@@ -3130,7 +3137,7 @@ SUITE(DocCommandTest)
     {
         //undo insertion
         Document doc(m_libraryScope);
-        doc.from_string("(score (vers 1.6)(instrument#121 (musicData )))");
+        doc.from_string("(score (vers 1.6)(instrument#121 (musicData)))");
         doc.clear_dirty();
         DocCommandExecuter executer(&doc);
         DocCommand* pCmd = LOMSE_NEW CmdInsertManyStaffObjs("(clef G)(n e4 e g+)(n c4 e g-)");
@@ -3148,7 +3155,7 @@ SUITE(DocCommandTest)
 //        cout << pSC->dump_cursor() << endl;
 
         CHECK( doc.is_dirty() == true );
-        CHECK( doc.to_string() == "(lenmusdoc (vers 0.0)(content  (score (vers 2.0)(instrument (staves 1)(musicData )))))" );
+        CHECK( doc.to_string() == "(lenmusdoc (vers 0.0)(content (score (vers 2.0)(instrument (staves 1)(musicData)))))" );
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
         CHECK( pScore->get_staffobjs_table()->num_entries() == 0 );
 //        cout << doc.to_string() << endl;
@@ -3159,7 +3166,7 @@ SUITE(DocCommandTest)
     {
         //redo insertion
         Document doc(m_libraryScope);
-        doc.from_string("(score (vers 2.0)(instrument#121 (musicData )))");
+        doc.from_string("(score (vers 2.0)(instrument#121 (musicData)))");
         doc.clear_dirty();
         DocCommandExecuter executer(&doc);
         DocCommand* pCmd = LOMSE_NEW CmdInsertManyStaffObjs("(clef G)(n e4 e g+)(n c4 e g-)");
@@ -3180,7 +3187,7 @@ SUITE(DocCommandTest)
         CHECK( pSC->is_at_end_of_empty_score() == false );
         CHECK( pSC->is_at_end_of_staff() == true );
 
-        CHECK( doc.to_string() == "(lenmusdoc (vers 0.0)(content  (score (vers 2.0)(instrument (staves 1)(musicData (clef G p1 )(n e4 e v1  p1 (beam 136 +))(n c4 e v1  p1 (beam 136 -)))))))" );
+        CHECK( doc.to_string() == "(lenmusdoc (vers 0.0)(content (score (vers 2.0)(instrument (staves 1)(musicData (clef G p1)(n e4 e v1 p1 (beam 136 +))(n c4 e v1 p1 (beam 136 -)))))))" );
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
         CHECK( pScore->get_staffobjs_table()->num_entries() == 3 );
 //        cout << doc.to_string() << endl;
@@ -3191,7 +3198,7 @@ SUITE(DocCommandTest)
     {
         //undo/redo when cursor repositioned
         Document doc(m_libraryScope);
-        doc.from_string("(score (vers 2.0)(instrument#121 (musicData )))");
+        doc.from_string("(score (vers 2.0)(instrument#121 (musicData)))");
         doc.clear_dirty();
         DocCommandExecuter executer(&doc);
         DocCommand* pCmd = LOMSE_NEW CmdInsertManyStaffObjs("(clef G)(n e4 e g+)(n c4 e g-)");
@@ -3237,7 +3244,7 @@ SUITE(DocCommandTest)
     {
         //clef inserted and cursor updated
         Document doc(m_libraryScope);
-        doc.from_string("(score (vers 1.6)(instrument#121 (musicData )))");
+        doc.from_string("(score (vers 1.6)(instrument#121 (musicData)))");
         doc.clear_dirty();
         DocCommandExecuter executer(&doc);
         DocCommand* pCmd = LOMSE_NEW CmdInsertStaffObj("(clef G)");
@@ -3268,7 +3275,7 @@ SUITE(DocCommandTest)
     {
         //undo insertion
         Document doc(m_libraryScope);
-        doc.from_string("(score (vers 1.6)(instrument#121 (musicData )))");
+        doc.from_string("(score (vers 1.6)(instrument#121 (musicData)))");
         doc.clear_dirty();
         DocCommandExecuter executer(&doc);
         DocCommand* pCmd = LOMSE_NEW CmdInsertStaffObj("(clef G)");
@@ -3282,8 +3289,8 @@ SUITE(DocCommandTest)
         ScoreCursor* pSC = static_cast<ScoreCursor*>( cursor.get_inner_cursor() );
         CHECK( pSC->is_at_end_of_empty_score() == true );
         CHECK( doc.is_dirty() == true );
-        string expected = "(lenmusdoc (vers 0.0)(content  (score (vers 2.0)"
-            "(instrument (staves 1)(musicData )))))";
+        string expected = "(lenmusdoc (vers 0.0)(content (score (vers 2.0)"
+            "(instrument (staves 1)(musicData)))))";
         CHECK( doc.to_string() == expected );
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
         CHECK( pScore->get_staffobjs_table()->num_entries() == 0 );
@@ -3295,7 +3302,7 @@ SUITE(DocCommandTest)
     {
         //source code validated
         Document doc(m_libraryScope);
-        doc.from_string("(score (vers 1.6)(instrument#121 (musicData )))");
+        doc.from_string("(score (vers 1.6)(instrument#121 (musicData)))");
         doc.clear_dirty();
         DocCommandExecuter executer(&doc);
         DocCommand* pCmd = LOMSE_NEW CmdInsertStaffObj("(clof G)");
@@ -3316,7 +3323,7 @@ SUITE(DocCommandTest)
     {
         //undo/redo with cursor changes
         Document doc(m_libraryScope);
-        doc.from_string("(score (vers 1.6)(instrument#121 (musicData )))");
+        doc.from_string("(score (vers 1.6)(instrument#121 (musicData)))");
         doc.clear_dirty();
         DocCommandExecuter executer(&doc);
         DocCursor cursor(&doc);
@@ -3356,7 +3363,7 @@ SUITE(DocCommandTest)
     {
         //validate source code: start/end parenthesis
         Document doc(m_libraryScope);
-        doc.from_string("(score (vers 1.6)(instrument#121 (musicData )))");
+        doc.from_string("(score (vers 1.6)(instrument#121 (musicData)))");
         doc.clear_dirty();
         DocCommandExecuter executer(&doc);
         DocCursor cursor(&doc);
@@ -3375,7 +3382,7 @@ SUITE(DocCommandTest)
     {
         //validate source code: more than one LDP elements
         Document doc(m_libraryScope);
-        doc.from_string("(score (vers 1.6)(instrument#121 (musicData )))");
+        doc.from_string("(score (vers 1.6)(instrument#121 (musicData)))");
         doc.clear_dirty();
         DocCommandExecuter executer(&doc);
         DocCursor cursor(&doc);
@@ -3394,7 +3401,7 @@ SUITE(DocCommandTest)
     {
         //validate source code: parenthesis mismatch
         Document doc(m_libraryScope);
-        doc.from_string("(score (vers 1.6)(instrument#121 (musicData )))");
+        doc.from_string("(score (vers 1.6)(instrument#121 (musicData)))");
         doc.clear_dirty();
         DocCommandExecuter executer(&doc);
         DocCursor cursor(&doc);
@@ -3433,7 +3440,7 @@ SUITE(DocCommandTest)
 
         CHECK( *cursor != NULL );
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n c4 q v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n c4 q v1 p1)" );
         //cout << "cursor: " << (*cursor)->to_string() << endl;
 
         ScoreCursor* pSC = static_cast<ScoreCursor*>( cursor.get_inner_cursor() );
@@ -3448,9 +3455,9 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v2  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     1, "(n c4 q v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v2 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     1, "(n c4 q v1 p1)" );
 //        cout << pTable->dump();
 //        cout << doc.to_string() << endl;
     }
@@ -3475,7 +3482,7 @@ SUITE(DocCommandTest)
 
         CHECK( *cursor != NULL );
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n c4 q v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n c4 q v1 p1)" );
         //cout << "cursor: " << (*cursor)->to_string() << endl;
 
         ScoreCursor* pSC = static_cast<ScoreCursor*>( cursor.get_inner_cursor() );
@@ -3490,8 +3497,8 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 q v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 q v1 p1)" );
 //        cout << pTable->dump();
 //        cout << doc.to_string() << endl;
     }
@@ -3518,7 +3525,7 @@ SUITE(DocCommandTest)
 
         CHECK( *cursor != NULL );
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n c4 q v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n c4 q v1 p1)" );
         //cout << "cursor: " << (*cursor)->to_string() << endl;
 
         ScoreCursor* pSC = static_cast<ScoreCursor*>( cursor.get_inner_cursor() );
@@ -3533,9 +3540,9 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v2  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     1, "(n c4 q v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v2 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     1, "(n c4 q v1 p1)" );
 //        cout << pTable->dump();
 //        cout << doc.to_string() << endl;
     }
@@ -3556,7 +3563,7 @@ SUITE(DocCommandTest)
         MySelectionSet sel(&doc);
         executer.execute(&cursor, pCmd, &sel);
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n c4 q v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n c4 q v1 p1)" );
 
         ColStaffObjs* pTable = pScore->get_staffobjs_table();
         CHECK( pTable->num_lines() == 2 );
@@ -3565,19 +3572,19 @@ SUITE(DocCommandTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v2  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     1, "(n c4 q v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v2 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     1, "(n c4 q v1 p1)" );
         //Fcout << pTable->dump();
 
         executer.undo(&cursor, &sel);    //remove note e4. Cursor points to note c4
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n c4 q v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n c4 q v1 p1)" );
         CHECK( pScore->get_staffobjs_table()->num_entries() == 2 );
 
         executer.redo(&cursor, &sel);    //add note e4. Cursor points to note c4
         CHECK( (*cursor)->is_note() == true );
-        CHECK( (*cursor)->to_string() == "(n c4 q v1  p1 )" );
+        CHECK( (*cursor)->to_string() == "(n c4 q v1 p1)" );
         CHECK( pScore->get_staffobjs_table()->num_entries() == 3 );
         //cout << "cursor: " << (*cursor)->to_string() << endl;
     }

--- a/src/tests/lomse_test_document.cpp
+++ b/src/tests/lomse_test_document.cpp
@@ -352,7 +352,7 @@ SUITE(DocumentTest)
         doc.from_file(m_scores_path + "00011-empty-fill-page.lms");
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
         CHECK( pScore != NULL );
-//        CHECK( pScore.to_string() == "(score (vers 1.6) (systemLayout first (systemMargins 0 0 0 2000)) (systemLayout other (systemMargins 0 0 1200 2000)) (opt Score.FillPageWithEmptyStaves true) (opt StaffLines.Truncate 1) (instrument (musicData )))" );
+//        CHECK( pScore.to_string() == "(score (vers 1.6) (systemLayout first (systemMargins 0 0 0 2000)) (systemLayout other (systemMargins 0 0 1200 2000)) (opt Score.FillPageWithEmptyStaves true) (opt StaffLines.Truncate 1) (instrument (musicData)))" );
     }
 
     TEST_FIXTURE(DocumentTestFixture, get_score_102)

--- a/src/tests/lomse_test_document_layouter.cpp
+++ b/src/tests/lomse_test_document_layouter.cpp
@@ -299,7 +299,7 @@ SUITE(DocLayouterTest)
         Document doc(m_libraryScope);
         doc.from_string("(lenmusdoc (vers 0.0) "
             "(content (score (vers 1.6) "
-            "(instrument (musicData )))))" );
+            "(instrument (musicData)))))" );
         DocLayouter dl( doc.get_im_model(), m_libraryScope);
         dl.layout_document();
         GraphicModel* pGModel = dl.get_graphic_model();
@@ -367,7 +367,7 @@ SUITE(DocLayouterTest)
         Document doc(m_libraryScope);
         doc.from_string("(lenmusdoc (vers 0.0) "
             "(content (score (vers 1.6) "
-            "(instrument (musicData )) )))" );
+            "(instrument (musicData)) )))" );
         DocLayouter dl( doc.get_im_model(), m_libraryScope);
         dl.layout_document();
         GraphicModel* pGModel = dl.get_graphic_model();
@@ -395,7 +395,7 @@ SUITE(DocLayouterTest)
         Document doc(m_libraryScope);
         doc.from_string("(lenmusdoc (vers 0.0) "
             "(content (score (vers 1.6) "
-            "(instrument (staves 2)(musicData )))))" );
+            "(instrument (staves 2)(musicData)))))" );
         DocLayouter dl( doc.get_im_model(), m_libraryScope);
         dl.layout_document();
         GraphicModel* pGModel = dl.get_graphic_model();
@@ -427,7 +427,7 @@ SUITE(DocLayouterTest)
     {
         Document doc(m_libraryScope);
         doc.from_string("(lenmusdoc (vers 0.0) (content (score (vers 1.6) "
-            "(instrument (musicData )) (instrument (musicData )) )))" );
+            "(instrument (musicData)) (instrument (musicData)) )))" );
         DocLayouter dl( doc.get_im_model(), m_libraryScope);
         dl.layout_document();
         GraphicModel* pGModel = dl.get_graphic_model();

--- a/src/tests/lomse_test_graphic_model.cpp
+++ b/src/tests/lomse_test_graphic_model.cpp
@@ -174,7 +174,7 @@ SUITE(GraphicModelTest)
         SpDocument spDoc( new Document(libraryScope) );
         spDoc->from_string("(lenmusdoc (vers 0.0) "
             "(content (score (vers 1.6) "
-            "(instrument (staves 2)(musicData )))))" );
+            "(instrument (staves 2)(musicData)))))" );
         VerticalBookView* pView = dynamic_cast<VerticalBookView*>(
             Injector::inject_View(libraryScope, ViewFactory::k_view_vertical_book, spDoc.get()) );
         Interactor* pIntor = Injector::inject_Interactor(libraryScope, WpDocument(spDoc), pView, NULL);
@@ -282,7 +282,7 @@ SUITE(GraphicModelTest)
         //    "(instrument (musicData (clef G)(key e)(n c4 q)(r q)(barline simple))))))" );
         spDoc->from_string("(lenmusdoc (vers 0.0) "
             "(content (score (vers 1.6) "
-            "(instrument (staves 2)(musicData )))))" );
+            "(instrument (staves 2)(musicData)))))" );
         VerticalBookView* pView = dynamic_cast<VerticalBookView*>(
             Injector::inject_View(libraryScope, ViewFactory::k_view_vertical_book, spDoc.get()) );
         Interactor* pIntor = Injector::inject_Interactor(libraryScope, WpDocument(spDoc), pView, NULL);
@@ -317,7 +317,7 @@ SUITE(GraphicModelTest)
         SpDocument spDoc( new Document(libraryScope) );
         spDoc->from_string("(lenmusdoc (vers 0.0) "
             "(content (score (vers 1.6) "
-            "(instrument (staves 2)(musicData )))))" );
+            "(instrument (staves 2)(musicData)))))" );
         VerticalBookView* pView = dynamic_cast<VerticalBookView*>(
             Injector::inject_View(libraryScope, ViewFactory::k_view_vertical_book, spDoc.get()) );
         Interactor* pIntor = Injector::inject_Interactor(libraryScope, WpDocument(spDoc), pView, NULL);

--- a/src/tests/lomse_test_ldp_analyser.cpp
+++ b/src/tests/lomse_test_ldp_analyser.cpp
@@ -5823,8 +5823,8 @@ SUITE(LdpAnalyserTest)
         //expected << "Line 0. No 'end' element for beam number 14. Beam ignored." << endl;
         string src =
             "(score (vers 1.7) (instrument (musicData "
-            "(clef F4 p1 )(n e3 e v1 p1 (beam 37 +)(t + 3 2))"
-            "(goBack start)(n c2 w v1  p1 )(goBack 234.667)"
+            "(clef F4 p1)(n e3 e v1 p1 (beam 37 +)(t + 3 2))"
+            "(goBack start)(n c2 w v1 p1)(goBack 234.667)"
             "(n g3 e v1 p1 (beam 37 =))(n c4 e v1 p1 (beam 37 -)(t -)) )))";
         parser.parse_text(src);
         LdpTree* tree = parser.get_ldp_tree();
@@ -6257,7 +6257,7 @@ SUITE(LdpAnalyserTest)
         //expected << "Line 0. No 'end' element for beam number 14. Beam ignored." << endl;
         string src =
             "(score (vers 1.6) (instrument (musicData "
-            "(clef F4 p1 )(n e3 e v1 p1 (beam 37 +)(t + 3 2))"
+            "(clef F4 p1)(n e3 e v1 p1 (beam 37 +)(t + 3 2))"
             "(n g3 e v1 p1 (beam 37 =))(n c4 e v1 p1 (beam 37 -)(t -)) )))";
         parser.parse_text(src);
         LdpTree* tree = parser.get_ldp_tree();
@@ -6305,7 +6305,7 @@ SUITE(LdpAnalyserTest)
         //expected << "Line 0. No 'end' element for beam number 14. Beam ignored." << endl;
         string src =
             "(score (vers 1.7) (instrument (musicData "
-            "(clef F4 p1 )(n e3 e v1 p1 (beam 37 +)(t + 3 2))"
+            "(clef F4 p1)(n e3 e v1 p1 (beam 37 +)(t + 3 2))"
             "(n g3 e v1 p1 (beam 37 =))(n c4 e v1 p1 (beam 37 -)(t -)) )))";
         parser.parse_text(src);
         LdpTree* tree = parser.get_ldp_tree();
@@ -9186,7 +9186,7 @@ SUITE(LdpAnalyserTest)
         //expected << "" << endl;
         parser.parse_text("(instrument (staves 2)(staff 2 (staffType ossia)"
             "(staffLines 4)(staffSpacing 200.0)(staffDistance 800)(lineThickness 20.5))"
-            "(musicData ))");
+            "(musicData))");
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         InternalModel* pIModel = a.analyse_tree(tree, "string:");

--- a/src/tests/lomse_test_ldp_analyser.cpp
+++ b/src/tests/lomse_test_ldp_analyser.cpp
@@ -94,6 +94,11 @@ public:
         }
     }
 
+    inline const char* test_name()
+    {
+        return UnitTest::CurrentTest::Details()->testName;
+    }
+
 };
 
 
@@ -3949,6 +3954,40 @@ SUITE(LdpAnalyserTest)
         delete pIModel;
     }
 
+    //@ metronome -----------------------------------------------------------------------
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, metronome_0)
+    {
+        //@00. metronome, note value
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+        stringstream expected;
+        //expected << "" << endl;
+        parser.parse_text("(score (vers 2.0) (instrument#100"
+                "(musicData (metronome q 55) )))");
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pIModel->get_root() );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMusic = pInstr->get_musicdata();
+        CHECK( pMusic != NULL );
+        ImoObj::children_iterator it = pMusic->begin();
+
+        ImoMetronomeMark* pImo = static_cast<ImoMetronomeMark*>(*it);
+        CHECK( pImo->get_ticks_per_minute() == 55 );
+        CHECK( pImo->get_mark_type() == ImoMetronomeMark::k_note_value );
+
+        delete tree->get_root();
+        delete pIModel;
+    }
+
     //@ time signature -------------------------------------------------------------------
 
     TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_TimeSignature)
@@ -4136,6 +4175,31 @@ SUITE(LdpAnalyserTest)
         CHECK( pTimeSignature->get_top_number() == 2 );
         CHECK( pTimeSignature->get_bottom_number() == 4 );
         CHECK( pTimeSignature->is_normal() );
+
+        delete tree->get_root();
+        delete pIModel;
+    }
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, timeSignature_10)
+    {
+        //@10. time signature. single number
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+        stringstream expected;
+        //expected << "" << endl;
+        parser.parse_text("(time single-number 10)");
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+        //cout << "[" << errormsg.str() << "]" << endl;
+        //cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pIModel->get_root()->is_time_signature() == true );
+        ImoTimeSignature* pTimeSignature = dynamic_cast<ImoTimeSignature*>( pIModel->get_root() );
+        CHECK( pTimeSignature != NULL );
+        CHECK( pTimeSignature->is_single_number() );
+        CHECK( pTimeSignature->get_top_number() == 10 );
 
         delete tree->get_root();
         delete pIModel;

--- a/src/tests/lomse_test_ldp_compiler.cpp
+++ b/src/tests/lomse_test_ldp_compiler.cpp
@@ -78,7 +78,7 @@ SUITE(LdpCompilerTest)
     {
         Document doc(m_libraryScope);
         LdpCompiler compiler(m_libraryScope, &doc);
-        InternalModel* pIModel = compiler.compile_string("(lenmusdoc (vers 0.0) (content (score (vers 1.6) (language en iso-8859-1) (opt Score.FillPageWithEmptyStaves true) (opt StaffLines.Truncate 1) (instrument (musicData )))))" );
+        InternalModel* pIModel = compiler.compile_string("(lenmusdoc (vers 0.0) (content (score (vers 1.6) (language en iso-8859-1) (opt Score.FillPageWithEmptyStaves true) (opt StaffLines.Truncate 1) (instrument (musicData)))))" );
         CHECK( compiler.get_file_locator() == "string:" );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>(pIModel->get_root());
         CHECK( pDoc->get_version() == "0.0" );

--- a/src/tests/lomse_test_ldp_exporter.cpp
+++ b/src/tests/lomse_test_ldp_exporter.cpp
@@ -128,7 +128,7 @@ SUITE(LdpExporterTest)
         LdpExporter exporter(&m_libraryScope);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pImo);
-        //cout << "\"" << source << "\"" << endl;
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
         CHECK( source == "(barline end)" );
     }
 
@@ -147,7 +147,7 @@ SUITE(LdpExporterTest)
         exporter.set_remove_newlines(true);
         exporter.set_add_id(true);
         string source = exporter.get_source(pImo);
-        //cout << "\"" << source << "\"" << endl;
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
         CHECK( source == "(barline#102 end)" );
     }
 
@@ -169,10 +169,10 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pMD);
-        //cout << "167: \"" << source << "\"" << endl;
+        //cout << test_name() << endl << "167: \"" << source << "\"" << endl;
         string expected =
-            "(musicData (clef G p1 )(n g5 s v1  p1 (beam 106 ++))"
-            "(n f5 s v1  p1 (beam 106 =-))(n g5 e v1  p1 (beam 106 -))(barline simple))";
+            "(musicData (clef G p1)(n g5 s v1 p1 (beam 106 ++))"
+            "(n f5 s v1 p1 (beam 106 =-))(n g5 e v1 p1 (beam 106 -))(barline simple))";
         CHECK( source == expected );
     }
 
@@ -192,10 +192,10 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pMD);
-        //cout << "190: \"" << source << "\"" << endl;
-        string expected = "(musicData (clef G p1 )"
-            "(chord (n e4 e. v1  (stem up) p1 (beam 111 +))(n g4 e. v1  p1 ))"
-            "(chord (n d4 s v1  (stem up) p1 (beam 111 -b))(n f4 s v1  p1 )))";
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        string expected = "(musicData (clef G p1)"
+            "(chord (n e4 e. v1 (stem up) p1 (beam 111 +))(n g4 e. v1 p1))"
+            "(chord (n d4 s v1 (stem up) p1 (beam 111 -b))(n f4 s v1 p1)))";
         CHECK( source == expected );
     }
 
@@ -216,11 +216,11 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pMD);
-        //cout << "214: \"" << source << "\"" << endl;
-        string expected = "(musicData (clef G p1 )"
-            "(n c4 q v1  p1 )(n e4 q v1  p1 )(goFwd 64 v2 p1)"
-            "(chord (n e4 e. v2  (stem up) p1 (beam 114 +))(n g4 e. v2  p1 ))"
-            "(chord (n d4 s v2  (stem up) p1 (beam 114 -b))(n f4 s v2  p1 )))";
+        //cout << test_name() << endl << "214: \"" << source << "\"" << endl;
+        string expected = "(musicData (clef G p1)"
+            "(n c4 q v1 p1)(n e4 q v1 p1)(goFwd 64 v2 p1)"
+            "(chord (n e4 e. v2 (stem up) p1 (beam 114 +))(n g4 e. v2 p1))"
+            "(chord (n d4 s v2 (stem up) p1 (beam 114 -b))(n f4 s v2 p1)))";
         CHECK( source == expected );
     }
 
@@ -240,10 +240,10 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pMD);
-        //cout << "238: \"" << source << "\"" << endl;
-        string expected = "(musicData (clef F4 p1 )"
-            "(n e3 e v1  p1 (beam 106 +))(n c2 w v3  p1 )(n g3 e v1  p1 (beam 106 =))"
-            "(n c4 e v1  p1 (beam 106 -))(barline simple))";
+        //cout << test_name() << endl << "238: \"" << source << "\"" << endl;
+        string expected = "(musicData (clef F4 p1)"
+            "(n e3 e v1 p1 (beam 106 +))(n c2 w v3 p1)(n g3 e v1 p1 (beam 106 =))"
+            "(n c4 e v1 p1 (beam 106 -))(barline simple))";
         CHECK( source == expected );
     }
 
@@ -259,8 +259,8 @@ SUITE(LdpExporterTest)
         LdpExporter exporter(&m_libraryScope);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pClef);
-//        cout << "\"" << source << "\"" << endl;
-        CHECK( source == "(clef F4 p1 )" );
+//        cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(clef F4 p1)" );
         delete pClef;
     }
 
@@ -275,8 +275,8 @@ SUITE(LdpExporterTest)
         exporter.set_remove_newlines(true);
         exporter.set_add_id(true);
         string source = exporter.get_source(pClef);
-//        cout << "\"" << source << "\"" << endl;
-        CHECK( source == "(clef#0 F4 p1 )" );
+//        cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(clef#0 F4 p1)" );
         delete pClef;
     }
 
@@ -301,13 +301,13 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pScore);
-        //cout << "\"" << source << "\"" << endl;
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
         string expected = "(score (vers 2.0)(instrument (staves 1)(musicData "
-            "(clef G p1 )(key C)"
-            "(n g4 q v1  p1 (dyn \"fff\" below))"
-            "(n g4 q v1  p1 (dyn \"ppp\"))"
-            "(n g4 q v1  p1 (dyn \"sfz\" above))"
-            "(n g4 q v1  p1 (dyn \"sfz\" above(color #ff0000ff) (dx 50) (dy -70)))"
+            "(clef G p1)(key C)"
+            "(n g4 q v1 p1 (dyn \"fff\" below))"
+            "(n g4 q v1 p1 (dyn \"ppp\"))"
+            "(n g4 q v1 p1 (dyn \"sfz\" above))"
+            "(n g4 q v1 p1 (dyn \"sfz\" above (color #ff0000ff)(dx 50)(dy -70)))"
             ")))";
         CHECK( source == expected );
     }
@@ -326,7 +326,7 @@ SUITE(LdpExporterTest)
     {
         //staves
         Document doc(m_libraryScope);
-        doc.from_string("(score (vers 1.6)(instrument (musicData )))" );
+        doc.from_string("(score (vers 1.6)(instrument (musicData)))" );
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
         ImoInstrument* pInstr = pScore->get_instrument(0);
 
@@ -334,8 +334,8 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pInstr);
-        //cout << "\"" << source << "\"" << endl;
-        CHECK( source == "(instrument (staves 1)(musicData ))" );
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(instrument (staves 1)(musicData))" );
     }
 
     TEST_FIXTURE(LdpExporterTestFixture, instrument_1)
@@ -345,7 +345,7 @@ SUITE(LdpExporterTest)
         doc.from_string("(score (vers 1.6)(instrument "
             "(staff 1 (staffType ossia)(staffLines 5)(staffSpacing 250.00)"
             "         (staffDistance 2000.00)(lineThickness 15.00))"
-            "(musicData )))" );
+            "(musicData)))" );
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
         ImoInstrument* pInstr = pScore->get_instrument(0);
 
@@ -353,10 +353,10 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pInstr);
-        //cout << "\"" << source << "\"" << endl;
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
         string expected = "(instrument (staves 1)(staff 1 (staffType ossia)"
             "(staffLines 5)(staffSpacing 250)(staffDistance 2000)"
-            "(lineThickness 15))(musicData ))";
+            "(lineThickness 15))(musicData))";
         CHECK( source == expected );
     }
 
@@ -364,7 +364,7 @@ SUITE(LdpExporterTest)
     {
         //midi data
         Document doc(m_libraryScope);
-        doc.from_string("(score (vers 1.6)(instrument (infoMIDI 9 12)(musicData )))" );
+        doc.from_string("(score (vers 1.6)(instrument (infoMIDI 9 12)(musicData)))" );
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
         ImoInstrument* pInstr = pScore->get_instrument(0);
 
@@ -372,15 +372,15 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pInstr);
-        //cout << "\"" << source << "\"" << endl;
-        CHECK( source == "(instrument (staves 1)(infoMIDI 9 12)(musicData ))" );
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(instrument (staves 1)(infoMIDI 9 12)(musicData))" );
     }
 
     TEST_FIXTURE(LdpExporterTestFixture, instrument_3)
     {
         //name, abbrev
         Document doc(m_libraryScope);
-        doc.from_string("(score (vers 1.6)(instrument (name \"Guitar\")(abbrev \"G.\")(musicData )))" );
+        doc.from_string("(score (vers 1.6)(instrument (name \"Guitar\")(abbrev \"G.\")(musicData)))" );
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
         ImoInstrument* pInstr = pScore->get_instrument(0);
 
@@ -388,8 +388,8 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pInstr);
-        //cout << "\"" << source << "\"" << endl;
-        CHECK( source == "(instrument (name \"Guitar\")(abbrev \"G.\")(staves 1)(musicData ))" );
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(instrument (name \"Guitar\")(abbrev \"G.\")(staves 1)(musicData))" );
     }
 
     TEST_FIXTURE(LdpExporterTestFixture, instrument_4)
@@ -400,7 +400,7 @@ SUITE(LdpExporterTest)
             "(defineStyle \"Best1\" (font \"Times New Roman\" 10pt bold) (color #000000))"
             "(defineStyle \"Best2\" (font \"Times New Roman\" 10pt bold) (color #000000))"
             "(instrument (name \"Guitar\" (style \"Best1\"))"
-            "(abbrev \"G.\" (style \"Best2\"))(musicData )))" );
+            "(abbrev \"G.\" (style \"Best2\"))(musicData)))" );
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
         ImoInstrument* pInstr = pScore->get_instrument(0);
 
@@ -408,9 +408,9 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pInstr);
-        //cout << "\"" << source << "\"" << endl;
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
         string expected = "(instrument (name \"Guitar\" (style \"Best1\"))"
-            "(abbrev \"G.\" (style \"Best2\"))(staves 1)(musicData ))";
+            "(abbrev \"G.\" (style \"Best2\"))(staves 1)(musicData))";
         CHECK( source == expected );
     }
 
@@ -424,7 +424,7 @@ SUITE(LdpExporterTest)
     {
         //empty musicData
         Document doc(m_libraryScope);
-        doc.from_string("(score (vers 1.6)(instrument (musicData )))" );
+        doc.from_string("(score (vers 1.6)(instrument (musicData)))" );
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
 //        dump_colection(pScore);
         ImoInstrument* pInstr = pScore->get_instrument(0);
@@ -434,8 +434,8 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pMD);
-//        cout << "\"" << source << "\"" << endl;
-        CHECK( source == "(musicData )" );
+//        cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(musicData)" );
     }
 
     TEST_FIXTURE(LdpExporterTestFixture, musicData_1)
@@ -454,8 +454,8 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pMD);
-        //cout << "\"" << source << "\"" << endl;
-        CHECK( source == "(musicData (clef G p1 )(r q v1  p1 )(barline simple)(n c4 q v1  p1 ))" );
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(musicData (clef G p1)(r q v1 p1)(barline simple)(n c4 q v1 p1))" );
     }
 
     TEST_FIXTURE(LdpExporterTestFixture, musicData_2)
@@ -475,8 +475,8 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pMD);
-        //cout << "\"" << source << "\"" << endl;
-        CHECK( source == "(musicData (clef C3 p1 )(n f4 e v1  p1 ))" );
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(musicData (clef C3 p1)(n f4 e v1 p1))" );
     }
 
     TEST_FIXTURE(LdpExporterTestFixture, musicData_3)
@@ -494,9 +494,9 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pMD);
-        //cout << "\"" << source << "\"" << endl;
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
         CHECK( source ==
-            "(musicData (clef G p1 )(n c4 q v1  p1 )(goFwd 32 v1 p1)(n a3 e v1  p1 ))" );
+            "(musicData (clef G p1)(n c4 q v1 p1)(goFwd 32 v1 p1)(n a3 e v1 p1))" );
     }
 
     TEST_FIXTURE(LdpExporterTestFixture, musicData_4)
@@ -516,11 +516,11 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pMD);
-        //cout << "\"" << source << "\"" << endl;
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
         string expected =
             "(musicData "
-            "(clef G p1 )(clef F4 p2 )(key C)(time 2 4)(n c4 e v1  p1 )"
-            "(n g2 e v3  p2 )(n c3 e v3  p2 )(n e3 e v3  p2 )(n g3 e v3  p2 )(barline simple))";
+            "(clef G p1)(clef F4 p2)(key C)(time 2 4)(n c4 e v1 p1)"
+            "(n g2 e v3 p2)(n c3 e v3 p2)(n e3 e v3 p2)(n g3 e v3 p2)(barline simple))";
         CHECK( source == expected );
     }
 
@@ -539,10 +539,10 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pMD);
-        //cout << "\"" << source << "\"" << endl;
-        string expected = "(musicData (clef G p1 )"
-            "(n c5 q v1  p1 )"
-            "(chord (n c4 e v1  p1 )(n e4 e v1  p1 )(n g4 e v1  p1 )))";
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        string expected = "(musicData (clef G p1)"
+            "(n c5 q v1 p1)"
+            "(chord (n c4 e v1 p1)(n e4 e v1 p1)(n g4 e v1 p1)))";
         CHECK( source == expected );
     }
 
@@ -562,10 +562,10 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pMD);
-        //cout << "\"" << source << "\"" << endl;
-        string expected = "(musicData (clef G p1 )"
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        string expected = "(musicData (clef G p1)"
             "(goFwd 64 v1 p1)"
-            "(chord (n c4 e v1  p1 )(n e4 e v1  p1 )(n g4 e v1  p1 )))";
+            "(chord (n c4 e v1 p1)(n e4 e v1 p1)(n g4 e v1 p1)))";
         CHECK( source == expected );
     }
 
@@ -593,13 +593,13 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pMD);
-        //cout << "558: \"" << source << "\"" << endl;
+        //cout << test_name() << endl << "558: \"" << source << "\"" << endl;
         string expected =
-            "(musicData (clef G p1 )(key G)(time 3 4)(chord (n g3 q v1  p1 )(n d4 q v1  p1 ))"
-            "(r e v1  p1 )(n g5 e v1  p1 )(n g5 s v1  p1 (beam 115 ++))(n f5 s v1  p1 (beam 115 =-))"
-            "(n g5 e v1  p1 (beam 115 -))(barline simple)"
-            "(chord (n a4 q v1  p1 )(n e5 q v1  p1 ))(r q v1  p1 )"
-            "(chord (n d4 q v1  p1 )(n g4 q v1  p1 )(n f5 q v1  p1 ))(barline simple))";
+            "(musicData (clef G p1)(key G)(time 3 4)(chord (n g3 q v1 p1)(n d4 q v1 p1))"
+            "(r e v1 p1)(n g5 e v1 p1)(n g5 s v1 p1 (beam 115 ++))(n f5 s v1 p1 (beam 115 =-))"
+            "(n g5 e v1 p1 (beam 115 -))(barline simple)"
+            "(chord (n a4 q v1 p1)(n e5 q v1 p1))(r q v1 p1)"
+            "(chord (n d4 q v1 p1)(n g4 q v1 p1)(n f5 q v1 p1))(barline simple))";
         CHECK( source == expected );
     }
 
@@ -619,9 +619,9 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pScore);
-        //cout << "\"" << source << "\"" << endl;
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
         string expected = "(score (vers 2.0)(instrument (staves 1)(musicData "
-            "(clef G p1 )(n c4 e v1 (tm 2 3) p1 (t + 3 2))(n e4 e v1 (tm 2 3) p1 )"
+            "(clef G p1)(n c4 e v1 (tm 2 3) p1 (t + 3 2))(n e4 e v1 (tm 2 3) p1)"
             "(n g4 e v1 (tm 2 3) p1 (t -))"
             ")))";
 
@@ -644,9 +644,9 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pScore);
-        //cout << "\"" << source << "\"" << endl;
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
         string expected = "(score (vers 2.0)(instrument (staves 1)(musicData "
-            "(clef G p1 )(n c4 e v1  p1 )(goFwd e v1 p1)(n e4 e v1  p1 ))))";
+            "(clef G p1)(n c4 e v1 p1)(goFwd e v1 p1)(n e4 e v1 p1))))";
 
         CHECK( source == expected );
     }
@@ -669,9 +669,9 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pScore);
-        //cout << "\"" << source << "\"" << endl;
-        string expected = "(score (vers 2.0) (style \"Score1\")"
-            "(instrument (staves 1)(musicData (clef G p1 ))))";
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        string expected = "(score (vers 2.0)(style \"Score1\")"
+            "(instrument (staves 1)(musicData (clef G p1))))";
 
         CHECK( source == expected );
     }
@@ -690,11 +690,11 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pScore);
-        //cout << "\"" << source << "\"" << endl;
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
         string expected = "(score (vers 2.0)"
             "(defineStyle \"Score1\" (font-name \"Arial\")(font-size 14pt)"
             "(font-style normal)(font-weight bold)(color #00fe0f7f))"
-            "(instrument (staves 1)(musicData (clef G p1 ))))";
+            "(instrument (staves 1)(musicData (clef G p1))))";
 
         CHECK( source == expected );
     }
@@ -713,11 +713,11 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pScore);
-        //cout << "\"" << source << "\"" << endl;
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
         string expected =
             "(score (vers 2.0)"
             "(opt Render.SpacingValue 40)(opt StaffLines.Truncate 0)"
-            "(instrument (staves 1)(musicData (clef G p1 ))))";
+            "(instrument (staves 1)(musicData (clef G p1))))";
 
         CHECK( source == expected );
     }
@@ -737,12 +737,39 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pScore);
-//        cout << "\"" << source << "\"" << endl;
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
         string expected =
             "(score (vers 2.0)"
             "(systemLayout first (systemMargins 0 0 1700 1200))"
             "(systemLayout other (systemMargins 0 0 1800 2000))"
-            "(instrument (staves 1)(musicData (clef G p1 ))))";
+            "(instrument (staves 1)(musicData (clef G p1))))";
+
+        CHECK( source == expected );
+    }
+
+    TEST_FIXTURE(LdpExporterTestFixture, score_4)
+    {
+        //systemLayout
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 1.6)"
+            "(systemLayout first (systemMargins 0 0 1500 1500))"
+            "(systemLayout other (systemMargins 0 0 1500 1000)) "
+            "(opt Score.FillPageWithEmptyStaves true)"
+            "(opt StaffLines.StopAtFinalBarline false) "
+            "(instrument (musicData)))" );
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
+
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_current_score(pScore);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pScore);
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        string expected =
+            "(score (vers 2.0)(systemLayout first (systemMargins 0 0 1500 1500))"
+            "(systemLayout other (systemMargins 0 0 1500 1000))"
+            "(opt Score.FillPageWithEmptyStaves true)"
+            "(opt StaffLines.Truncate 0)"
+            "(instrument (staves 1)(musicData)))";
 
         CHECK( source == expected );
     }
@@ -770,8 +797,8 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pMD);
-        //cout << "\"" << source << "\"" << endl;
-        string expected = "(musicData (clef G p1 )"
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        string expected = "(musicData (clef G p1)"
             "(spacer 0 p1 (text \"Largo\" (style \"Notations\")(dx -20)(dy -45))))";
 
         CHECK( source == expected );
@@ -795,11 +822,11 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pMD);
-        string expected = "(musicData (n c4 q v1  p1 (slur 1 start))"
-            "(n e4 q v1  p1 (slur 1 stop)))";
+        string expected = "(musicData (n c4 q v1 p1 (slur 1 start))"
+            "(n e4 q v1 p1 (slur 1 stop)))";
 
 //        cout << test_name() << endl;
-//        cout << "\"" << source << "\"" << endl;
+//        cout << test_name() << endl << "\"" << source << "\"" << endl;
 
         CHECK( source == expected );
     }
@@ -808,8 +835,33 @@ SUITE(LdpExporterTest)
     // StaffObjLdpGenerator -------------------------------------------------------------
 
     // SystemBreakLdpGenerator ----------------------------------------------------------
-    // SpacerLdpGenerator
-    // TieLdpGenerator
+    // SpacerLdpGenerator ---------------------------------------------------------------
+    // TieLdpGenerator ------------------------------------------------------------------
+
+    TEST_FIXTURE(LdpExporterTestFixture, tie_01)
+    {
+        //@ 01
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0)"
+            "(instrument (musicData (n c4 q (tie 1 start))"
+            "(n c4 q (tie 1 stop)) )))"
+            );
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_current_score(pScore);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pMD);
+        string expected = "(musicData (n c4 q v1 p1 (tie 1 start))"
+            "(n c4 q v1 p1 (tie 1 stop)))";
+
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+
+        CHECK( source == expected );
+    }
+
     // TimeSignatureLdpGenerator
     // TupletLdpGenerator
 
@@ -823,7 +875,7 @@ SUITE(LdpExporterTest)
 //        pImoDoc->set_version("2.3");
 //        LdpExporter exporter(&m_libraryScope);
 //        string source = exporter.get_source(pImoDoc);
-////        cout << source << endl;
+////        cout << test_name() << endl << source << endl;
 //        CHECK( source ==
 //            "(lenmusdoc (vers 2.3)\n"
 //            "   //LDP file generated by Lomse, version \n"
@@ -839,7 +891,7 @@ SUITE(LdpExporterTest)
 //        ImoTie* pTie = static_cast<ImoTie*>(ImFactory::inject(k_imo_tie, &doc));
 //        LdpExporter exporter(&m_libraryScope);
 //        string source = exporter.get_source(pTie);
-////        cout << source << endl;
+////        cout << test_name() << endl << source << endl;
 //        CHECK( source == "(TODO: tie   type=76, id=0 )\n" );
 //        delete pTie;
 //    }
@@ -856,7 +908,7 @@ SUITE(LdpExporterTest)
 //        ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
 //        LdpExporter exporter(&m_libraryScope);
 //        string source = exporter.get_source(pScore);
-//        cout << "\"" << source << "\"" << endl;
+//        cout << test_name() << endl << "\"" << source << "\"" << endl;
 //        CHECK( source ==
 //              "(score (vers 1.6)\n"
 //              "   (instrument \n"
@@ -877,7 +929,7 @@ SUITE(LdpExporterTest)
 //                            k_eighth, k_no_accidentals);
 //        LdpExporter exporter(&m_libraryScope);
 //        string source = exporter.get_source(pImo);
-//        //cout << "\"" << source << "\"" << endl;
+//        //cout << test_name() << endl << "\"" << source << "\"" << endl;
 //        CHECK( source == "(n d4 e p1)" );
 //        delete pImo;
 //    }
@@ -889,7 +941,7 @@ SUITE(LdpExporterTest)
 //                            k_whole, k_sharp, 2);
 //        LdpExporter exporter(&m_libraryScope);
 //        string source = exporter.get_source(pImo);
-//        //cout << "\"" << source << "\"" << endl;
+//        //cout << test_name() << endl << "\"" << source << "\"" << endl;
 //        CHECK( source == "(n +b7 w.. p1)" );
 //        delete pImo;
 //    }
@@ -905,7 +957,7 @@ SUITE(LdpExporterTest)
 //        pImo->set_color( Color(127, 40, 12, 128) );
 //        LdpExporter exporter(&m_libraryScope);
 //        string source = exporter.get_source(pImo);
-////        cout << "\"" << source << "\"" << endl;
+////        cout << test_name() << endl << "\"" << source << "\"" << endl;
 //        CHECK( source == "(clef F4 p1 (color #7f280c80))" );
 //        delete pImo;
 //    }
@@ -920,7 +972,7 @@ SUITE(LdpExporterTest)
 ////        obj.set_user_location_y(-7.05f);
 ////        LdpExporter exporter(&m_libraryScope);
 ////        string source = exporter.get_source(&obj);
-////        cout << "\"" << source << "\"" << endl;
+////        cout << test_name() << endl << "\"" << source << "\"" << endl;
 ////        CHECK( source == "(clef G3 p1 (dx 30.0000) (dy -7.0500))" );
 ////    }
 
@@ -941,9 +993,9 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pMD);
-        //cout << "\"" << source << "\"" << endl;
-        string expected = "(musicData (clef G p1 )"
-            "(key C)(time common)(n c4 q v1  p1 ))";
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        string expected = "(musicData (clef G p1)"
+            "(key C)(time common)(n c4 q v1 p1))";
 
         CHECK( source == expected );
     }

--- a/src/tests/lomse_test_ldp_exporter.cpp
+++ b/src/tests/lomse_test_ldp_exporter.cpp
@@ -112,11 +112,11 @@ SUITE(LdpExporterTest)
 //        cout << "----------------------------------------------------" << endl;
 //    }
 
-    // BarlineLdpGenerator --------------------------------------------------------------
+    //@ barline -------------------------------------------------------------------------
 
-    TEST_FIXTURE(LdpExporterTestFixture, barline)
+    TEST_FIXTURE(LdpExporterTestFixture, barline_0)
     {
-        //@ barline, type
+        //@00. barline, type
 
         Document doc(m_libraryScope);
         doc.from_string("(score (vers 1.6) (instrument (musicData (barline end))))");
@@ -132,12 +132,12 @@ SUITE(LdpExporterTest)
         CHECK( source == "(barline end)" );
     }
 
-    TEST_FIXTURE(LdpExporterTestFixture, barline_id)
+    TEST_FIXTURE(LdpExporterTestFixture, barline_1)
     {
-        //@ barline, type, id
+        //@01. barline id
 
         Document doc(m_libraryScope);
-        doc.from_string("(score (vers 1.6) (instrument#100 (musicData (barline end))))");
+        doc.from_string("(score (vers 1.6) (instrument#100 (musicData (barline#105 end))))");
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         ImoMusicData* pMD = pInstr->get_musicdata();
@@ -148,7 +148,57 @@ SUITE(LdpExporterTest)
         exporter.set_add_id(true);
         string source = exporter.get_source(pImo);
         //cout << test_name() << endl << "\"" << source << "\"" << endl;
-        CHECK( source == "(barline#102 end)" );
+        CHECK( source == "(barline#105 end)" );
+    }
+
+    TEST_FIXTURE(LdpExporterTestFixture, barline_2)
+    {
+        //@02. barline. middle
+
+        Document doc(m_libraryScope);
+        ImoBarline* pImo = static_cast<ImoBarline*>(ImFactory::inject(k_imo_barline, &doc));
+        pImo->set_type(k_barline_double);
+        pImo->set_middle(true);
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pImo);
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(barline double middle)" );
+        delete pImo;
+    }
+
+    TEST_FIXTURE(LdpExporterTestFixture, barline_3)
+    {
+        //@03. barline. no visible
+
+        Document doc(m_libraryScope);
+        ImoBarline* pImo = static_cast<ImoBarline*>(ImFactory::inject(k_imo_barline, &doc));
+        pImo->set_type(k_barline_start_repetition);
+        pImo->set_visible(false);
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pImo);
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(barline startRepetition (visible no))" );
+        delete pImo;
+    }
+
+    TEST_FIXTURE(LdpExporterTestFixture, barline_4)
+    {
+        //@04. barline. Attachments
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument#100"
+                "(musicData (barline end (text \"Hello\")) )))");
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+        ImoBarline* pImo = static_cast<ImoBarline*>(
+                                        pMD->get_child_of_type(k_imo_barline) );
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pImo);
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(barline end (text \"Hello\"))" );
     }
 
     // BeamLdpGenerator -----------------------------------------------------------------
@@ -194,8 +244,8 @@ SUITE(LdpExporterTest)
         string source = exporter.get_source(pMD);
         //cout << test_name() << endl << "\"" << source << "\"" << endl;
         string expected = "(musicData (clef G p1)"
-            "(chord (n e4 e. v1 (stem up) p1 (beam 111 +))(n g4 e. v1 p1))"
-            "(chord (n d4 s v1 (stem up) p1 (beam 111 -b))(n f4 s v1 p1)))";
+            "(chord (n e4 e. v1 p1 (stem up)(beam 111 +))(n g4 e. v1 p1))"
+            "(chord (n d4 s v1 p1 (stem up)(beam 111 -b))(n f4 s v1 p1)))";
         CHECK( source == expected );
     }
 
@@ -216,11 +266,11 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pMD);
-        //cout << test_name() << endl << "214: \"" << source << "\"" << endl;
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
         string expected = "(musicData (clef G p1)"
             "(n c4 q v1 p1)(n e4 q v1 p1)(goFwd 64 v2 p1)"
-            "(chord (n e4 e. v2 (stem up) p1 (beam 114 +))(n g4 e. v2 p1))"
-            "(chord (n d4 s v2 (stem up) p1 (beam 114 -b))(n f4 s v2 p1)))";
+            "(chord (n e4 e. v2 p1 (stem up)(beam 114 +))(n g4 e. v2 p1))"
+            "(chord (n d4 s v2 p1 (stem up)(beam 114 -b))(n f4 s v2 p1)))";
         CHECK( source == expected );
     }
 
@@ -247,9 +297,9 @@ SUITE(LdpExporterTest)
         CHECK( source == expected );
     }
 
-    // ClefLdpGenerator -----------------------------------------------------------------
+    //@ clef ----------------------------------------------------------------------------
 
-    TEST_FIXTURE(LdpExporterTestFixture, clef)
+    TEST_FIXTURE(LdpExporterTestFixture, clef_0)
     {
         //@ clef, type and base staffobj
 
@@ -264,19 +314,35 @@ SUITE(LdpExporterTest)
         delete pClef;
     }
 
-    TEST_FIXTURE(LdpExporterTestFixture, clef_id)
+    TEST_FIXTURE(LdpExporterTestFixture, clef_1)
     {
         //@ clef & id, type and base staffobj
 
         Document doc(m_libraryScope);
-        ImoClef* pClef = static_cast<ImoClef*>(ImFactory::inject(k_imo_clef, &doc));
+        ImoClef* pClef = static_cast<ImoClef*>(ImFactory::inject(k_imo_clef, &doc, 27L));
         pClef->set_clef_type(k_clef_F4);
         LdpExporter exporter(&m_libraryScope);
         exporter.set_remove_newlines(true);
         exporter.set_add_id(true);
         string source = exporter.get_source(pClef);
 //        cout << test_name() << endl << "\"" << source << "\"" << endl;
-        CHECK( source == "(clef#0 F4 p1)" );
+        CHECK( source == "(clef#27 F4 p1)" );
+        delete pClef;
+    }
+
+    TEST_FIXTURE(LdpExporterTestFixture, clef_2)
+    {
+        //@ clef. symbolSize
+
+        Document doc(m_libraryScope);
+        ImoClef* pClef = static_cast<ImoClef*>(ImFactory::inject(k_imo_clef, &doc));
+        pClef->set_clef_type(k_clef_F4);
+        pClef->set_symbol_size(k_size_cue);
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pClef);
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(clef F4 (symbolSize cue) p1)" );
         delete pClef;
     }
 
@@ -414,9 +480,170 @@ SUITE(LdpExporterTest)
         CHECK( source == expected );
     }
 
-    // KeySignatureLdpGenerator ---------------------------------------------------------
+    //@ key -----------------------------------------------------------------------------
+
+    TEST_FIXTURE(LdpExporterTestFixture, key_0)
+    {
+        //@00 key, type
+
+        Document doc(m_libraryScope);
+        ImoKeySignature* pImo = static_cast<ImoKeySignature*>(
+                                        ImFactory::inject(k_imo_key_signature, &doc));
+        pImo->set_key_type(k_key_A);
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pImo);
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(key A)" );
+        delete pImo;
+    }
+
+    TEST_FIXTURE(LdpExporterTestFixture, key_1)
+    {
+        //@01 key id
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument#100 (musicData (key#123 A))))");
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+        ImoKeySignature* pImo = static_cast<ImoKeySignature*>(
+                                        pMD->get_child_of_type(k_imo_key_signature) );
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_remove_newlines(true);
+        exporter.set_add_id(true);
+        string source = exporter.get_source(pImo);
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(key#123 A)" );
+    }
+
+    TEST_FIXTURE(LdpExporterTestFixture, key_2)
+    {
+        //@02 key. Attachments
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument#100"
+                "(musicData (key A (text \"Hello\")) )))");
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+        ImoKeySignature* pImo = static_cast<ImoKeySignature*>(
+                                        pMD->get_child_of_type(k_imo_key_signature) );
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pImo);
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(key A (text \"Hello\"))" );
+    }
+
     // LenmusdocLdpGenerator
-    // MetronomeLdpGenerator
+
+    //@ Lyric ---------------------------------------------------------------------------
+
+    TEST_FIXTURE(LdpExporterTestFixture, lyric_0)
+    {
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0)"
+            "(instrument (musicData (clef G)"
+            "(n c4 q (lyric 1 \"This\")(lyric 2 \"A\"))"
+            "(n d4 q (lyric 1 \"is\")(lyric 2 \"se\" -))"
+            "(n e4 q (lyric 1 \"line\")(lyric 2 \"cond\"))"
+            "(n f4 q (lyric 1 \"one.\")(lyric 2 \"line.\"))"
+            "(barline))))" );
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
+//        dump_colection(pScore);
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_current_score(pScore);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pMD);
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(musicData (clef G p1)"
+            "(n c4 q v1 p1 (lyric 1 \"This\" below)(lyric 2 \"A\" below))"
+            "(n d4 q v1 p1 (lyric 1 \"is\" below)(lyric 2 \"se\" - below))"
+            "(n e4 q v1 p1 (lyric 1 \"line\" below)(lyric 2 \"cond\" below))"
+            "(n f4 q v1 p1 (lyric 1 \"one.\" below)(lyric 2 \"line.\" below))"
+            "(barline simple))" );
+    }
+
+    //@ metronome -----------------------------------------------------------------------
+
+    TEST_FIXTURE(LdpExporterTestFixture, metronome_0)
+    {
+        //@00. metronome: note-value
+
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument#100"
+                "(musicData (metronome q 55) )))");
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+        ImoMetronomeMark* pImo = static_cast<ImoMetronomeMark*>(
+                                        pMD->get_child_of_type(k_imo_metronome_mark) );
+
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pImo);
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(metronome q 55 p1)" );
+    }
+
+    TEST_FIXTURE(LdpExporterTestFixture, metronome_1)
+    {
+        //@01. metronome: id, note-note
+
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument#100"
+                "(musicData (metronome#123 q q.) )))");
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+        ImoMetronomeMark* pImo = static_cast<ImoMetronomeMark*>(
+                                        pMD->get_child_of_type(k_imo_metronome_mark) );
+
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_remove_newlines(true);
+        exporter.set_add_id(true);
+        string source = exporter.get_source(pImo);
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(metronome#123 q q. p1)" );
+    }
+
+    TEST_FIXTURE(LdpExporterTestFixture, metronome_2)
+    {
+        //@02. metronome: value, no visible
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument#100"
+                "(musicData (metronome 77 noVisible) )))");
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+        ImoMetronomeMark* pImo = static_cast<ImoMetronomeMark*>(
+                                        pMD->get_child_of_type(k_imo_metronome_mark) );
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pImo);
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(metronome 77 p1 (visible no))" );
+    }
+
+    TEST_FIXTURE(LdpExporterTestFixture, metronome_3)
+    {
+        //@03. metronome. parenthesis
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument#100"
+                "(musicData (metronome q 80 parenthesis) )))");
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+        ImoMetronomeMark* pImo = static_cast<ImoMetronomeMark*>(
+                                        pMD->get_child_of_type(k_imo_metronome_mark) );
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pImo);
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(metronome q 80 parenthesis p1)" );
+    }
 
     // MusicDataLdpGenerator ------------------------------------------------------------
 
@@ -593,7 +820,7 @@ SUITE(LdpExporterTest)
         exporter.set_current_score(pScore);
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pMD);
-        //cout << test_name() << endl << "558: \"" << source << "\"" << endl;
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
         string expected =
             "(musicData (clef G p1)(key G)(time 3 4)(chord (n g3 q v1 p1)(n d4 q v1 p1))"
             "(r e v1 p1)(n g5 e v1 p1)(n g5 s v1 p1 (beam 115 ++))(n f5 s v1 p1 (beam 115 =-))"
@@ -621,8 +848,8 @@ SUITE(LdpExporterTest)
         string source = exporter.get_source(pScore);
         //cout << test_name() << endl << "\"" << source << "\"" << endl;
         string expected = "(score (vers 2.0)(instrument (staves 1)(musicData "
-            "(clef G p1)(n c4 e v1 (tm 2 3) p1 (t + 3 2))(n e4 e v1 (tm 2 3) p1)"
-            "(n g4 e v1 (tm 2 3) p1 (t -))"
+            "(clef G p1)(n c4 e v1 p1 (tm 2 3)(t + 3 2))(n e4 e v1 p1 (tm 2 3))"
+            "(n g4 e v1 p1 (tm 2 3)(t -))"
             ")))";
 
         CHECK( source == expected );
@@ -831,11 +1058,66 @@ SUITE(LdpExporterTest)
         CHECK( source == expected );
     }
 
+    //@ spacer --------------------------------------------------------------------------
+
+    TEST_FIXTURE(LdpExporterTestFixture, spacer_0)
+    {
+        //@00. spacer, type
+
+        Document doc(m_libraryScope);
+        ImoSpacer* pImo = static_cast<ImoSpacer*>(
+                            ImFactory::inject(k_imo_spacer, &doc));
+        pImo->set_width(53.2f);
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pImo);
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(spacer 53.2 p1)" );
+        delete pImo;
+    }
+
+    TEST_FIXTURE(LdpExporterTestFixture, spacer_1)
+    {
+        //@01. spacer id
+
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument#100"
+                "(musicData (spacer#123 50) )))");
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+        ImoSpacer* pImo = static_cast<ImoSpacer*>(
+                                        pMD->get_child_of_type(k_imo_spacer) );
+
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_remove_newlines(true);
+        exporter.set_add_id(true);
+        string source = exporter.get_source(pImo);
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(spacer#123 50 p1)" );
+    }
+
+    TEST_FIXTURE(LdpExporterTestFixture, spacer_2)
+    {
+        //@02. spacer. Attachments
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument#100"
+                "(musicData (spacer 50 (text \"Hello\")) )))");
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+        ImoSpacer* pImo = static_cast<ImoSpacer*>(
+                                        pMD->get_child_of_type(k_imo_spacer) );
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pImo);
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(spacer 50 p1 (text \"Hello\"))" );
+    }
 
     // StaffObjLdpGenerator -------------------------------------------------------------
 
     // SystemBreakLdpGenerator ----------------------------------------------------------
-    // SpacerLdpGenerator ---------------------------------------------------------------
     // TieLdpGenerator ------------------------------------------------------------------
 
     TEST_FIXTURE(LdpExporterTestFixture, tie_01)
@@ -862,40 +1144,66 @@ SUITE(LdpExporterTest)
         CHECK( source == expected );
     }
 
-    // TimeSignatureLdpGenerator
+    //@ time signature ------------------------------------------------------------------
+
+    TEST_FIXTURE(LdpExporterTestFixture, time_signature_0)
+    {
+        //@00. time, type
+
+        Document doc(m_libraryScope);
+        ImoTimeSignature* pImo = static_cast<ImoTimeSignature*>(
+                            ImFactory::inject(k_imo_time_signature, &doc));
+        pImo->set_type(ImoTimeSignature::k_single_number);
+        pImo->set_top_number(10);
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pImo);
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(time single-number 10)" );
+        delete pImo;
+    }
+
+    TEST_FIXTURE(LdpExporterTestFixture, time_signature_1)
+    {
+        //@01. time id
+
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument#100"
+                "(musicData (time#123 5 4) )))");
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+        ImoTimeSignature* pImo = static_cast<ImoTimeSignature*>(
+                                        pMD->get_child_of_type(k_imo_time_signature) );
+
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_remove_newlines(true);
+        exporter.set_add_id(true);
+        string source = exporter.get_source(pImo);
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(time#123 5 4)" );
+    }
+
+    TEST_FIXTURE(LdpExporterTestFixture, time_signature_2)
+    {
+        //@02. time. Attachments
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument#100"
+                "(musicData (time common (text \"Hello\")) )))");
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+        ImoTimeSignature* pImo = static_cast<ImoTimeSignature*>(
+                                        pMD->get_child_of_type(k_imo_time_signature) );
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pImo);
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        CHECK( source == "(time common (text \"Hello\"))" );
+    }
+
     // TupletLdpGenerator
 
-//    // lenmusdoc ----------------------------------------------------------------------------------
-//
-//    TEST_FIXTURE(LdpExporterTestFixture, lenmusdoc_empty)
-//    {
-//        Document doc(m_libraryScope);
-//        ImoDocument* pImoDoc = static_cast<ImoDocument*>(
-//                                        ImFactory::inject(k_imo_document, &doc));
-//        pImoDoc->set_version("2.3");
-//        LdpExporter exporter(&m_libraryScope);
-//        string source = exporter.get_source(pImoDoc);
-////        cout << test_name() << endl << source << endl;
-//        CHECK( source ==
-//            "(lenmusdoc (vers 2.3)\n"
-//            "   //LDP file generated by Lomse, version \n"
-//            "   (content\n"
-//            "))\n"
-//        );
-//        delete pImoDoc;
-//    }
-//
-//    TEST_FIXTURE(LdpExporterTestFixture, ErrorNotImplemented)
-//    {
-//        Document doc(m_libraryScope);
-//        ImoTie* pTie = static_cast<ImoTie*>(ImFactory::inject(k_imo_tie, &doc));
-//        LdpExporter exporter(&m_libraryScope);
-//        string source = exporter.get_source(pTie);
-////        cout << test_name() << endl << source << endl;
-//        CHECK( source == "(TODO: tie   type=76, id=0 )\n" );
-//        delete pTie;
-//    }
-//
 //    // score ----------------------------------------------------------------------------
 //
 //    TEST_FIXTURE(LdpExporterTestFixture, score)
@@ -976,15 +1284,20 @@ SUITE(LdpExporterTest)
 ////        CHECK( source == "(clef G3 p1 (dx 30.0000) (dy -7.0500))" );
 ////    }
 
-    // TimeSignatureLdpGenerator ------------------------------------------------------------
 
-    TEST_FIXTURE(LdpExporterTestFixture, time_signature_0)
+    //@ tuplet --------------------------------------------------------------------------
+
+    TEST_FIXTURE(LdpExporterTestFixture, tuplet_0)
     {
-        //text
+        //tuplet v1.6: tm implicit
         Document doc(m_libraryScope);
-        doc.from_string("(score (vers 2.0)"
-            "(instrument (musicData (clef G)(key C)(time common)(n c4 q)))"
-            ")");
+        doc.from_string(
+            "(score (vers 1.6)(instrument#100 (musicData (clef G)"
+            "(n c4 e (t 100 + 2 3)(beam 101 +))"
+            "(n d4 s (beam 101 =+))"
+            "(n c4 s (beam 101 ==))"
+            "(n b3 e (t 100 -)(beam 101 --))"
+            ")))" );
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         ImoMusicData* pMD = pInstr->get_musicdata();
@@ -994,8 +1307,75 @@ SUITE(LdpExporterTest)
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pMD);
         //cout << test_name() << endl << "\"" << source << "\"" << endl;
-        string expected = "(musicData (clef G p1)"
-            "(key C)(time common)(n c4 q v1 p1))";
+        string expected =
+            "(musicData (clef G p1)"
+            "(n c4 e v1 p1 (tm 3 2)(t + 2 3)(beam 112 +))"
+            "(n d4 s v1 p1 (tm 3 2)(beam 112 =+))"
+            "(n c4 s v1 p1 (tm 3 2)(beam 112 ==))"
+            "(n b3 e v1 p1 (tm 3 2)(t -)(beam 112 --))"
+            ")";
+        CHECK( source == expected );
+    }
+
+    TEST_FIXTURE(LdpExporterTestFixture, tuplet_1)
+    {
+        //tuplet v2.0: tm explicit
+        Document doc(m_libraryScope);
+        doc.from_string(
+            "(score (vers 1.6)(instrument#100 (musicData (clef G)"
+            "(n c4 e (t 100 + 2 3)(tm 3 2)(beam 101 +))"
+            "(n d4 s (beam 101 =+)(tm 3 2))"
+            "(n c4 s (beam 101 ==)(tm 3 2))"
+            "(n b3 e (t 100 -)(tm 3 2)(beam 101 --))"
+            ")))" );
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_current_score(pScore);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pMD);
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
+        string expected =
+            "(musicData (clef G p1)"
+            "(n c4 e v1 p1 (tm 3 2)(t + 2 3)(beam 112 +))"
+            "(n d4 s v1 p1 (tm 3 2)(beam 112 =+))"
+            "(n c4 s v1 p1 (tm 3 2)(beam 112 ==))"
+            "(n b3 e v1 p1 (tm 3 2)(t -)(beam 112 --))"
+            ")";
+        CHECK( source == expected );
+    }
+
+    //@ Order of elements in the score --------------------------------------------------
+
+    TEST_FIXTURE(LdpExporterTestFixture, order_01)
+    {
+        //@ 01 Note
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0)"
+            "(instrument#100 (staves 2)(musicData (n c4 q p1 (stem down))"
+            "(n c4 q (slur 1 start))(n e4 q (slur 1 stop))"
+            "(n c4 q (tie 2 start))(n c4 q (tie 2 stop))"
+            "(n c4 q (lyric 1 \"This\")(lyric 2 \"A\"))"
+            "(n g5 s g+)(n f5 s)(n g5 e g-)"
+            ")))" );
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+
+        LdpExporter exporter(&m_libraryScope);
+        exporter.set_current_score(pScore);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pMD);
+        string expected = "(musicData (n c4 q v1 p1 (stem down))"
+            "(n c4 q v1 p1 (slur 1 start))(n e4 q v1 p1 (slur 1 stop))"
+            "(n c4 q v1 p1 (tie 2 start))(n c4 q v1 p1 (tie 2 stop))"
+            "(n c4 q v1 p1 (lyric 1 \"This\" below)(lyric 2 \"A\" below))"
+            "(n g5 s v1 p1 (beam 126 ++))(n f5 s v1 p1 (beam 126 =-))"
+            "(n g5 e v1 p1 (beam 126 -)))";
+
+        //cout << test_name() << endl << "\"" << source << "\"" << endl;
 
         CHECK( source == expected );
     }

--- a/src/tests/lomse_test_lmd_analyser.cpp
+++ b/src/tests/lomse_test_lmd_analyser.cpp
@@ -6899,7 +6899,7 @@ SUITE(LmdAnalyserTest)
 //        //expected << "" << endl;
 //        parser.parse_text("(instrument (staves 2)(staff 2 (staffType ossia)"
 //            "(staffLines 4)(staffSpacing 200.0)(staffDistance 800)(lineThickness 20.5))"
-//            "(musicData ))");
+//            "(musicData))");
 //        LmdAnalyser a(errormsg, m_libraryScope, &doc, &parser);
 //        InternalModel* pIModel = a.analyse_tree(tree, "string:");
 //

--- a/src/tests/lomse_test_lmd_compiler.cpp
+++ b/src/tests/lomse_test_lmd_compiler.cpp
@@ -103,7 +103,7 @@ SUITE(LmdCompilerTest)
     //{
     //    Document doc(m_libraryScope);
     //    LmdCompiler compiler(m_libraryScope, &doc);
-    //    InternalModel* pIModel = compiler.compile_string("(score (vers 1.6) (language en iso-8859-1) (systemLayout first (systemMargins 0 0 0 2000)) (systemLayout other (systemMargins 0 0 1200 2000)) (opt Score.FillPageWithEmptyStaves true) (opt StaffLines.Truncate 1) (instrument (musicData )))" );
+    //    InternalModel* pIModel = compiler.compile_string("(score (vers 1.6) (language en iso-8859-1) (systemLayout first (systemMargins 0 0 0 2000)) (systemLayout other (systemMargins 0 0 1200 2000)) (opt Score.FillPageWithEmptyStaves true) (opt StaffLines.Truncate 1) (instrument (musicData)))" );
     //    ImoDocument* pDoc = dynamic_cast<ImoDocument*>(pIModel->get_root());
     //    CHECK( pDoc->get_version() == "0.0" );
     //    CHECK( pDoc->get_num_content_items() == 1 );

--- a/src/tests/lomse_test_mxl_analyser.cpp
+++ b/src/tests/lomse_test_mxl_analyser.cpp
@@ -7266,7 +7266,7 @@ SUITE(MxlAnalyserTest)
 ////        //expected << "" << endl;
 ////        parser.parse_text("(instrument (staves 2)(staff 2 (staffType ossia)"
 ////            "(staffLines 4)(staffSpacing 200.0)(staffDistance 800)(lineThickness 20.5))"
-////            "(musicData ))");
+////            "(musicData))");
 ////        MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
 ////        InternalModel* pIModel = a.analyse_tree(tree, "string:");
 ////

--- a/src/tests/lomse_test_presenter.cpp
+++ b/src/tests/lomse_test_presenter.cpp
@@ -146,7 +146,7 @@ SUITE(PresenterTest)
     //    CHECK( pPresenter != NULL );
     //    Document* pDoc = pPresenter->get_document();
     //    //cout << pDoc->to_string() << endl;
-    //    CHECK( pDoc->to_string() == "(lenmusdoc (vers 0.0) (content (score (vers 1.6) (systemLayout first (systemMargins 0 0 0 2000)) (systemLayout other (systemMargins 0 0 1200 2000)) (opt Score.FillPageWithEmptyStaves true) (opt StaffLines.Truncate 1) (instrument (musicData )))))" );
+    //    CHECK( pDoc->to_string() == "(lenmusdoc (vers 0.0) (content (score (vers 1.6) (systemLayout first (systemMargins 0 0 0 2000)) (systemLayout other (systemMargins 0 0 1200 2000)) (opt Score.FillPageWithEmptyStaves true) (opt StaffLines.Truncate 1) (instrument (musicData)))))" );
     //    CHECK( pPresenter->get_command_executer() != NULL );
 
     //    delete pPresenter;

--- a/src/tests/lomse_test_score_cursor.cpp
+++ b/src/tests/lomse_test_score_cursor.cpp
@@ -263,13 +263,13 @@ public:
     {
         //score with one staff and two voices
         //(score#4 (vers 2.0)(instrument##101L (musicData#22L
-        //(clef#103L G p1 )(key#104L F)(time#105L 4 4)
-        //(n#106L c5 q v1  (stem up) p1 )(n#110L g4 e v2  (stem down) p1 )
-        //(n#111L a4 q v2  (stem down) p1 )(goFwd#107L q v1 p1)
-        //(n#112L f4 e v2  (stem down) p1 )(n#108L d5 q v1  (stem up) p1 )
-        //(n#113L e4 e v2  (stem down) p1 )(r#114L e v2 p1)
-        //(goFwd#109L e v1 p1)(n#115L d4 q v2  (stem down) p1 )
-        //(n#109L e5 e v1  (stem up) p1 )(barline#116L simple)
+        //(clef#103L G p1)(key#104L F)(time#105L 4 4)
+        //(n#106L c5 q v1  (stem up) p1)(n#110L g4 e v2  (stem down) p1)
+        //(n#111L a4 q v2  (stem down) p1)(goFwd#107L q v1 p1)
+        //(n#112L f4 e v2  (stem down) p1)(n#108L d5 q v1  (stem up) p1)
+        //(n#113L e4 e v2  (stem down) p1)(r#114L e v2 p1)
+        //(goFwd#109L e v1 p1)(n#115L d4 q v2  (stem down) p1)
+        //(n#109L e5 e v1  (stem up) p1)(barline#116L simple)
         //(n#117L c5 e v1 (stem up))
         //(n#118L g4 q v2 (stem down))(n#119L a4 e v2 (stem down))
         m_pDoc = LOMSE_NEW Document(m_libraryScope);
@@ -290,7 +290,7 @@ public:
     {
         //two staves, only clef, key and time signature
         //(score#5L (vers 2.0)(instrument#21L (musicData#22L
-        //(clef#103L G p1 )(clef#104L F4 p2 )(key#105L D)(time#106L 4 4)
+        //(clef#103L G p1)(clef#104L F4 p2)(key#105L D)(time#106L 4 4)
         m_pDoc = LOMSE_NEW Document(m_libraryScope);
         m_pDoc->from_string(
             "(score (vers 2.0)(instrument#101L (staves 2)(musicData "

--- a/src/tests/lomse_test_score_layouter.cpp
+++ b/src/tests/lomse_test_score_layouter.cpp
@@ -290,7 +290,7 @@ SUITE(ScoreLayouterTest)
 //    {
 //        Document doc(m_libraryScope);
 //        doc.from_string("(lenmusdoc (vers 0.0) (content (score (vers 1.6) "
-//            "(instrument (musicData ))) ))" );
+//            "(instrument (musicData))) ))" );
 //        GraphicModel gmodel;
 //        ImoScore* pImoScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
 //        MyScoreLayouter scoreLyt(pImoScore, &gmodel, m_libraryScope);
@@ -307,7 +307,7 @@ SUITE(ScoreLayouterTest)
     {
         Document doc(m_libraryScope);
         doc.from_string("(lenmusdoc (vers 0.0) (content (score (vers 1.6) "
-            "(instrument (musicData ))) ))" );
+            "(instrument (musicData))) ))" );
         GraphicModel gmodel;
         ImoScore* pImoScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
         MyScoreLayouter scoreLyt(pImoScore, &gmodel, m_libraryScope);
@@ -761,7 +761,7 @@ SUITE(ColumnsBuilderTest)
 //    {
 //        Document doc(m_libraryScope);
 //        doc.from_string("(lenmusdoc (vers 0.0) (content (score (vers 1.6) "
-//            "(instrument (musicData ))) ))" );
+//            "(instrument (musicData))) ))" );
 //        GraphicModel gmodel;
 //        ImoScore* pImoScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
 //        MyScoreLayouter scoreLyt(pImoScore, &gmodel, m_libraryScope);

--- a/src/tests/lomse_test_score_meter.cpp
+++ b/src/tests/lomse_test_score_meter.cpp
@@ -67,8 +67,8 @@ SUITE(ScoreMeterTest)
     {
         Document doc(m_libraryScope);
         doc.from_string("(lenmusdoc (vers 0.0) (content (score (vers 1.6) "
-            "(instrument (staves 2)(musicData ))"
-            "(instrument (staves 3)(musicData ))"
+            "(instrument (staves 2)(musicData))"
+            "(instrument (staves 3)(musicData))"
             ")))" );
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
         ScoreMeter meter(pScore);

--- a/src/tests/lomse_test_staffobjs_table.cpp
+++ b/src/tests/lomse_test_staffobjs_table.cpp
@@ -196,11 +196,11 @@ SUITE(ColStaffObjsBuilderTest)
         //cout << pTable->dump();
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 q v1  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     1, "(n c5 e v2  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,  32,     1, "(n e5 e v2  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n e4 e v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 q v1 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     1, "(n c5 e v2 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,  32,     1, "(n e5 e v2 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n e4 e v1 p1)" );
         CHECK( pTable->min_note_duration() == 32.0 );
     }
 
@@ -223,11 +223,11 @@ SUITE(ColStaffObjsBuilderTest)
 //        cout << pTable->dump();
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 q v1  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     1, "(n c5 e v2  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,  32,     1, "(n e5 w v2  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n e4 e v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 q v1 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     1, "(n c5 e v2 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,  32,     1, "(n e5 w v2 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n e4 e v1 p1)" );
         CHECK_ENTRY0(it, 0,    0,      0, 288,     0, "(barline simple)" );
         CHECK( pTable->min_note_duration() == 32.0 );
     }
@@ -252,16 +252,16 @@ SUITE(ColStaffObjsBuilderTest)
 //        cout << pTable->dump();
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 q v1  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     1, "(n c5 e v2  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,  32,     1, "(n e5 w v2  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n e4 e v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 q v1 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     1, "(n c5 e v2 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,  32,     1, "(n e5 w v2 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n e4 e v1 p1)" );
         CHECK_ENTRY0(it, 0,    0,      0, 288,     0, "(barline simple)" );
-        CHECK_ENTRY0(it, 0,    0,      1, 288,     0, "(n c4 q v1  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      1, 288,     1, "(n c5 e v2  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      1, 320,     1, "(n e5 w v2  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      1, 352,     0, "(n e4 e v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      1, 288,     0, "(n c4 q v1 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      1, 288,     1, "(n c5 e v2 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      1, 320,     1, "(n e5 w v2 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      1, 352,     0, "(n e4 e v1 p1)" );
         CHECK( pTable->min_note_duration() == 32.0 );
     }
 
@@ -284,8 +284,8 @@ SUITE(ColStaffObjsBuilderTest)
         //cout << pTable->dump();
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    1,      0,   0,     1, "(clef F4 p2 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    1,      0,   0,     1, "(clef F4 p2)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(key C)" );
         CHECK_ENTRY0(it, 0,    1,      0,   0,     1, "(key C)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(time 2 4)" );
@@ -313,16 +313,16 @@ SUITE(ColStaffObjsBuilderTest)
         //cout << pTable->dump();
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    1,      0,   0,     1, "(clef F4 p2 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    1,      0,   0,     1, "(clef F4 p2)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(key C)" );
         CHECK_ENTRY0(it, 0,    1,      0,   0,     1, "(key C)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(time 2 4)" );
         CHECK_ENTRY0(it, 0,    1,      0,   0,     1, "(time 2 4)" );
-        CHECK_ENTRY0(it, 0,    1,      0,   0,     1, "(chord (n c3 w v1  p2 )" );
-        CHECK_ENTRY0(it, 0,    1,      0,   0,     1, "(n g3 w v1  p2 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 w v1  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c5 w v1  p1 ))" );
+        CHECK_ENTRY0(it, 0,    1,      0,   0,     1, "(chord (n c3 w v1 p2)" );
+        CHECK_ENTRY0(it, 0,    1,      0,   0,     1, "(n g3 w v1 p2)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 w v1 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c5 w v1 p1))" );
         CHECK_ENTRY0(it, 0,    0,      0, 256,     0, "(barline simple)" );
         CHECK( pTable->min_note_duration() == 256.0 );
     }
@@ -346,9 +346,9 @@ SUITE(ColStaffObjsBuilderTest)
         //cout << pTable->dump();
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(key C)" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n f4 q v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n f4 q v1 p1)" );
         CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(spacer 0 p1 (text \"Hello world\"))" );
         CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(barline simple)" );
         CHECK( pTable->min_note_duration() == 64.0 );
@@ -374,12 +374,12 @@ SUITE(ColStaffObjsBuilderTest)
         //cout << pTable->dump();
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(time 3 4)" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 q v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 q v1 p1)" );
         CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(barline simple)" );
-        CHECK_ENTRY0(it, 0,    0,      1,  64,     0, "(n d4 e. v1  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      1, 112,     0, "(n d4 s v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      1,  64,     0, "(n d4 e. v1 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      1, 112,     0, "(n d4 s v1 p1)" );
         CHECK( pTable->min_note_duration() == 16.0 );
     }
 
@@ -402,10 +402,10 @@ SUITE(ColStaffObjsBuilderTest)
         //cout << pTable->dump();
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 e v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 e v1 p1)" );
         CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(goFwd e v1 p1)" );
-        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n e4 e v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n e4 e v1 p1)" );
         CHECK( pTable->min_note_duration() == 32.0 );
     }
 
@@ -429,11 +429,11 @@ SUITE(ColStaffObjsBuilderTest)
 //        cout << pTable->dump();
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef F4 p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e3 e v1  p1 (beam 25 +))" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     1, "(n c2 w v3  p1 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n g3 e v1  p1 (beam 25 =))" );
-        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n c4 e v1  p1 (beam 25 -))" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef F4 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e3 e v1 p1 (beam 25 +))" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     1, "(n c2 w v3 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n g3 e v1 p1 (beam 25 =))" );
+        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n c4 e v1 p1 (beam 25 -))" );
         CHECK_ENTRY0(it, 0,    0,      0, 256,     0, "(barline simple)" );
         CHECK( pTable->min_note_duration() == 32.0 );
     }
@@ -458,13 +458,13 @@ SUITE(ColStaffObjsBuilderTest)
 //        cout << pTable->dump();
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,    1,      0,   0,     1, "(clef F4 p2 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 q v1  p1 )" );
-        CHECK_ENTRY0(it, 0,    1,      0,   0,     1, "(n c3 e v2  p2 )" );
-        CHECK_ENTRY0(it, 0,    1,      0,  32,     1, "(clef G p2 )" );
-        CHECK_ENTRY0(it, 0,    1,      0,  32,     1, "(n c4 e v2  p2 )" );
-        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n e4 e v1  p1 )" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    1,      0,   0,     1, "(clef F4 p2)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 q v1 p1)" );
+        CHECK_ENTRY0(it, 0,    1,      0,   0,     1, "(n c3 e v2 p2)" );
+        CHECK_ENTRY0(it, 0,    1,      0,  32,     1, "(clef G p2)" );
+        CHECK_ENTRY0(it, 0,    1,      0,  32,     1, "(n c4 e v2 p2)" );
+        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n e4 e v1 p1)" );
         CHECK( pTable->min_note_duration() == 32.0 );
     }
 
@@ -498,30 +498,30 @@ SUITE(ColStaffObjsBuilderTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,     0,	    0,	0,	    0,	"(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,	    1,	    0,	0,	    1,	"(clef F4 p2 )" );
+        CHECK_ENTRY0(it, 0,     0,	    0,	0,	    0,	"(clef G p1)" );
+        CHECK_ENTRY0(it, 0,	    1,	    0,	0,	    1,	"(clef F4 p2)" );
         CHECK_ENTRY0(it, 0,	    0,	    0,	0,	    0,	"(key D)" );
         CHECK_ENTRY0(it, 0,	    1,	    0,	0,	    1,	"(key D)" );
         CHECK_ENTRY0(it, 0,	    0,	    0,	0,	    0,	"(time 2 4)" );
         CHECK_ENTRY0(it, 0,	    1,	    0,	0,	    1,	"(time 2 4)" );
-        CHECK_ENTRY0(it, 1,	    0,	    0,	0,	    2,	"(clef G p1 )" );
-        CHECK_ENTRY0(it, 1,	    1,	    0,	0,	    3,	"(clef F4 p2 )" );
+        CHECK_ENTRY0(it, 1,	    0,	    0,	0,	    2,	"(clef G p1)" );
+        CHECK_ENTRY0(it, 1,	    1,	    0,	0,	    3,	"(clef F4 p2)" );
         CHECK_ENTRY0(it, 1,	    0,	    0,	0,	    2,	"(key D)" );
         CHECK_ENTRY0(it, 1,	    1,	    0,	0,	    3,	"(key D)" );
         CHECK_ENTRY0(it, 1,	    0,	    0,	0,	    2,	"(time 2 4)" );
         CHECK_ENTRY0(it, 1,	    1,	    0,	0,	    3,	"(time 2 4)" );
-        CHECK_ENTRY0(it, 0,	    0,	    0,	0,	    0,	"(n f4 h v1  p1 )" );
-        CHECK_ENTRY0(it, 0,	    1,	    0,	0,	    1,	"(n c3 e v2  p2 (beam 28 +))" );
-        CHECK_ENTRY0(it, 1,	    0,	    0,	0,	    2,	"(n f4 q. v1  p1 )" );  // line 4 !
-        CHECK_ENTRY0(it, 1,	    1,	    0,	0,	    3,	"(n c3 q v2  p2 )" );
-        CHECK_ENTRY0(it, 0,	    1,	    0,	32,	    1,	"(n c3 e v2  p2 (beam 28 -))" );
-        CHECK_ENTRY0(it, 0,	    1,	    0,	64,	    1,	"(n d3 q v2  p2 )" );
-        CHECK_ENTRY0(it, 1,	    1,	    0,	64,	    3,	"(n c3 e v2  p2 )" );
-        CHECK_ENTRY0(it, 1,	    0,	    0,	96,	    2,	"(clef F4 p1 )" );  // line 4 !
-        CHECK_ENTRY0(it, 1,	    1,	    0,	96,	    3,	"(clef G p2 )" );
-        CHECK_ENTRY0(it, 1,	    1,	    0,	96,	    3,	"(clef F4 p2 )" );
-        CHECK_ENTRY0(it, 1,	    0,	    0,	96,	    2,	"(n a3 e v1  p1 )" );  // line 4 !
-        CHECK_ENTRY0(it, 1,	    1,	    0,	96,	    3,	"(n c3 e v2  p2 )" );
+        CHECK_ENTRY0(it, 0,	    0,	    0,	0,	    0,	"(n f4 h v1 p1)" );
+        CHECK_ENTRY0(it, 0,	    1,	    0,	0,	    1,	"(n c3 e v2 p2 (beam 28 +))" );
+        CHECK_ENTRY0(it, 1,	    0,	    0,	0,	    2,	"(n f4 q. v1 p1)" );  // line 4 !
+        CHECK_ENTRY0(it, 1,	    1,	    0,	0,	    3,	"(n c3 q v2 p2)" );
+        CHECK_ENTRY0(it, 0,	    1,	    0,	32,	    1,	"(n c3 e v2 p2 (beam 28 -))" );
+        CHECK_ENTRY0(it, 0,	    1,	    0,	64,	    1,	"(n d3 q v2 p2)" );
+        CHECK_ENTRY0(it, 1,	    1,	    0,	64,	    3,	"(n c3 e v2 p2)" );
+        CHECK_ENTRY0(it, 1,	    0,	    0,	96,	    2,	"(clef F4 p1)" );  // line 4 !
+        CHECK_ENTRY0(it, 1,	    1,	    0,	96,	    3,	"(clef G p2)" );
+        CHECK_ENTRY0(it, 1,	    1,	    0,	96,	    3,	"(clef F4 p2)" );
+        CHECK_ENTRY0(it, 1,	    0,	    0,	96,	    2,	"(n a3 e v1 p1)" );  // line 4 !
+        CHECK_ENTRY0(it, 1,	    1,	    0,	96,	    3,	"(n c3 e v2 p2)" );
         CHECK_ENTRY0(it, 0,	    0,	    0,	128,	0,	"(barline simple)" );
         CHECK_ENTRY0(it, 1,	    0,	    0,	128,	2,	"(barline simple)" );
         CHECK( pTable->min_note_duration() == 32.0 );
@@ -1448,30 +1448,30 @@ SUITE(ColStaffObjsBuilderTest)
 
         ColStaffObjsIterator it = pTable->begin();
         //              instr, staff, meas. time, line, scr
-        CHECK_ENTRY0(it, 0,     0,	    0,	0,	    0,	"(clef G p1 )" );
-        CHECK_ENTRY0(it, 0,	    1,	    0,	0,	    1,	"(clef F4 p2 )" );
+        CHECK_ENTRY0(it, 0,     0,	    0,	0,	    0,	"(clef G p1)" );
+        CHECK_ENTRY0(it, 0,	    1,	    0,	0,	    1,	"(clef F4 p2)" );
         CHECK_ENTRY0(it, 0,	    0,	    0,	0,	    0,	"(key D)" );
         CHECK_ENTRY0(it, 0,	    1,	    0,	0,	    1,	"(key D)" );
         CHECK_ENTRY0(it, 0,	    0,	    0,	0,	    0,	"(time 2 4)" );
         CHECK_ENTRY0(it, 0,	    1,	    0,	0,	    1,	"(time 2 4)" );
-        CHECK_ENTRY0(it, 1,	    0,	    0,	0,	    2,	"(clef G p1 )" );
-        CHECK_ENTRY0(it, 1,	    1,	    0,	0,	    3,	"(clef F4 p2 )" );
+        CHECK_ENTRY0(it, 1,	    0,	    0,	0,	    2,	"(clef G p1)" );
+        CHECK_ENTRY0(it, 1,	    1,	    0,	0,	    3,	"(clef F4 p2)" );
         CHECK_ENTRY0(it, 1,	    0,	    0,	0,	    2,	"(key D)" );
         CHECK_ENTRY0(it, 1,	    1,	    0,	0,	    3,	"(key D)" );
         CHECK_ENTRY0(it, 1,	    0,	    0,	0,	    2,	"(time 2 4)" );
         CHECK_ENTRY0(it, 1,	    1,	    0,	0,	    3,	"(time 2 4)" );
-        CHECK_ENTRY0(it, 0,	    0,	    0,	0,	    0,	"(n f4 h v1  p1 )" );
-        CHECK_ENTRY0(it, 0,	    1,	    0,	0,	    1,	"(n c3 e v2  p2 (beam 29 +))" );
-        CHECK_ENTRY0(it, 1,	    0,	    0,	0,	    2,	"(n f4 q. v1  p1 )" );
-        CHECK_ENTRY0(it, 1,	    1,	    0,	0,	    3,	"(n c3 q v2  p2 )" );
-        CHECK_ENTRY0(it, 0,	    1,	    0,	32,	    1,	"(n c3 e v2  p2 (beam 29 -))" );
-        CHECK_ENTRY0(it, 0,	    1,	    0,	64,	    1,	"(n d3 q v2  p2 )" );
-        CHECK_ENTRY0(it, 1,	    1,	    0,	64,	    3,	"(n c3 e v2  p2 )" );
-        CHECK_ENTRY0(it, 1,	    0,	    0,	96,	    2,	"(clef F4 p1 )" );
-        CHECK_ENTRY0(it, 1,	    1,	    0,	96,	    3,	"(clef G p2 )" );
-        CHECK_ENTRY0(it, 1,	    1,	    0,	96,	    3,	"(clef F4 p2 )" );
-        CHECK_ENTRY0(it, 1,	    0,	    0,	96,	    2,	"(n a3 e v1  p1 )" );
-        CHECK_ENTRY0(it, 1,	    1,	    0,	96,	    3,	"(n c3 e v2  p2 )" );
+        CHECK_ENTRY0(it, 0,	    0,	    0,	0,	    0,	"(n f4 h v1 p1)" );
+        CHECK_ENTRY0(it, 0,	    1,	    0,	0,	    1,	"(n c3 e v2 p2 (beam 29 +))" );
+        CHECK_ENTRY0(it, 1,	    0,	    0,	0,	    2,	"(n f4 q. v1 p1)" );
+        CHECK_ENTRY0(it, 1,	    1,	    0,	0,	    3,	"(n c3 q v2 p2)" );
+        CHECK_ENTRY0(it, 0,	    1,	    0,	32,	    1,	"(n c3 e v2 p2 (beam 29 -))" );
+        CHECK_ENTRY0(it, 0,	    1,	    0,	64,	    1,	"(n d3 q v2 p2)" );
+        CHECK_ENTRY0(it, 1,	    1,	    0,	64,	    3,	"(n c3 e v2 p2)" );
+        CHECK_ENTRY0(it, 1,	    0,	    0,	96,	    2,	"(clef F4 p1)" );
+        CHECK_ENTRY0(it, 1,	    1,	    0,	96,	    3,	"(clef G p2)" );
+        CHECK_ENTRY0(it, 1,	    1,	    0,	96,	    3,	"(clef F4 p2)" );
+        CHECK_ENTRY0(it, 1,	    0,	    0,	96,	    2,	"(n a3 e v1 p1)" );
+        CHECK_ENTRY0(it, 1,	    1,	    0,	96,	    3,	"(n c3 e v2 p2)" );
         CHECK_ENTRY0(it, 0,	    0,	    0,	128,	0,	"(barline simple)" );
         CHECK_ENTRY0(it, 1,	    0,	    0,	128,	2,	"(barline simple)" );
         CHECK( pTable->min_note_duration() == 32.0 );

--- a/src/tests/lomse_test_system_cursor.cpp
+++ b/src/tests/lomse_test_system_cursor.cpp
@@ -300,7 +300,7 @@ SUITE(SystemCursorTest)
     {
         Document doc(m_libraryScope);
         doc.from_string("(lenmusdoc (vers 0.0) (content (score (vers 1.6) "
-            "(instrument (musicData ) )) "
+            "(instrument (musicData) )) "
             "))" );
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
         StaffObjsCursor cursor(pScore);


### PR DESCRIPTION
LDP Exporter needed some improvements:
- First,  blank space in LDP exporter has been normalized. This simplifies automated tests and produces LDP code that is, visually, better.
- But the most important change has been to ensure that LDP exporter follows the same syntax rules than LDP Analyser, thus ensuring a round trip in LDP export-import.
- Some fixes in LDP exporter also added, for generating code for elements or options that were not taken into account.