### PR TITLE
Fix prolog spacing issues detected in regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ##### COMPATIBLE CHANGES
 
+- Fixed spacing issues, related to clefs and prolog objects, detected 
+  in regression tests.
 - Blank space in LDP exporter has been normalized.
 - LDP exporter reviewed for following the same syntax rules than LDP 
   Analyser, thus ensuring a round trip in LDP export-import.

--- a/include/lomse_spacing_algorithm_gourlay.h
+++ b/include/lomse_spacing_algorithm_gourlay.h
@@ -84,7 +84,7 @@ protected:
     vector<StaffObjData*> m_data;           //data associated to each staff object
 
     //auxiliary temporal variables used while collecting columns' data
-    TimeSlice*   m_pCurSlice;
+    TimeSlice*          m_pCurSlice;
     ColStaffObjsEntry*  m_pLastEntry;
     int                 m_prevType;
     TimeUnits           m_prevTime;
@@ -92,6 +92,12 @@ protected:
     ColumnDataGourlay*  m_pCurColumn;
     int                 m_numSlices;
     int                 m_iPrevColumn;
+
+    //auxiliary, for controlling objects to include in a prolog slice
+    TimeUnits    m_lastPrologTime;
+    vector<bool> m_prologClefs;
+    vector<bool> m_prologKeys;
+    vector<bool> m_prologTimes;
 
     //data collected for each slice
     TimeUnits   m_maxNoteDur;
@@ -155,6 +161,7 @@ protected:
     void order_slices_in_columns();
     void apply_force(float F);
     void determine_spacing_parameters();
+    bool accept_for_prolog_slice(ColStaffObjsEntry* pEntry);
 
 };
 
@@ -222,7 +229,8 @@ public:
                            vector<StaffObjData*>& data);
     void delete_shapes(vector<StaffObjData*>& data);
     void move_shapes_to_final_positions(vector<StaffObjData*>& data, LUnits xPos,
-                                        LUnits yPos, LUnits* yMin, LUnits* yMax);
+                                        LUnits yPos, LUnits* yMin, LUnits* yMax,
+                                        ScoreMeter* pMeter);
 
     //debug
     void dump(ostream& outStream, bool fOrdered=false);
@@ -266,7 +274,6 @@ protected:
     int         m_numEntries;   //num staffobjs in this slice
     int         m_type;         //type of slice. Value from enum ESliceType
     int         m_iColumn;      //Column in which this slice is included
-    bool        m_fInProlog;    //this slice is part of the score prolog
 
     //lyrics
     vector<ImoLyric*> m_lyrics;
@@ -290,8 +297,7 @@ protected:
     TimeUnits   m_minNoteNext;  //min note/rest duration still sounding in next segment
 
 public:
-    TimeSlice(ColStaffObjsEntry* pEntry, int entryType, int column,
-                     int iData, bool fInProlog);
+    TimeSlice(ColStaffObjsEntry* pEntry, int entryType, int column, int iData);
     virtual ~TimeSlice();
 
     enum ESliceType {
@@ -344,7 +350,8 @@ public:
                            vector<StaffObjData*>& data);
     void delete_shapes(vector<StaffObjData*>& data);
     virtual void move_shapes_to_final_positions(vector<StaffObjData*>& data, LUnits xPos,
-                                                LUnits yPos, LUnits* yMin, LUnits* yMax);
+                                                LUnits yPos, LUnits* yMin, LUnits* yMax,
+                                                ScoreMeter* pMeter);
     //access to information
     inline LUnits get_width() { return m_width; }
 
@@ -363,7 +370,6 @@ protected:
     void compute_pre_stretching_force();
     LUnits spacing_function(LUnits uSmin, float alpha, float log2dmin, TimeUnits dmin);
     inline TimeUnits get_min_note_still_sounding() { return m_minNoteNext; }
-    bool is_last_slice_in_prolog();
 
     void add_lyrics();
     LUnits measure_lyric(ImoLyric* pLyric, ScoreMeter* pMeter, TextMeter& textMeter);
@@ -375,7 +381,8 @@ protected:
 
 //---------------------------------------------------------------------------------------
 // TimeSliceProlog
-// An slice for the prolog objects
+// An slice for the prolog objects.
+// At maximum one clef, one key and one time signature per staff
 class TimeSliceProlog : public TimeSlice
 {
 protected:
@@ -392,8 +399,11 @@ public:
     void assign_spacing_values(vector<StaffObjData*>& data, ScoreMeter* pMeter,
                                TextMeter& textMeter);
     void move_shapes_to_final_positions(vector<StaffObjData*>& data, LUnits xPos,
-                                        LUnits yPos, LUnits* yMin, LUnits* yMax);
+                                        LUnits yPos, LUnits* yMin, LUnits* yMax,
+                                        ScoreMeter* pMeter);
 
+    //specific methods
+    void remove_after_space_if_not_full(ScoreMeter* pMeter, int SOtype);
 };
 
 
@@ -416,7 +426,8 @@ public:
     void assign_spacing_values(vector<StaffObjData*>& data, ScoreMeter* pMeter,
                                TextMeter& textMeter);
     void move_shapes_to_final_positions(vector<StaffObjData*>& data, LUnits xPos,
-                                        LUnits yPos, LUnits* yMin, LUnits* yMax);
+                                        LUnits yPos, LUnits* yMin, LUnits* yMax,
+                                        ScoreMeter* pMeter);
 
 };
 

--- a/src/graphic_model/layouters/lomse_spacing_algorithm.cpp
+++ b/src/graphic_model/layouters/lomse_spacing_algorithm.cpp
@@ -385,7 +385,9 @@ void ColumnsBuilder::collect_content_for_this_column()
                 pShape = m_pShapesCreator->create_staffobj_shape(pSO, iInstr, iStaff,
                          m_pagePos, clefType, flags);
                 pShape->assign_id_as_main_shape();
-                m_pSpAlgorithm->include_object(m_pSysCursor->cur_entry(), m_iColumn, iLine, iInstr, pSO, -1.0f, iStaff, pShape, fInProlog);
+                m_pSpAlgorithm->include_object(m_pSysCursor->cur_entry(), m_iColumn,
+                                               iLine, iInstr, pSO, -1.0f, iStaff,
+                                               pShape, fInProlog);
             }
 
             else if (pSO->is_key_signature() || pSO->is_time_signature())
@@ -396,7 +398,9 @@ void ColumnsBuilder::collect_content_for_this_column()
                 pShape = m_pShapesCreator->create_staffobj_shape(pSO, iInstr, iStaff,
                          m_pagePos, clefType, flags);
                 pShape->assign_id_as_main_or_implicit_shape(iStaff);
-                m_pSpAlgorithm->include_object(m_pSysCursor->cur_entry(), m_iColumn, iLine, iInstr, pSO, -1.0f, iStaff, pShape, fInProlog);
+                m_pSpAlgorithm->include_object(m_pSysCursor->cur_entry(), m_iColumn,
+                                               iLine, iInstr, pSO, -1.0f, iStaff,
+                                               pShape, fInProlog);
             }
 
 //            else if (pSO->is_barline())
@@ -404,7 +408,9 @@ void ColumnsBuilder::collect_content_for_this_column()
 //                int clefType = m_pSysCursor->get_applicable_clef_type();
 //                pShape = m_pShapesCreator->create_staffobj_shape(pSO, iInstr, iStaff,
 //                                                                 m_pagePos, clefType);
-//                m_pSpAlgorithm->include_object(m_pSysCursor->cur_entry(), m_iColumn, iLine, iInstr, pSO, rTime-0.5f, iStaff, pShape);
+//                m_pSpAlgorithm->include_object(m_pSysCursor->cur_entry(), m_iColumn,
+//                                               iLine, iInstr, pSO, rTime-0.5f, iStaff,
+//                                               pShape);
 //            }
 
             else
@@ -413,7 +419,8 @@ void ColumnsBuilder::collect_content_for_this_column()
                 pShape = m_pShapesCreator->create_staffobj_shape(pSO, iInstr, iStaff,
                          m_pagePos, clefType);
                 TimeUnits time = (pSO->is_spacer() ? -1.0f : rTime);
-                m_pSpAlgorithm->include_object(m_pSysCursor->cur_entry(), m_iColumn, iLine, iInstr, pSO, time, iStaff, pShape);
+                m_pSpAlgorithm->include_object(m_pSysCursor->cur_entry(), m_iColumn,
+                                               iLine, iInstr, pSO, time, iStaff, pShape);
             }
 
             store_info_about_attached_objects(pSO, pShape, iInstr, iStaff,

--- a/src/tests/lomse_test_spacing_algorithm.cpp
+++ b/src/tests/lomse_test_spacing_algorithm.cpp
@@ -90,9 +90,8 @@ public:
 class MyTimeSlice : public TimeSlice
 {
 public:
-    MyTimeSlice(ColStaffObjsEntry* pEntry, int entryType, int column, int iData,
-                bool fInProlog)
-        : TimeSlice(pEntry, entryType, column, iData, fInProlog)
+    MyTimeSlice(ColStaffObjsEntry* pEntry, int entryType, int column, int iData)
+        : TimeSlice(pEntry, entryType, column, iData)
     {
     }
     virtual ~MyTimeSlice() {}

--- a/test-scores/00142-clef-change-at-start.lms
+++ b/test-scores/00142-clef-change-at-start.lms
@@ -1,0 +1,21 @@
+(score (vers 2.1)
+   (instrument (staves 2)
+      (musicData 
+        (clef G p1)
+        (clef F4 p2)
+        (key c)
+        (time 4 4)
+        (clef F4 p1)
+        (n g3 q p1)
+        (n a3 q)
+        (n g3 q)
+        (n e3 q)
+
+        //left hand
+        (n c2 q v2 p2)
+        (n f1 q)
+        (n g1 q)
+        (n c2 q)
+        (barline)
+)))
+

--- a/test-scores/02042-text-attached.lms
+++ b/test-scores/02042-text-attached.lms
@@ -1,0 +1,13 @@
+(score (vers 2.0) (instrument (musicData 
+    (clef G)
+    (key C)
+    (spacer 50
+        (text "spacer" (dy -10)) )
+    (n c4 q
+        (text "note" (dy 80)) )
+    (spacer 50)
+    (barline simple
+        (text "barline" (dx 15)(dy -20)) )
+    (spacer 50)
+    (barline end)
+)))


### PR DESCRIPTION
Fixes spacing issues with non-standard scores with several consecutive clefs, detected in regression tests after changing the spacing algorithm.