### PR TITLE
Fixes #73: Highlight is not synced. when moving to next page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@
 
 ##### COMPATIBLE CHANGES
 
+- Fixed issue #73: Highlight is not synced. when moving to next page.
 - Fixed issue #70: Score highlight does not work in some scores.
-- Line breaker algorithm improved. Now it considers different break modes.
 - Fixed issue #10: note flags too long for short stems.
+- Line breaker algorithm improved. Now it considers different break modes.
 - Fixed an issue with justification, detected in regression tests. It
   caused that in some cases the system was not justified.
 - Improvements in tuplets renderization and support:
@@ -27,6 +28,7 @@
 - LDP exporter reviewed for following the same syntax rules than LDP 
   Analyser, thus ensuring a round trip in LDP export-import.
 - Some fixes in LDP exporter.
+- Implemented method SimpleView::get_view_size().
 
 
 Version [0.20.0] (1/Sep/2016)

--- a/src/graphic_model/lomse_shapes.cpp
+++ b/src/graphic_model/lomse_shapes.cpp
@@ -60,6 +60,7 @@ void GmoShapeGlyph::on_draw(Drawer* pDrawer, RenderOptions& opt)
                          m_libraryScope.get_music_font_name(),
                          m_fontHeight);
     pDrawer->set_text_color( determine_color_to_use(opt) );
+    pDrawer->move_to(m_origin.x, m_origin.y);       //this line fixes issue #73 !!!
     LUnits x = m_shiftToDraw.width + m_origin.x;
     LUnits y = m_shiftToDraw.height + m_origin.y;
     pDrawer->draw_glyph(x, y, m_glyph);

--- a/src/mvc/lomse_graphic_view.cpp
+++ b/src/mvc/lomse_graphic_view.cpp
@@ -1300,9 +1300,19 @@ void SimpleView::set_viewport_for_page_fit_full(Pixels screenWidth)
 }
 
 //---------------------------------------------------------------------------------------
-void SimpleView::get_view_size(Pixels* UNUSED(xWidth), Pixels* UNUSED(yHeight))
+void SimpleView::get_view_size(Pixels* xWidth, Pixels* yHeight)
 {
-    //TODO: SimpleView::get_view_size
+    *xWidth = 0;
+    *yHeight = 0;
+
+    GraphicModel* pGModel = get_graphic_model();
+    if (pGModel && pGModel->get_num_pages() > 0)
+    {
+        GmoBoxDocPage* pPage = pGModel->get_page(0);
+        URect rect = pPage->get_bounds();
+        *xWidth = m_pDrawer->LUnits_to_Pixels(rect.width);
+        *yHeight = m_pDrawer->LUnits_to_Pixels(rect.height);
+    }
 }
 
 


### PR DESCRIPTION
This PR fixes issue #73 and also implements method SimpleView::get_view_size() that was empty.

@juuk100 
In relation to your question about the image size, method view->get_view_size(&xWidth, &yHeight) will return the size for rendering the full score (all the pages). For k_simple_view it will return the size for rendering one page without borders. For other view types it will return the size for rendering all pages, including the margin between pages, and left and right view margins.

I've noticed that in your tests you are using k_view_simple. Take into account that SimpleView is just for rendering small scores that occupy a page at maximum. It assumes that the score has only a page and doesn't checks this, so behaviour can be wrong for scores having more than one page. I developed it for creating images for short scores, for instance for a combo box or other controls, such as a combobox for selecting a clef, by displaying a single music line with the clef. The only fully tested View is k_view_vertical_book. k_view_horizontal_book should work but to my knowledge it has never been tested in an application and could have stupid bugs.
