### PR TITLE
Fix #77: The score and sound do not match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Blank space in LDP exporter has been normalized.
 - LDP exporter reviewed for following the same syntax rules than LDP 
   Analyser, thus ensuring a round trip in LDP export-import.
+- Fixed issue #77: The score and sound do not match
 - Fixed issue #68: Assume some default value for clef in MusicXML importer
 - Fixed issue #69: Playback very slow for 3/8 tempo
 - Fixed issue #67: Fix beams in malformed MusicXML files.

--- a/include/lomse_im_note.h
+++ b/include/lomse_im_note.h
@@ -155,7 +155,8 @@ protected:
     int     m_step;
     int     m_octave;
     EAccidentals m_notated_acc;
-    float   m_actual_acc;
+    float   m_actual_acc;           //number of semitones (i.e, -1 for flat). Decimal
+                                    //values like 0.5 (quarter tone sharp) are also valid.
     int     m_stemDirection;
     ImoTie* m_pTieNext;
     ImoTie* m_pTiePrev;

--- a/src/internal_model/lomse_im_note.cpp
+++ b/src/internal_model/lomse_im_note.cpp
@@ -291,8 +291,8 @@ MidiPitch ImoNote::get_midi_pitch()
         return k_undefined_midi_pitch;
     else
         return MidiPitch(m_step, m_octave, int(m_actual_acc));
+        //TODO: deal with fractional values used for microtones.
 }
-
 
 //---------------------------------------------------------------------------------------
 int ImoNote::get_midi_bend()

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -3755,11 +3755,11 @@ public:
 
         ImoNote* pNote = dynamic_cast<ImoNote*>(m_pAnchor);
         int nStep = mxl_step_to_step(step);
-        EAccidentals nAcc = mxl_alter_to_accidentals(accidentals);
+        float acc = mxl_alter_to_accidentals(accidentals);
         int nOctave = mxl_octave_to_octave(octave);
         pNote->set_step(nStep);
         pNote->set_octave(nOctave);
-        pNote->set_actual_accidentals(nAcc);
+        pNote->set_actual_accidentals(acc);
         return pNote;
     }
 
@@ -3813,7 +3813,7 @@ protected:
         }
     }
 
-    EAccidentals mxl_alter_to_accidentals(const string& accidentals)
+    float mxl_alter_to_accidentals(const string& accidentals)
     {
         //@ The <alter> element is needed for the sounding pitch, whether the
         //@ accidental is in the key signature or not. If you want to see an
@@ -3826,32 +3826,15 @@ protected:
         //@ AWARE: <alter> is for pitch, not for displayed accidental. The displayed
         //@ accidentals is encoded in an <accidental> element
 
-        //TODO: only integer accidentals -2..+2 supported. Modify for more.
-
-        long nNumber;
+        float number;
         std::istringstream iss(accidentals);
-        if ((iss >> std::dec >> nNumber).fail() || nNumber > 2 || nNumber < -2)
+        if ((iss >> number).fail())
         {
-            //report_msg(m_pAnalyser->get_line_number(&m_analysedNode),
             error_msg2(
                 "Invalid or not supported <alter> value '" + accidentals + "'. Ignored.");
-            return k_no_accidentals;
+            return 0.0f;
         }
-
-        switch(nNumber)
-        {
-            case 0:
-                return k_no_accidentals;
-            case 1:
-                return k_sharp;
-            case 2:
-                return k_double_sharp;
-            case -1:
-                return k_flat;
-            case -2:
-                return k_flat_flat;
-        }
-        return k_no_accidentals;        //should not reach this
+        return number;
     }
 
 };

--- a/src/tests/lomse_test_mxl_analyser.cpp
+++ b/src/tests/lomse_test_mxl_analyser.cpp
@@ -1595,7 +1595,7 @@ SUITE(MxlAnalyserTest)
         CHECK( pIModel->get_root()->is_note() == true );
         ImoNote* pNote = dynamic_cast<ImoNote*>( pIModel->get_root() );
         CHECK( pNote != NULL );
-        CHECK( pNote->get_actual_accidentals() == k_flat );
+        CHECK( is_equal(pNote->get_actual_accidentals(), -1.0f) );
         CHECK( pNote->get_notated_accidentals() == k_no_accidentals );
         CHECK( pNote->get_dots() == 0 );
         CHECK( pNote->get_note_type() == k_eighth );
@@ -1862,7 +1862,7 @@ SUITE(MxlAnalyserTest)
         CHECK( pIModel->get_root()->is_note() == true );
         ImoNote* pNote = dynamic_cast<ImoNote*>( pIModel->get_root() );
         CHECK( pNote != NULL );
-        CHECK( pNote->get_actual_accidentals() == k_flat );
+        CHECK( is_equal(pNote->get_actual_accidentals(), -1.0f) );
         CHECK( pNote->get_notated_accidentals() == k_no_accidentals );
         CHECK( pNote->get_dots() == 0 );
         CHECK( pNote->get_note_type() == k_half );


### PR DESCRIPTION
It was a problem in MusicXML importer, with the &lt;alter&gt; element. The pitch for notes with accidentals was computed wrong. It is now fixed.
