### PR TITLE
Fix #82. MusicXML importer: midi information in score-part is ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Blank space in LDP exporter has been normalized.
 - LDP exporter reviewed for following the same syntax rules than LDP 
   Analyser, thus ensuring a round trip in LDP export-import.
+- Fixed issue #82. MusicXML importer now deals with all midi information
+  in score-part.
 - Fixed issue #77: The score and sound do not match
 - Fixed issue #68: Assume some default value for clef in MusicXML importer
 - Fixed issue #69: Playback very slow for 3/8 tempo

--- a/include/lomse_internal_model.h
+++ b/include/lomse_internal_model.h
@@ -86,7 +86,7 @@ class ImoImage;
 class ImoInlineLevelObj;
 class ImoInlineWrapper;
 class ImoInstrument;
-class ImoInstrInfo;
+class ImoSoundInfo;
 class ImoKeySignature;
 class ImoLineStyle;
 class ImoLink;
@@ -2391,7 +2391,7 @@ public:
 //---------------------------------------------------------------------------------------
 //The score-instrument element allows for multiple instruments per
 //score-part. Contains the information for an instrument in an score-part
-class ImoInstrInfo : public ImoSimpleObj
+class ImoSoundInfo : public ImoSimpleObj
 {
 protected:
 	string	m_id;
@@ -2419,6 +2419,7 @@ protected:
 	string	m_midiDeviceId;
 
 	//midi instrument
+	string m_midiName;  //name: ProgramName meta-events
 	int m_bank;			//bank: 0-16383 (MIDI 1-16,384)
     int m_channel;		//channel: 0-15 (MIDI 1-16)
     int m_program;		//patch: 0-127 (MIDI 1-128)
@@ -2437,7 +2438,7 @@ protected:
 
     friend class ImFactory;
     friend class ImoInstrument;
-    ImoInstrInfo()
+    ImoSoundInfo()
 		: ImoSimpleObj(k_imo_instr_info)
 		, m_instrName("")
 		, m_instrAbbrev("")
@@ -2449,6 +2450,7 @@ protected:
 		, m_virtualName("")
 		, m_port(0)
         , m_midiDeviceId("")
+        , m_midiName("")
 		, m_bank(0)
     	, m_channel(0)
     	, m_program(0)
@@ -2460,7 +2462,7 @@ protected:
 	}
 
 public:
-    virtual ~ImoInstrInfo() {}
+    virtual ~ImoSoundInfo() {}
 
     //getters
 	inline string& get_score_instr_id() { return 	m_id; }
@@ -2474,6 +2476,7 @@ public:
 	inline string& get_score_instr_virtual_name() { return m_virtualName; }
     inline int get_midi_port() { return m_port; }
     inline string& get_midi_device_id() { return m_midiDeviceId; }
+    inline string& get_midi_name() { return m_midiName; }
     inline int get_midi_bank() { return m_bank; }
     inline int get_midi_channel() { return m_channel; }
     inline int get_midi_program() { return m_program; }
@@ -2494,6 +2497,7 @@ public:
 	inline void set_score_instr_virtual_name(const string& value) { m_virtualName = value; }
     inline void set_midi_port(int value) { m_port = value; }
     inline void set_midi_device_id(const string& value) { m_midiDeviceId = value; }
+    inline void set_midi_name(const string& value) { m_midiName = value; }
     inline void set_midi_bank(int value) { m_bank = value; }
     inline void set_midi_channel(int value) { m_channel = value; }
     inline void set_midi_program(int value) { m_program = value; }
@@ -3319,7 +3323,7 @@ protected:
     ImoScore*       m_pScore;
     ImoScoreText    m_name;
     ImoScoreText    m_abbrev;
-	ImoInstrInfo	m_sound;
+	ImoSoundInfo	m_sound;
     string          m_partId;
     std::list<ImoStaffInfo*> m_staves;
     int             m_barlineLayout;        //enum EBarlineLayout
@@ -3340,8 +3344,7 @@ public:
     inline int get_num_staves() { return static_cast<int>(m_staves.size()); }
     inline ImoScoreText& get_name() { return m_name; }
     inline ImoScoreText& get_abbrev() { return m_abbrev; }
-    inline int get_midi_program() { return m_sound.get_midi_program(); }
-    inline int get_midi_channel() { return m_sound.get_midi_channel(); }
+    //inline ImoSoundInfo& get_instr_info() { return m_sound; }
     ImoMusicData* get_musicdata();
     ImoStaffInfo* get_staff(int iStaff);
     LUnits get_line_spacing_for_staff(int iStaff);
@@ -3355,12 +3358,52 @@ public:
     void set_name(const string& value);
     void set_abbrev(const string& value);
     void set_midi_info(ImoMidiInfo* pInfo);
-    void set_instr_info(ImoInstrInfo* pInfo);
-    void set_midi_instrument(int instr);
-    void set_midi_channel(int channel);
+    void set_instr_info(ImoSoundInfo* pInfo);
     void replace_staff_info(ImoStaffInfo* pInfo);
     inline void set_instr_id(const string& id) { m_partId = id; }
     inline void set_barline_layout(int value) { m_barlineLayout = value; }
+
+    //getters for ImoSoundInfo
+	inline string& get_score_instr_id() { return m_sound.get_score_instr_id(); }
+	inline string& get_score_instr_name() { return m_sound.get_score_instr_name(); }
+	inline string& get_score_instr_abbrev() { return m_sound.get_score_instr_abbrev(); }
+	inline string& get_score_instr_sound() { return m_sound.get_score_instr_sound(); }
+	inline bool	get_score_instr_solo() { return m_sound.get_score_instr_solo(); }
+	inline bool	get_score_instr_ensemble() { return m_sound.get_score_instr_ensemble(); }
+	inline int get_score_instr_ensemble_size() { return m_sound.get_score_instr_ensemble_size(); }
+	inline string& get_score_instr_virtual_library() { return m_sound.get_score_instr_virtual_library(); }
+	inline string& get_score_instr_virtual_name() { return m_sound.get_score_instr_virtual_name(); }
+    inline int get_midi_port() { return m_sound.get_midi_port(); }
+    inline string& get_midi_device_id() { return m_sound.get_midi_device_id(); }
+    inline string& get_midi_name() { return m_sound.get_midi_name(); }
+    inline int get_midi_bank() { return m_sound.get_midi_bank(); }
+    inline int get_midi_channel() { return m_sound.get_midi_channel(); }
+    inline int get_midi_program() { return m_sound.get_midi_program(); }
+    inline int get_midi_unpitched() { return m_sound.get_midi_unpitched(); }
+    inline float get_midi_volume() { return m_sound.get_midi_volume(); }
+    inline int get_midi_pan() { return m_sound.get_midi_pan(); }
+    inline int get_midi_elevation() { return m_sound.get_midi_elevation(); }
+
+    //setters for ImoSoundInfo
+    inline void set_score_instr_id(const string& value) { m_sound.set_score_instr_id(value); }
+	inline void set_score_instr_name(const string& value) { m_sound.set_score_instr_name(value); }
+	inline void set_score_instr_abbrev(const string& value) { m_sound.set_score_instr_abbrev(value); }
+	inline void set_score_instr_sound(const string& value) { m_sound.set_score_instr_sound(value); }
+	inline void set_score_instr_solo(bool value) { m_sound.set_score_instr_solo(value); }
+	inline void set_score_instr_ensemble(bool value) { m_sound.set_score_instr_ensemble(value); }
+	inline void set_score_instr_ensemble_size(int value) { m_sound.set_score_instr_ensemble_size(value); }
+	inline void set_score_instr_virtual_library(const string& value) { m_sound.set_score_instr_virtual_library(value); }
+	inline void set_score_instr_virtual_name(const string& value) { m_sound.set_score_instr_virtual_name(value); }
+    inline void set_midi_port(int value) { m_sound.set_midi_port(value); }
+    inline void set_midi_device_id(const string& value) { m_sound.set_midi_device_id(value); }
+    inline void set_midi_name(const string& value) { m_sound.set_midi_name(value); }
+    inline void set_midi_bank(int value) { m_sound.set_midi_bank(value); }
+    inline void set_midi_channel(int value) { m_sound.set_midi_channel(value); }
+    inline void set_midi_program(int value) { m_sound.set_midi_program(value); }
+    inline void set_midi_unpitched(int value) { m_sound.set_midi_unpitched(value); }
+    inline void set_midi_volume(float value) { m_sound.set_midi_volume(value); }
+    inline void set_midi_pan(int value) { m_sound.set_midi_pan(value); }
+    inline void set_midi_elevation(int value) { m_sound.set_midi_elevation(value); }
 
     //info
     inline bool has_name() { return m_name.get_text() != ""; }

--- a/include/lomse_internal_model.h
+++ b/include/lomse_internal_model.h
@@ -86,6 +86,7 @@ class ImoImage;
 class ImoInlineLevelObj;
 class ImoInlineWrapper;
 class ImoInstrument;
+class ImoInstrInfo;
 class ImoKeySignature;
 class ImoLineStyle;
 class ImoLink;
@@ -433,6 +434,7 @@ class ImoWrapperBox;
                 k_imo_cursor_info,
                 k_imo_figured_bass_info,
                 k_imo_instr_group,
+                k_imo_instr_info,
                 k_imo_line_style,
                 k_imo_lyrics_text_info,
                 k_imo_midi_info,
@@ -831,6 +833,7 @@ public:
     inline bool is_inline_wrapper() { return m_objtype == k_imo_inline_wrapper; }
     inline bool is_instrument() { return m_objtype == k_imo_instrument; }
     inline bool is_instr_group() { return m_objtype == k_imo_instr_group; }
+    inline bool is_instr_info() { return m_objtype == k_imo_instr_info; }
     inline bool is_key_signature() { return m_objtype == k_imo_key_signature; }
     inline bool is_line() { return m_objtype == k_imo_line; }
     inline bool is_line_style() { return m_objtype == k_imo_line_style; }
@@ -2360,23 +2363,144 @@ public:
 class ImoMidiInfo : public ImoSimpleObj
 {
 protected:
-    int m_instr;
-    int m_channel;
+    int m_channel;		//channel: 0-15 (MIDI 1-16)
+    int m_program;		//patch: 0-127 (MIDI 1-128)
 
     friend class ImFactory;
     friend class ImoInstrument;
-    ImoMidiInfo() : ImoSimpleObj(k_imo_midi_info) , m_instr(0) , m_channel(0) {}
+    ImoMidiInfo()
+		: ImoSimpleObj(k_imo_midi_info)
+    	, m_channel(0)
+    	, m_program(0)
+	{
+	}
 
 public:
     virtual ~ImoMidiInfo() {}
 
     //getters
-    inline int get_instrument() { return m_instr; }
-    inline int get_channel() { return m_channel; }
+    inline int get_midi_channel() { return m_channel; }
+    inline int get_midi_program() { return m_program; }
 
     //setters
-    inline void set_instrument(int value) { m_instr = value; }
-    inline void set_channel(int value) { m_channel = value; }
+    inline void set_midi_channel(int value) { m_channel = value; }
+    inline void set_midi_instrument(int value) { m_program = value; }
+
+};
+
+//---------------------------------------------------------------------------------------
+//The score-instrument element allows for multiple instruments per
+//score-part. Contains the information for an instrument in an score-part
+class ImoInstrInfo : public ImoSimpleObj
+{
+protected:
+	string	m_id;
+	string	m_instrName;		//not oriented to appearing printed on the score
+	string	m_instrAbbrev;		//not oriented to appearing printed on the score
+	string	m_instrSound;		//describes the default timbre of the score-instrument
+								//Allows playback to be shared more easily between
+								//applications and libraries.
+
+	//performance data: a solo instrument? or an ensemble?
+	bool	m_fSolo;			//performance by a solo instrument
+	bool	m_fEnsemble;		//performance by an ensemble
+	int		m_ensembleSize;		//if ensemble, the size of the section, or
+								//0 if the ensemble size is not specified.
+
+	//defines the specific virtual instrument used for sound.
+	string	m_virtualLibrary;		//virtual library name
+	string	m_virtualName;			//virtual instrument to use
+
+
+        //MIDI information
+
+	//midi device
+	int     m_port;			    //port: 0-15 (MIDI 1-16)
+	string	m_midiDeviceId;
+
+	//midi instrument
+	int m_bank;			//bank: 0-16383 (MIDI 1-16,384)
+    int m_channel;		//channel: 0-15 (MIDI 1-16)
+    int m_program;		//patch: 0-127 (MIDI 1-128)
+	int m_unpitched;	//pitch number for percussion: 1-128
+
+	//mixer information
+	float m_volume;		//channel volume: 0.0 (muted) to 1.0
+	int m_pan;			//degrees: -180 to 180.
+							// 0 = in front of the listener, centered
+							//-90 = hard left, 90 is hard right
+							//-180 and 180 = behind the listener, centered
+	int m_elevation;	//degrees: -90 to 90.
+							// 0 = listener level
+							// 90 = directly above
+							//-90 = directly below.
+
+    friend class ImFactory;
+    friend class ImoInstrument;
+    ImoInstrInfo()
+		: ImoSimpleObj(k_imo_instr_info)
+		, m_instrName("")
+		, m_instrAbbrev("")
+		, m_instrSound("")
+		, m_fSolo(false)
+		, m_fEnsemble(false)
+		, m_ensembleSize(0)
+		, m_virtualLibrary("")
+		, m_virtualName("")
+		, m_port(0)
+        , m_midiDeviceId("")
+		, m_bank(0)
+    	, m_channel(0)
+    	, m_program(0)
+		, m_unpitched(-1)
+		, m_volume(1.0)
+		, m_pan(0)
+		, m_elevation(0)
+	{
+	}
+
+public:
+    virtual ~ImoInstrInfo() {}
+
+    //getters
+	inline string& get_score_instr_id() { return 	m_id; }
+	inline string& get_score_instr_name() { return m_instrName; }
+	inline string& get_score_instr_abbrev() { return m_instrAbbrev; }
+	inline string& get_score_instr_sound() { return m_instrSound; }
+	inline bool	get_score_instr_solo() { return m_fSolo; }
+	inline bool	get_score_instr_ensemble() { return m_fEnsemble; }
+	inline int get_score_instr_ensemble_size() { return m_ensembleSize; }
+	inline string& get_score_instr_virtual_library() { return m_virtualLibrary; }
+	inline string& get_score_instr_virtual_name() { return m_virtualName; }
+    inline int get_midi_port() { return m_port; }
+    inline string& get_midi_device_id() { return m_midiDeviceId; }
+    inline int get_midi_bank() { return m_bank; }
+    inline int get_midi_channel() { return m_channel; }
+    inline int get_midi_program() { return m_program; }
+    inline int get_midi_unpitched() { return m_unpitched; }
+    inline float get_midi_volume() { return m_volume; }
+    inline int get_midi_pan() { return m_pan; }
+    inline int get_midi_elevation() { return m_elevation; }
+
+    //setters
+    inline void set_score_instr_id(const string& value) { m_id = value; }
+	inline void set_score_instr_name(const string& value) { m_instrName = value; }
+	inline void set_score_instr_abbrev(const string& value) { m_instrAbbrev = value; }
+	inline void set_score_instr_sound(const string& value) { m_instrSound = value; }
+	inline void set_score_instr_solo(bool value) { m_fSolo = value; }
+	inline void set_score_instr_ensemble(bool value) { m_fEnsemble = value; }
+	inline void set_score_instr_ensemble_size(int value) { m_ensembleSize = value; }
+	inline void set_score_instr_virtual_library(const string& value) { m_virtualLibrary = value; }
+	inline void set_score_instr_virtual_name(const string& value) { m_virtualName = value; }
+    inline void set_midi_port(int value) { m_port = value; }
+    inline void set_midi_device_id(const string& value) { m_midiDeviceId = value; }
+    inline void set_midi_bank(int value) { m_bank = value; }
+    inline void set_midi_channel(int value) { m_channel = value; }
+    inline void set_midi_program(int value) { m_program = value; }
+    inline void set_midi_unpitched(int value) { m_unpitched = value; }
+    inline void set_midi_volume(float value) { m_volume = value; }
+    inline void set_midi_pan(int value) { m_pan = value; }
+    inline void set_midi_elevation(int value) { m_elevation = value; }
 
 };
 
@@ -3195,7 +3319,7 @@ protected:
     ImoScore*       m_pScore;
     ImoScoreText    m_name;
     ImoScoreText    m_abbrev;
-    ImoMidiInfo     m_midi;
+	ImoInstrInfo	m_sound;
     string          m_partId;
     std::list<ImoStaffInfo*> m_staves;
     int             m_barlineLayout;        //enum EBarlineLayout
@@ -3216,8 +3340,8 @@ public:
     inline int get_num_staves() { return static_cast<int>(m_staves.size()); }
     inline ImoScoreText& get_name() { return m_name; }
     inline ImoScoreText& get_abbrev() { return m_abbrev; }
-    inline int get_instrument() { return m_midi.get_instrument(); }
-    inline int get_channel() { return m_midi.get_channel(); }
+    inline int get_midi_program() { return m_sound.get_midi_program(); }
+    inline int get_midi_channel() { return m_sound.get_midi_channel(); }
     ImoMusicData* get_musicdata();
     ImoStaffInfo* get_staff(int iStaff);
     LUnits get_line_spacing_for_staff(int iStaff);
@@ -3231,6 +3355,7 @@ public:
     void set_name(const string& value);
     void set_abbrev(const string& value);
     void set_midi_info(ImoMidiInfo* pInfo);
+    void set_instr_info(ImoInstrInfo* pInfo);
     void set_midi_instrument(int instr);
     void set_midi_channel(int channel);
     void replace_staff_info(ImoStaffInfo* pInfo);
@@ -3264,10 +3389,11 @@ public:
                                                ostream& reporter);
 
 protected:
-    //FIX: For lyrics space
     friend class LdpAnalyser;
     friend class MxlAnalyser;
     friend class InstrumentAnalyser;
+
+    //FIX: For lyrics space
     void reserve_space_for_lyrics(int iStaff, LUnits space);
 
 };

--- a/include/lomse_internal_model.h
+++ b/include/lomse_internal_model.h
@@ -2384,7 +2384,7 @@ public:
 
     //setters
     inline void set_midi_channel(int value) { m_channel = value; }
-    inline void set_midi_instrument(int value) { m_program = value; }
+    inline void set_midi_program(int value) { m_program = value; }
 
 };
 
@@ -2416,7 +2416,7 @@ protected:
 
 	//midi device
 	int     m_port;			    //port: 0-15 (MIDI 1-16)
-	string	m_midiDeviceId;
+    string  m_midiDeviceName;   //DeviceName meta event
 
 	//midi instrument
 	string m_midiName;  //name: ProgramName meta-events
@@ -2449,7 +2449,7 @@ protected:
 		, m_virtualLibrary("")
 		, m_virtualName("")
 		, m_port(0)
-        , m_midiDeviceId("")
+        , m_midiDeviceName("")
         , m_midiName("")
 		, m_bank(0)
     	, m_channel(0)
@@ -2475,7 +2475,7 @@ public:
 	inline string& get_score_instr_virtual_library() { return m_virtualLibrary; }
 	inline string& get_score_instr_virtual_name() { return m_virtualName; }
     inline int get_midi_port() { return m_port; }
-    inline string& get_midi_device_id() { return m_midiDeviceId; }
+    inline string& get_midi_device_name() { return m_midiDeviceName; }
     inline string& get_midi_name() { return m_midiName; }
     inline int get_midi_bank() { return m_bank; }
     inline int get_midi_channel() { return m_channel; }
@@ -2496,7 +2496,7 @@ public:
 	inline void set_score_instr_virtual_library(const string& value) { m_virtualLibrary = value; }
 	inline void set_score_instr_virtual_name(const string& value) { m_virtualName = value; }
     inline void set_midi_port(int value) { m_port = value; }
-    inline void set_midi_device_id(const string& value) { m_midiDeviceId = value; }
+    inline void set_midi_device_name(const string& value) { m_midiDeviceName = value; }
     inline void set_midi_name(const string& value) { m_midiName = value; }
     inline void set_midi_bank(int value) { m_bank = value; }
     inline void set_midi_channel(int value) { m_channel = value; }
@@ -3374,7 +3374,7 @@ public:
 	inline string& get_score_instr_virtual_library() { return m_sound.get_score_instr_virtual_library(); }
 	inline string& get_score_instr_virtual_name() { return m_sound.get_score_instr_virtual_name(); }
     inline int get_midi_port() { return m_sound.get_midi_port(); }
-    inline string& get_midi_device_id() { return m_sound.get_midi_device_id(); }
+    inline string& get_midi_device_name() { return m_sound.get_midi_device_name(); }
     inline string& get_midi_name() { return m_sound.get_midi_name(); }
     inline int get_midi_bank() { return m_sound.get_midi_bank(); }
     inline int get_midi_channel() { return m_sound.get_midi_channel(); }
@@ -3395,7 +3395,7 @@ public:
 	inline void set_score_instr_virtual_library(const string& value) { m_sound.set_score_instr_virtual_library(value); }
 	inline void set_score_instr_virtual_name(const string& value) { m_sound.set_score_instr_virtual_name(value); }
     inline void set_midi_port(int value) { m_sound.set_midi_port(value); }
-    inline void set_midi_device_id(const string& value) { m_sound.set_midi_device_id(value); }
+    inline void set_midi_device_name(const string& value) { m_sound.set_midi_device_name(value); }
     inline void set_midi_name(const string& value) { m_sound.set_midi_name(value); }
     inline void set_midi_bank(int value) { m_sound.set_midi_bank(value); }
     inline void set_midi_channel(int value) { m_sound.set_midi_channel(value); }

--- a/include/lomse_linker.h
+++ b/include/lomse_linker.h
@@ -49,7 +49,7 @@ class ImoFontStyleDto;
 class ImoInlineLevelObj;
 class ImoInstrGroup;
 class ImoInstrument;
-class ImoInstrInfo;
+class ImoSoundInfo;
 class ImoListItem;
 class ImoMidiInfo;
 class ImoObj;
@@ -94,7 +94,7 @@ protected:
     ImoObj* add_cursor(ImoCursorInfo* pCursor);
     ImoObj* add_listitem(ImoListItem* pItem);
     ImoObj* add_midi_info(ImoMidiInfo* pInfo);
-    ImoObj* add_instr_info(ImoInstrInfo* pInfo);
+    ImoObj* add_instr_info(ImoSoundInfo* pInfo);
     ImoObj* add_param_info(ImoParamInfo* pParam);
     ImoObj* add_staff_info(ImoStaffInfo* pInfo);
     ImoObj* add_instrument(ImoInstrument* pInstrument);

--- a/include/lomse_linker.h
+++ b/include/lomse_linker.h
@@ -49,6 +49,7 @@ class ImoFontStyleDto;
 class ImoInlineLevelObj;
 class ImoInstrGroup;
 class ImoInstrument;
+class ImoInstrInfo;
 class ImoListItem;
 class ImoMidiInfo;
 class ImoObj;
@@ -93,6 +94,7 @@ protected:
     ImoObj* add_cursor(ImoCursorInfo* pCursor);
     ImoObj* add_listitem(ImoListItem* pItem);
     ImoObj* add_midi_info(ImoMidiInfo* pInfo);
+    ImoObj* add_instr_info(ImoInstrInfo* pInfo);
     ImoObj* add_param_info(ImoParamInfo* pParam);
     ImoObj* add_staff_info(ImoStaffInfo* pInfo);
     ImoObj* add_instrument(ImoInstrument* pInstrument);

--- a/src/document/lomse_command.cpp
+++ b/src/document/lomse_command.cpp
@@ -2527,7 +2527,7 @@ int CmdMoveObjectPoint::perform_action(Document* pDoc, DocCursor* UNUSED(pCursor
         ImoInstrument* pInstr = pNote->get_instrument();
         int iStaff = pNote->get_staff();
         ImoScore* pScore = pInstr->get_score();
-        int iInstr = pInstr->get_instrument();
+        int iInstr = pScore->get_instr_number_for(pInstr);
         ScoreMeter meter(pScore);
         TPoint pos(m_oldPos.x + meter.logical_to_tenths(m_shift.x, iInstr, iStaff),
                    m_oldPos.y + meter.logical_to_tenths(m_shift.y, iInstr, iStaff) );

--- a/src/exporters/lomse_ldp_exporter.cpp
+++ b/src/exporters/lomse_ldp_exporter.cpp
@@ -1087,8 +1087,8 @@ protected:
 
     void add_midi_info()
     {
-        int instr = m_pObj->get_instrument();
-        int channel = m_pObj->get_channel();
+        int instr = m_pObj->get_midi_program();
+        int channel = m_pObj->get_midi_channel();
         if (instr != 0 || channel != 0)
         {
             start_element("infoMIDI", k_no_imoid);

--- a/src/internal_model/lomse_im_factory.cpp
+++ b/src/internal_model/lomse_im_factory.cpp
@@ -78,7 +78,7 @@ ImoObj* ImFactory::inject(int type, Document* pDoc, ImoId id)
         case k_imo_image:               pObj = LOMSE_NEW ImoImage();              break;
         case k_imo_inline_wrapper:      pObj = LOMSE_NEW ImoInlineWrapper();      break;
         case k_imo_instr_group:         pObj = LOMSE_NEW ImoInstrGroup();         break;
-        case k_imo_instr_info:          pObj = LOMSE_NEW ImoInstrInfo();          break;
+        case k_imo_instr_info:          pObj = LOMSE_NEW ImoSoundInfo();          break;
         case k_imo_instrument:          pObj = LOMSE_NEW ImoInstrument();         break;
         case k_imo_instruments:         pObj = LOMSE_NEW ImoInstruments();        break;
         case k_imo_instrument_groups:   pObj = LOMSE_NEW ImoInstrGroups();        break;

--- a/src/internal_model/lomse_im_factory.cpp
+++ b/src/internal_model/lomse_im_factory.cpp
@@ -78,6 +78,7 @@ ImoObj* ImFactory::inject(int type, Document* pDoc, ImoId id)
         case k_imo_image:               pObj = LOMSE_NEW ImoImage();              break;
         case k_imo_inline_wrapper:      pObj = LOMSE_NEW ImoInlineWrapper();      break;
         case k_imo_instr_group:         pObj = LOMSE_NEW ImoInstrGroup();         break;
+        case k_imo_instr_info:          pObj = LOMSE_NEW ImoInstrInfo();          break;
         case k_imo_instrument:          pObj = LOMSE_NEW ImoInstrument();         break;
         case k_imo_instruments:         pObj = LOMSE_NEW ImoInstruments();        break;
         case k_imo_instrument_groups:   pObj = LOMSE_NEW ImoInstrGroups();        break;

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -2155,7 +2155,7 @@ void ImoInstrument::set_abbrev(const string& value)
 }
 
 //---------------------------------------------------------------------------------------
-void ImoInstrument::set_instr_info(ImoInstrInfo* pInfo)
+void ImoInstrument::set_instr_info(ImoSoundInfo* pInfo)
 {
     m_sound = *pInfo;
     delete pInfo;
@@ -2167,18 +2167,6 @@ void ImoInstrument::set_midi_info(ImoMidiInfo* pInfo)
     m_sound.set_midi_channel(pInfo->get_midi_channel());
     m_sound.set_midi_program(pInfo->get_midi_program());
     delete pInfo;
-}
-
-//---------------------------------------------------------------------------------------
-void ImoInstrument::set_midi_instrument(int instr)
-{
-    m_sound.set_midi_program(instr);
-}
-
-//---------------------------------------------------------------------------------------
-void ImoInstrument::set_midi_channel(int channel)
-{
-    m_sound.set_midi_channel(channel);
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -2145,12 +2145,24 @@ void ImoInstrument::set_abbrev(ImoScoreText* pText)
 //---------------------------------------------------------------------------------------
 void ImoInstrument::set_name(const string& value)
 {
+    if (!m_name.get_document())
+    {
+        Document* pDoc = get_the_document();
+        m_name.set_owner_document(pDoc);
+    }
+
     m_name.set_text(value);
 }
 
 //---------------------------------------------------------------------------------------
 void ImoInstrument::set_abbrev(const string& value)
 {
+    if (!m_abbrev.get_document())
+    {
+        Document* pDoc = get_the_document();
+        m_abbrev.set_owner_document(pDoc);
+    }
+
     m_abbrev.set_text(value);
 }
 

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -360,6 +360,7 @@ const string& ImoObj::get_name(int type)
         m_TypeToName[k_imo_figured_bass_info] = "figured-bass";
         m_TypeToName[k_imo_font_style_dto] = "font-style";
         m_TypeToName[k_imo_instr_group] = "instr-group";
+        m_TypeToName[k_imo_instr_info] = "instr-info";
         m_TypeToName[k_imo_line_style] = "line-style";
         m_TypeToName[k_imo_lyrics_text_info] = "lyric-text";
         m_TypeToName[k_imo_midi_info] = "midi-info";
@@ -2083,7 +2084,7 @@ ImoInstrument::ImoInstrument()
     , m_pScore(NULL)
     , m_name()
     , m_abbrev()
-    , m_midi()
+    , m_sound()
 //    , m_pGroup(NULL)
     , m_partId("")
     , m_barlineLayout(k_isolated)
@@ -2154,22 +2155,30 @@ void ImoInstrument::set_abbrev(const string& value)
 }
 
 //---------------------------------------------------------------------------------------
+void ImoInstrument::set_instr_info(ImoInstrInfo* pInfo)
+{
+    m_sound = *pInfo;
+    delete pInfo;
+}
+
+//---------------------------------------------------------------------------------------
 void ImoInstrument::set_midi_info(ImoMidiInfo* pInfo)
 {
-    m_midi = *pInfo;
+    m_sound.set_midi_channel(pInfo->get_midi_channel());
+    m_sound.set_midi_program(pInfo->get_midi_program());
     delete pInfo;
 }
 
 //---------------------------------------------------------------------------------------
 void ImoInstrument::set_midi_instrument(int instr)
 {
-    m_midi.set_instrument(instr);
+    m_sound.set_midi_program(instr);
 }
 
 //---------------------------------------------------------------------------------------
 void ImoInstrument::set_midi_channel(int channel)
 {
-    m_midi.set_channel(channel);
+    m_sound.set_midi_channel(channel);
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/parser/ldp/lomse_ldp_analyser.cpp
+++ b/src/parser/ldp/lomse_ldp_analyser.cpp
@@ -2808,7 +2808,7 @@ public:
                             ImFactory::inject(k_imo_midi_info, pDoc, get_node_id()) );
 
         // num_instr
-        if (!get_optional(k_number) || !set_midi_instrument(pInfo))
+        if (!get_optional(k_number) || !set_midi_program(pInfo))
         {
             error_msg("Missing or invalid MIDI instrument (0..127). MIDI info ignored.");
             delete pInfo;
@@ -2829,13 +2829,13 @@ public:
 
 protected:
 
-    bool set_midi_instrument(ImoMidiInfo* pInfo)
+    bool set_midi_program(ImoMidiInfo* pInfo)
     {
         int value = get_integer_value(0);
         if (value < 0 || value > 127)
             return false;   //error
 
-        pInfo->set_midi_instrument(value);
+        pInfo->set_midi_program(value);
         return true;
     }
 

--- a/src/parser/ldp/lomse_ldp_analyser.cpp
+++ b/src/parser/ldp/lomse_ldp_analyser.cpp
@@ -2791,7 +2791,7 @@ protected:
 
 //@--------------------------------------------------------------------------------------
 //@ <infoMIDI> = (infoMIDI num_instr [num_channel])
-//@ num_instr = integer: 0..255
+//@ num_instr = integer: 0..127
 //@ num_channel = integer: 0..15
 
 class InfoMidiAnalyser : public ElementAnalyser
@@ -2808,15 +2808,15 @@ public:
                             ImFactory::inject(k_imo_midi_info, pDoc, get_node_id()) );
 
         // num_instr
-        if (!get_optional(k_number) || !set_instrument(pInfo))
+        if (!get_optional(k_number) || !set_midi_instrument(pInfo))
         {
-            error_msg("Missing or invalid MIDI instrument (0..255). MIDI info ignored.");
+            error_msg("Missing or invalid MIDI instrument (0..127). MIDI info ignored.");
             delete pInfo;
             return;
         }
 
         // [num_channel]
-        if (get_optional(k_number) && !set_channel(pInfo))
+        if (get_optional(k_number) && !set_midi_channel(pInfo))
         {
             report_msg(m_pAnalysedNode->get_line_number(),
                         "Invalid MIDI channel (0..15). Channel info ignored.");
@@ -2829,23 +2829,23 @@ public:
 
 protected:
 
-    bool set_instrument(ImoMidiInfo* pInfo)
+    bool set_midi_instrument(ImoMidiInfo* pInfo)
     {
         int value = get_integer_value(0);
-        if (value < 0 || value > 255)
+        if (value < 0 || value > 127)
             return false;   //error
 
-        pInfo->set_instrument(value);
+        pInfo->set_midi_instrument(value);
         return true;
     }
 
-    bool set_channel(ImoMidiInfo* pInfo)
+    bool set_midi_channel(ImoMidiInfo* pInfo)
     {
         int value = get_integer_value(0);
         if (value < 0 || value > 15)
             return false;   //error
 
-        pInfo->set_channel(value);
+        pInfo->set_midi_channel(value);
         return true;
     }
 
@@ -6423,7 +6423,7 @@ void LdpAnalyser::add_marging_space_for_lyrics(ImoNote* pNote, ImoLyric* pLyric)
             //AWARE: If m_fInstrIdRequired==true all instruments are already created
             if (m_fInstrIdRequired)
             {
-                int iInstr = pInstr->get_instrument() + 1;
+                int iInstr = m_pCurScore->get_instr_number_for(pInstr) + 1;
                 if (iInstr < m_pCurScore->get_num_instruments())
                 {
                     pInstr = m_pCurScore->get_instrument(iInstr);

--- a/src/parser/lmd/lomse_lmd_analyser.cpp
+++ b/src/parser/lmd/lomse_lmd_analyser.cpp
@@ -2341,15 +2341,15 @@ public:
                                     ImFactory::inject(k_imo_midi_info, pDoc) );
 
         // num_instr
-        if (!get_optional(k_number) || !set_instrument(pInfo))
+        if (!get_optional(k_number) || !set_midi_instrument(pInfo))
         {
-            error_msg("Missing or invalid MIDI instrument (0..255). MIDI info ignored.");
+            error_msg("Missing or invalid MIDI instrument (0..127). MIDI info ignored.");
             delete pInfo;
             return NULL;
         }
 
         // [num_channel]
-        if (get_optional(k_number) && !set_channel(pInfo))
+        if (get_optional(k_number) && !set_midi_channel(pInfo))
         {
             report_msg(m_pAnalyser->get_line_number(&m_analysedNode),
                         "Invalid MIDI channel (0..15). Channel info ignored.");
@@ -2363,23 +2363,23 @@ public:
 
 protected:
 
-    bool set_instrument(ImoMidiInfo* pInfo)
+    bool set_midi_instrument(ImoMidiInfo* pInfo)
     {
         int value = get_integer_value(0);
-        if (value < 0 || value > 255)
+        if (value < 0 || value > 127)
             return false;   //error
 
-        pInfo->set_instrument(value);
+        pInfo->set_midi_instrument(value);
         return true;
     }
 
-    bool set_channel(ImoMidiInfo* pInfo)
+    bool set_midi_channel(ImoMidiInfo* pInfo)
     {
         int value = get_integer_value(0);
         if (value < 0 || value > 15)
             return false;   //error
 
-        pInfo->set_channel(value);
+        pInfo->set_midi_channel(value);
         return true;
     }
 

--- a/src/parser/lmd/lomse_lmd_analyser.cpp
+++ b/src/parser/lmd/lomse_lmd_analyser.cpp
@@ -2341,7 +2341,7 @@ public:
                                     ImFactory::inject(k_imo_midi_info, pDoc) );
 
         // num_instr
-        if (!get_optional(k_number) || !set_midi_instrument(pInfo))
+        if (!get_optional(k_number) || !set_midi_program(pInfo))
         {
             error_msg("Missing or invalid MIDI instrument (0..127). MIDI info ignored.");
             delete pInfo;
@@ -2363,13 +2363,13 @@ public:
 
 protected:
 
-    bool set_midi_instrument(ImoMidiInfo* pInfo)
+    bool set_midi_program(ImoMidiInfo* pInfo)
     {
         int value = get_integer_value(0);
         if (value < 0 || value > 127)
             return false;   //error
 
-        pInfo->set_midi_instrument(value);
+        pInfo->set_midi_program(value);
         return true;
     }
 

--- a/src/parser/lomse_linker.cpp
+++ b/src/parser/lomse_linker.cpp
@@ -80,7 +80,7 @@ ImoObj* Linker::add_child_to_model(ImoObj* pParent, ImoObj* pChild, int ldpChild
             return add_midi_info(static_cast<ImoMidiInfo*>(pChild));
 
         case k_imo_instr_info:
-            return add_instr_info(static_cast<ImoInstrInfo*>(pChild));
+            return add_instr_info(static_cast<ImoSoundInfo*>(pChild));
 
         case k_imo_music_data:
             return add_child(k_imo_instrument, pChild);
@@ -314,7 +314,7 @@ ImoObj* Linker::add_midi_info(ImoMidiInfo* pInfo)
 }
 
 //---------------------------------------------------------------------------------------
-ImoObj* Linker::add_instr_info(ImoInstrInfo* pInfo)
+ImoObj* Linker::add_instr_info(ImoSoundInfo* pInfo)
 {
     if (m_pParent && m_pParent->is_instrument())
     {

--- a/src/parser/lomse_linker.cpp
+++ b/src/parser/lomse_linker.cpp
@@ -79,6 +79,9 @@ ImoObj* Linker::add_child_to_model(ImoObj* pParent, ImoObj* pChild, int ldpChild
         case k_imo_midi_info:
             return add_midi_info(static_cast<ImoMidiInfo*>(pChild));
 
+        case k_imo_instr_info:
+            return add_instr_info(static_cast<ImoInstrInfo*>(pChild));
+
         case k_imo_music_data:
             return add_child(k_imo_instrument, pChild);
 
@@ -305,6 +308,18 @@ ImoObj* Linker::add_midi_info(ImoMidiInfo* pInfo)
     {
         ImoInstrument* pInstr = static_cast<ImoInstrument*>(m_pParent);
         pInstr->set_midi_info(pInfo);
+        return NULL;
+    }
+    return pInfo;
+}
+
+//---------------------------------------------------------------------------------------
+ImoObj* Linker::add_instr_info(ImoInstrInfo* pInfo)
+{
+    if (m_pParent && m_pParent->is_instrument())
+    {
+        ImoInstrument* pInstr = static_cast<ImoInstrument*>(m_pParent);
+        pInstr->set_instr_info(pInfo);
         return NULL;
     }
     return pInfo;

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -2647,6 +2647,69 @@ protected:
 
 };
 
+//@--------------------------------------------------------------------------------------
+//@ <infoMIDI> = (infoMIDI num_instr [num_channel])
+//@ num_instr = integer: 0..255
+//@ num_channel = integer: 0..15
+
+class MidiInstrumentMxlAnalyser : public MxlElementAnalyser
+{
+public:
+    MidiInstrumentMxlAnalyser(MxlAnalyser* pAnalyser, ostream& reporter,
+                              LibraryScope& libraryScope, ImoObj* pAnchor)
+        : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
+
+
+    ImoObj* do_analysis()
+    {
+//        Document* pDoc = m_pAnalyser->get_document_being_analysed();
+//        ImoMidiInfo* pInfo = static_cast<ImoMidiInfo*>(
+//                            ImFactory::inject(k_imo_midi_info, pDoc) );
+//
+//        // num_instr
+//        if (!get_optional(k_number) || !set_midi_instrument(pInfo))
+//        {
+//            error_msg("Missing or invalid MIDI instrument (1..128). MIDI info ignored.");
+//            delete pInfo;
+//            return;
+//        }
+//
+//        // [num_channel]
+//        if (get_optional(k_number) && !set_midi_channel(pInfo))
+//        {
+//            report_msg(m_pAnalysedNode->get_line_number(),
+//                        "Invalid MIDI channel (1..16). Channel info ignored.");
+//        }
+//
+//        error_if_more_elements();
+//
+//        add_to_model(pInfo);
+        return NULL;
+    }
+
+protected:
+
+    bool set_midi_instrument(ImoMidiInfo* pInfo)
+    {
+        int value = get_integer_value(0);
+        if (value < 1 || value > 128)
+            return false;   //error
+
+        pInfo->set_midi_instrument(value-1);
+        return true;
+    }
+
+    bool set_midi_channel(ImoMidiInfo* pInfo)
+    {
+        int value = get_integer_value(1);
+        if (value < 1 || value > 16)
+            return false;   //error
+
+        pInfo->set_midi_channel(value-1);
+        return true;
+    }
+
+};
 
 //@--------------------------------------------------------------------------------------
 //@ <!ELEMENT notations
@@ -3906,27 +3969,13 @@ public:
             ;   //TODO <score-instrument>
 
         // { [<midi-device>][<midi-instrument>] }*
-        while (get_optional("midi-instrument"))
+        while (get_optional("midi-device") || get_optional("midi-instrument") )
         {
-            //TODO: Are these the children? See Saltarello.xml
+            // [<midi-device>]
+            analyse_optional("midi-device", pInstrument);
 
-//            // [<midi-device>]
-//            analyse_optional("midi-device", pInstrument);
-//
-//            // [<midi-instrument>]
-//            analyse_optional("midi-instrument", pInstrument);
-//
-//            // [<midi-channel>]
-//            get_optional("midi-channel");   //TODO <midi-channel>
-//
-//            // [<midi-program>]
-//            get_optional("midi-program");   //TODO <midi-program>
-//
-//            // [<volume>]
-//            get_optional("volume");   //TODO <volume>
-//
-//            // [<pan>]
-//            get_optional("pan");   //TODO <pan>
+            // [<midi-instrument>]
+            analyse_optional("midi-instrument", pInstrument);
         }
 
         error_if_more_elements();
@@ -5216,7 +5265,7 @@ void MxlAnalyser::add_marging_space_for_lyrics(ImoNote* pNote, ImoLyric* pLyric)
         {
             //add space to top margin of first staff in next instrument
             //AWARE: All instruments are already created
-            int iInstr = pInstr->get_instrument() + 1;
+            int iInstr = m_pCurScore->get_instr_number_for(pInstr) + 1;
             if (iInstr < m_pCurScore->get_num_instruments())
             {
                 pInstr = m_pCurScore->get_instrument(iInstr);

--- a/src/sound/lomse_midi_table.cpp
+++ b/src/sound/lomse_midi_table.cpp
@@ -110,9 +110,9 @@ void SoundEventsTable::program_sounds_for_instruments()
     for (int iInstr = 0; iInstr < numInstruments; iInstr++)
     {
         ImoInstrument* pInstr = m_pScore->get_instrument(iInstr);
-        int channel = pInstr->get_channel();
+        int channel = pInstr->get_midi_channel();
         m_channels[iInstr] = channel;
-        int instr = pInstr->get_instrument();
+        int instr = pInstr->get_midi_program();
         store_event(0, SoundEvent::k_prog_instr, channel, instr, 0, 0, NULL, 0);
     }
 }

--- a/src/tests/lomse_test_ldp_analyser.cpp
+++ b/src/tests/lomse_test_ldp_analyser.cpp
@@ -3229,7 +3229,7 @@ SUITE(LdpAnalyserTest)
         Document doc(m_libraryScope);
         LdpParser parser(errormsg, m_libraryScope.ldp_factory());
         stringstream expected;
-        expected << "Line 0. Missing or invalid MIDI instrument (0..255). MIDI info ignored." << endl;
+        expected << "Line 0. Missing or invalid MIDI instrument (0..127). MIDI info ignored." << endl;
         parser.parse_text("(infoMIDI piano 1)");
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
@@ -3252,7 +3252,7 @@ SUITE(LdpAnalyserTest)
         Document doc(m_libraryScope);
         LdpParser parser(errormsg, m_libraryScope.ldp_factory());
         stringstream expected;
-        expected << "Line 0. Missing or invalid MIDI instrument (0..255). MIDI info ignored." << endl;
+        expected << "Line 0. Missing or invalid MIDI instrument (0..127). MIDI info ignored." << endl;
         parser.parse_text("(infoMIDI 315 1)");
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
@@ -3288,8 +3288,8 @@ SUITE(LdpAnalyserTest)
         CHECK( pIModel->get_root()->is_midi_info() == true );
         ImoMidiInfo* pInfo = dynamic_cast<ImoMidiInfo*>( pIModel->get_root() );
         CHECK( pInfo != NULL );
-        CHECK( pInfo->get_channel() == 0 );
-        CHECK( pInfo->get_instrument() == 56 );
+        CHECK( pInfo->get_midi_channel() == 0 );
+        CHECK( pInfo->get_midi_program() == 56 );
 
         delete tree->get_root();
         delete pIModel;
@@ -3313,8 +3313,8 @@ SUITE(LdpAnalyserTest)
 
         ImoMidiInfo* pInfo = dynamic_cast<ImoMidiInfo*>( pIModel->get_root() );
         CHECK( pInfo != NULL );
-        CHECK( pInfo->get_channel() == 0 );
-        CHECK( pInfo->get_instrument() == 56 );
+        CHECK( pInfo->get_midi_channel() == 0 );
+        CHECK( pInfo->get_midi_program() == 56 );
 
         delete tree->get_root();
         delete pIModel;
@@ -3338,8 +3338,8 @@ SUITE(LdpAnalyserTest)
 
         ImoMidiInfo* pInfo = dynamic_cast<ImoMidiInfo*>( pIModel->get_root() );
         CHECK( pInfo != NULL );
-        CHECK( pInfo->get_channel() == 10 );
-        CHECK( pInfo->get_instrument() == 56 );
+        CHECK( pInfo->get_midi_channel() == 10 );
+        CHECK( pInfo->get_midi_program() == 56 );
 
         delete tree->get_root();
         delete pIModel;
@@ -3366,8 +3366,8 @@ SUITE(LdpAnalyserTest)
         CHECK( pInstr->get_num_staves() == 1 );
         CHECK( pInstr->get_name().get_text() == "" );
         CHECK( pInstr->get_abbrev().get_text() == "" );
-        CHECK( pInstr->get_channel() == 12 );
-        CHECK( pInstr->get_instrument() == 56 );
+        CHECK( pInstr->get_midi_channel() == 12 );
+        CHECK( pInstr->get_midi_program() == 56 );
 
         delete tree->get_root();
         delete pIModel;

--- a/src/tests/lomse_test_mxl_analyser.cpp
+++ b/src/tests/lomse_test_mxl_analyser.cpp
@@ -2049,6 +2049,247 @@ SUITE(MxlAnalyserTest)
 //    }
 
 
+    //@ midi-instrument -----------------------------------------------------------------
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, midi_instrument_01)
+    {
+        //@01. midi_instrument
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        //expected << "Line 0. <score-partwise>: missing mandatory element <part>." << endl;
+        parser.parse_text(
+            "<score-partwise version='3.0'><part-list><score-part id='P1'>"
+                "<part-name>Music</part-name>"
+                "<midi-instrument id='P1'>"
+                    "<midi-channel>1</midi-channel>"
+                    "<midi-program>56</midi-program>"
+                "</midi-instrument>"
+            "</score-part></part-list><part id='P1'></part></score-partwise>");
+        MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pIModel->get_root() != NULL);
+        CHECK( pIModel->get_root()->is_document() == true );
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pIModel->get_root() );
+        CHECK( pDoc != NULL );
+        CHECK( pDoc->get_num_content_items() == 1 );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore != NULL );
+        CHECK( pScore->get_num_instruments() == 1 );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        CHECK( pInstr != NULL );
+        CHECK( pInstr->get_midi_channel() == 0 );
+        CHECK( pInstr->get_midi_program() == 56 );
+        cout << test_name() << endl;
+        cout << "midi: channel= " << pInstr->get_midi_channel()
+             << ", program= " << pInstr->get_midi_program() << endl;
+
+        delete pIModel;
+    }
+
+//    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_MidiInfo_InstrErrorValue)
+//    {
+//        stringstream errormsg;
+//        Document doc(m_libraryScope);
+//        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+//        stringstream expected;
+//        expected << "Line 0. Missing or invalid MIDI instrument (0..255). MIDI info ignored." << endl;
+//        parser.parse_text("(infoMIDI piano 1)");
+//        LdpTree* tree = parser.get_ldp_tree();
+//        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+//        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+//
+//        //cout << "[" << errormsg.str() << "]" << endl;
+//        //cout << "[" << expected.str() << "]" << endl;
+//        CHECK( errormsg.str() == expected.str() );
+//
+//        ImoMidiInfo* pInfo = dynamic_cast<ImoMidiInfo*>( pIModel->get_root() );
+//        CHECK( pInfo == NULL );
+//
+//        delete tree->get_root();
+//        delete pIModel;
+//    }
+//
+//    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_MidiInfo_InstrErrorRange)
+//    {
+//        stringstream errormsg;
+//        Document doc(m_libraryScope);
+//        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+//        stringstream expected;
+//        expected << "Line 0. Missing or invalid MIDI instrument (0..255). MIDI info ignored." << endl;
+//        parser.parse_text("(infoMIDI 315 1)");
+//        LdpTree* tree = parser.get_ldp_tree();
+//        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+//        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+//
+//        //cout << "[" << errormsg.str() << "]" << endl;
+//        //cout << "[" << expected.str() << "]" << endl;
+//        CHECK( errormsg.str() == expected.str() );
+//
+//        ImoMidiInfo* pInfo = dynamic_cast<ImoMidiInfo*>( pIModel->get_root() );
+//        CHECK( pInfo == NULL );
+//
+//        delete tree->get_root();
+//        delete pIModel;
+//    }
+//
+//    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_MidiInfo_InstrumentOk)
+//    {
+//        stringstream errormsg;
+//        Document doc(m_libraryScope);
+//        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+//        stringstream expected;
+//        //expected << "Line 0. " << endl;
+//        parser.parse_text("(infoMIDI 56)");
+//        LdpTree* tree = parser.get_ldp_tree();
+//        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+//        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+//
+//        //cout << "[" << errormsg.str() << "]" << endl;
+//        //cout << "[" << expected.str() << "]" << endl;
+//        CHECK( errormsg.str() == expected.str() );
+//
+//        CHECK( pIModel->get_root()->is_midi_info() == true );
+//        ImoMidiInfo* pInfo = dynamic_cast<ImoMidiInfo*>( pIModel->get_root() );
+//        CHECK( pInfo != NULL );
+//        CHECK( pInfo->get_midi_channel() == 0 );
+//        CHECK( pInfo->get_midi_program() == 56 );
+//
+//        delete tree->get_root();
+//        delete pIModel;
+//    }
+//
+//    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_MidiInfo_ChannelErrorValue)
+//    {
+//        stringstream errormsg;
+//        Document doc(m_libraryScope);
+//        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+//        stringstream expected;
+//        expected << "Line 0. Invalid MIDI channel (0..15). Channel info ignored." << endl;
+//        parser.parse_text("(infoMIDI 56 25)");
+//        LdpTree* tree = parser.get_ldp_tree();
+//        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+//        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+//
+//        //cout << "[" << errormsg.str() << "]" << endl;
+//        //cout << "[" << expected.str() << "]" << endl;
+//        CHECK( errormsg.str() == expected.str() );
+//
+//        ImoMidiInfo* pInfo = dynamic_cast<ImoMidiInfo*>( pIModel->get_root() );
+//        CHECK( pInfo != NULL );
+//        CHECK( pInfo->get_midi_channel() == 0 );
+//        CHECK( pInfo->get_midi_program() == 56 );
+//
+//        delete tree->get_root();
+//        delete pIModel;
+//    }
+//
+//    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_MidiInfo_InstrumentChannelOk)
+//    {
+//        stringstream errormsg;
+//        Document doc(m_libraryScope);
+//        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+//        stringstream expected;
+//        //expected << "Line 0. " << endl;
+//        parser.parse_text("(infoMIDI 56 10)");
+//        LdpTree* tree = parser.get_ldp_tree();
+//        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+//        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+//
+//        //cout << "[" << errormsg.str() << "]" << endl;
+//        //cout << "[" << expected.str() << "]" << endl;
+//        CHECK( errormsg.str() == expected.str() );
+//
+//        ImoMidiInfo* pInfo = dynamic_cast<ImoMidiInfo*>( pIModel->get_root() );
+//        CHECK( pInfo != NULL );
+//        CHECK( pInfo->get_midi_channel() == 10 );
+//        CHECK( pInfo->get_midi_program() == 56 );
+//
+//        delete tree->get_root();
+//        delete pIModel;
+//    }
+//
+//    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Instrument_MidiInfo)
+//    {
+//        stringstream errormsg;
+//        Document doc(m_libraryScope);
+//        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+//        stringstream expected;
+//        //expected << "" << endl;
+//        parser.parse_text("(instrument (infoMIDI 56 12)(musicData))");
+//        LdpTree* tree = parser.get_ldp_tree();
+//        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+//        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+//
+//        //cout << "[" << errormsg.str() << "]" << endl;
+//        //cout << "[" << expected.str() << "]" << endl;
+//        CHECK( errormsg.str() == expected.str() );
+//
+//        ImoInstrument* pInstr = dynamic_cast<ImoInstrument*>( pIModel->get_root() );
+//        CHECK( pInstr != NULL );
+//        CHECK( pInstr->get_num_staves() == 1 );
+//        CHECK( pInstr->get_name().get_text() == "" );
+//        CHECK( pInstr->get_abbrev().get_text() == "" );
+//        CHECK( pInstr->get_midi_channel() == 12 );
+//        CHECK( pInstr->get_midi_program() == 56 );
+//
+//        delete tree->get_root();
+//        delete pIModel;
+//    }
+
+
+    //@ score-instrument ----------------------------------------------------------------
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, score_instrument_01)
+    {
+        //@01. score_instrument
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        //expected << "Line 0. <score-partwise>: missing mandatory element <part>." << endl;
+        parser.parse_text(
+            "<score-partwise version='3.0'><part-list><score-part id='P1'>"
+                "<part-name>Music</part-name>"
+                "<score-instrument id='P1-I1'>"
+                    "<instrument-name>Marimba</instrument-name>"
+                "</score-instrument>"
+            "</score-part></part-list><part id='P1'></part></score-partwise>");
+        MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pIModel->get_root() != NULL);
+        CHECK( pIModel->get_root()->is_document() == true );
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pIModel->get_root() );
+        CHECK( pDoc != NULL );
+        CHECK( pDoc->get_num_content_items() == 1 );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore != NULL );
+        CHECK( pScore->get_num_instruments() == 1 );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        CHECK( pInstr != NULL );
+        CHECK( pInstr->get_midi_channel() == 0 );
+        CHECK( pInstr->get_midi_program() == 56 );
+        cout << test_name() << endl;
+        cout << "midi: channel= " << pInstr->get_midi_channel()
+             << ", program= " << pInstr->get_midi_program() << endl;
+
+        delete pIModel;
+    }
+
+
     //@ time-modification ---------------------------------------------------------------
 
     TEST_FIXTURE(MxlAnalyserTestFixture, time_modification_0)

--- a/src/tests/lomse_test_mxl_analyser.cpp
+++ b/src/tests/lomse_test_mxl_analyser.cpp
@@ -2454,6 +2454,77 @@ SUITE(MxlAnalyserTest)
         delete pIModel;
     }
 
+    //@ midi-device -----------------------------------------------------------------
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, score_instrument_30)
+    {
+        //@30. midi-device
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        //expected << "" << endl;
+        parser.parse_text(
+            "<score-partwise version='3.0'><part-list><score-part id='P1'>"
+                "<part-name>Music</part-name>"
+                "<score-instrument id='P1-I1'>"
+                    "<instrument-name>Marimba</instrument-name>"
+                "</score-instrument>"
+                "<midi-device>Bank 1</midi-device>"
+            "</score-part></part-list><part id='P1'></part></score-partwise>");
+        MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pIModel->get_root() != NULL);
+        CHECK( pIModel->get_root()->is_document() == true );
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pIModel->get_root() );
+        CHECK( pDoc != NULL );
+        CHECK( pDoc->get_num_content_items() == 1 );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore != NULL );
+        CHECK( pScore->get_num_instruments() == 1 );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        CHECK( pInstr != NULL );
+        CHECK( pInstr->get_score_instr_id() == "P1-I1" );
+        CHECK( pInstr->get_score_instr_name() == "Marimba" );
+        CHECK( pInstr->get_midi_port() == 0 );
+        CHECK( pInstr->get_midi_device_name() == "Bank 1" );
+        CHECK( pInstr->get_midi_name() == "" );
+        CHECK( pInstr->get_midi_bank() == 0 );
+        CHECK( pInstr->get_midi_channel() == 0 );
+        CHECK( pInstr->get_midi_program() == 0 );
+        CHECK( pInstr->get_midi_unpitched() == -1 );
+        CHECK( is_equal(pInstr->get_midi_volume(), 1.0f) );
+        CHECK( pInstr->get_midi_pan() == 0.0 );
+        CHECK( pInstr->get_midi_elevation() == 0.0 );
+//        cout << test_name() << endl;
+//        cout << "instr.name= " << pInstr->get_name().get_text() << endl
+//             << "instr.abbrev= " << pInstr->get_abbrev().get_text() << endl
+//             << "id= " << pInstr->get_score_instr_id() << endl
+//             << "name= " << pInstr->get_score_instr_name() << endl
+//             << "abbrev= " << pInstr->get_score_instr_abbrev() << endl
+//             << "sound= " << pInstr->get_score_instr_sound() << endl
+//             << "virt.library= " << pInstr->get_score_instr_virtual_library() << endl
+//             << "virt.name= " << pInstr->get_score_instr_virtual_name() << endl
+//             << "port= " << pInstr->get_midi_port() << endl
+//             << "device name= " << pInstr->get_midi_device_name() << endl
+//             << "midi name= " << pInstr->get_midi_name() << endl
+//             << "bank= " << pInstr->get_midi_bank() << endl
+//             << "channel= " << pInstr->get_midi_channel() << endl
+//             << "program= " << pInstr->get_midi_program() << endl
+//             << "unpitched= " << pInstr->get_midi_unpitched() << endl
+//             << "volume= " << pInstr->get_midi_volume() << endl
+//             << "pan= " << pInstr->get_midi_pan() << endl
+//             << "elevation= " << pInstr->get_midi_elevation() << endl;
+
+        delete pIModel;
+    }
+
     //@ midi-instrument -----------------------------------------------------------------
 
     TEST_FIXTURE(MxlAnalyserTestFixture, score_instrument_40)
@@ -2500,6 +2571,7 @@ SUITE(MxlAnalyserTest)
 
         delete pIModel;
     }
+
     TEST_FIXTURE(MxlAnalyserTestFixture, score_instrument_41)
     {
         //@41. midi instrument. full information
@@ -2517,10 +2589,10 @@ SUITE(MxlAnalyserTest)
                     "<instrument-name>ARIA Player</instrument-name>"
                     "<instrument-abbreviation>ARIA</instrument-abbreviation>"
                     "<instrument-sound>wind.flutes.flute</instrument-sound>"
-//                    "<virtual-instrument>"
-//                        "<virtual-library>Garritan Instruments for Finale</virtual-library>"
-//                        "<virtual-name>001. Woodwinds/1. Flutes/Flute Plr1</virtual-name>"
-//                    "</virtual-instrument>"
+                    "<virtual-instrument>"
+                        "<virtual-library>Garritan Instruments for Finale</virtual-library>"
+                        "<virtual-name>001. Woodwinds/1. Flutes/Flute Plr1</virtual-name>"
+                    "</virtual-instrument>"
                 "</score-instrument>"
                 "<midi-device>Bank 1</midi-device>"
                 "<midi-instrument id='P1-I1'>"
@@ -2534,9 +2606,9 @@ SUITE(MxlAnalyserTest)
         MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
         XmlNode* tree = parser.get_tree_root();
         InternalModel* pIModel = a.analyse_tree(tree, "string:");
-        cout << test_name() << endl;
-        cout << "[" << errormsg.str() << "]" << endl;
-        cout << "[" << expected.str() << "]" << endl;
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
         CHECK( errormsg.str() == expected.str() );
         CHECK( pIModel->get_root() != NULL);
         CHECK( pIModel->get_root()->is_document() == true );
@@ -2554,37 +2626,37 @@ SUITE(MxlAnalyserTest)
         CHECK( pInstr->get_score_instr_name() == "ARIA Player" );
         CHECK( pInstr->get_score_instr_abbrev() == "ARIA" );
         CHECK( pInstr->get_score_instr_sound() == "wind.flutes.flute" );
-//        CHECK( pInstr->get_score_instr_virtual_library() == "Garritan Instruments for Finale" );
-//	    CHECK( pInstr->get_score_instr_virtual_name() == "001. Woodwinds/1. Flutes/Flute Plr1" );
+        CHECK( pInstr->get_score_instr_virtual_library() == "Garritan Instruments for Finale" );
+	    CHECK( pInstr->get_score_instr_virtual_name() == "001. Woodwinds/1. Flutes/Flute Plr1" );
         CHECK( pInstr->get_midi_port() == 0 );
-        //CHECK( pInstr->get_midi_device_id() == "Bank 1" );
+        CHECK( pInstr->get_midi_device_name() == "Bank 1" );
         CHECK( pInstr->get_midi_name() == "" );
         CHECK( pInstr->get_midi_bank() == 0 );
         CHECK( pInstr->get_midi_channel() == 0 );
         CHECK( pInstr->get_midi_program() == 0 );
         CHECK( pInstr->get_midi_unpitched() == 0 );
-        CHECK( pInstr->get_midi_volume() == 80.0 );
+        CHECK( is_equal(pInstr->get_midi_volume(), 0.8f) );
         CHECK( pInstr->get_midi_pan() == -70.0 );
         CHECK( pInstr->get_midi_elevation() == 0.0 );
-        cout << test_name() << endl;
-        cout << "instr.name= " << pInstr->get_name().get_text() << endl
-             << "instr.abbrev= " << pInstr->get_abbrev().get_text() << endl
-             << "id= " << pInstr->get_score_instr_id() << endl
-             << "name= " << pInstr->get_score_instr_name() << endl
-             << "abbrev= " << pInstr->get_score_instr_abbrev() << endl
-             << "sound= " << pInstr->get_score_instr_sound() << endl
-             << "virt.library= " << pInstr->get_score_instr_virtual_library() << endl
-             << "virt.name= " << pInstr->get_score_instr_virtual_name() << endl
-             << "port= " << pInstr->get_midi_port() << endl
-             << "device id= " << pInstr->get_midi_device_id() << endl
-             << "midi name= " << pInstr->get_midi_name() << endl
-             << "bank= " << pInstr->get_midi_bank() << endl
-             << "channel= " << pInstr->get_midi_channel() << endl
-             << "program= " << pInstr->get_midi_program() << endl
-             << "unpitched= " << pInstr->get_midi_unpitched() << endl
-             << "volume= " << pInstr->get_midi_volume() << endl
-             << "pan= " << pInstr->get_midi_pan() << endl
-             << "elevation= " << pInstr->get_midi_elevation() << endl;
+//        cout << test_name() << endl;
+//        cout << "instr.name= " << pInstr->get_name().get_text() << endl
+//             << "instr.abbrev= " << pInstr->get_abbrev().get_text() << endl
+//             << "id= " << pInstr->get_score_instr_id() << endl
+//             << "name= " << pInstr->get_score_instr_name() << endl
+//             << "abbrev= " << pInstr->get_score_instr_abbrev() << endl
+//             << "sound= " << pInstr->get_score_instr_sound() << endl
+//             << "virt.library= " << pInstr->get_score_instr_virtual_library() << endl
+//             << "virt.name= " << pInstr->get_score_instr_virtual_name() << endl
+//             << "port= " << pInstr->get_midi_port() << endl
+//             << "device name= " << pInstr->get_midi_device_name() << endl
+//             << "midi name= " << pInstr->get_midi_name() << endl
+//             << "bank= " << pInstr->get_midi_bank() << endl
+//             << "channel= " << pInstr->get_midi_channel() << endl
+//             << "program= " << pInstr->get_midi_program() << endl
+//             << "unpitched= " << pInstr->get_midi_unpitched() << endl
+//             << "volume= " << pInstr->get_midi_volume() << endl
+//             << "pan= " << pInstr->get_midi_pan() << endl
+//             << "elevation= " << pInstr->get_midi_elevation() << endl;
 
         delete pIModel;
     }

--- a/src/tests/lomse_test_mxl_analyser.cpp
+++ b/src/tests/lomse_test_mxl_analyser.cpp
@@ -2051,48 +2051,48 @@ SUITE(MxlAnalyserTest)
 
     //@ midi-instrument -----------------------------------------------------------------
 
-    TEST_FIXTURE(MxlAnalyserTestFixture, midi_instrument_01)
-    {
-        //@01. midi_instrument
-
-        stringstream errormsg;
-        Document doc(m_libraryScope);
-        XmlParser parser;
-        stringstream expected;
-        //expected << "Line 0. <score-partwise>: missing mandatory element <part>." << endl;
-        parser.parse_text(
-            "<score-partwise version='3.0'><part-list><score-part id='P1'>"
-                "<part-name>Music</part-name>"
-                "<midi-instrument id='P1'>"
-                    "<midi-channel>1</midi-channel>"
-                    "<midi-program>56</midi-program>"
-                "</midi-instrument>"
-            "</score-part></part-list><part id='P1'></part></score-partwise>");
-        MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
-        XmlNode* tree = parser.get_tree_root();
-        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+//    TEST_FIXTURE(MxlAnalyserTestFixture, midi_instrument_01)
+//    {
+//        //@01. midi_instrument
+//
+//        stringstream errormsg;
+//        Document doc(m_libraryScope);
+//        XmlParser parser;
+//        stringstream expected;
+//        //expected << "Line 0. <score-partwise>: missing mandatory element <part>." << endl;
+//        parser.parse_text(
+//            "<score-partwise version='3.0'><part-list><score-part id='P1'>"
+//                "<part-name>Music</part-name>"
+//                "<midi-instrument id='P1'>"
+//                    "<midi-channel>1</midi-channel>"
+//                    "<midi-program>56</midi-program>"
+//                "</midi-instrument>"
+//            "</score-part></part-list><part id='P1'></part></score-partwise>");
+//        MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+//        XmlNode* tree = parser.get_tree_root();
+//        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+////        cout << test_name() << endl;
+////        cout << "[" << errormsg.str() << "]" << endl;
+////        cout << "[" << expected.str() << "]" << endl;
+//        CHECK( errormsg.str() == expected.str() );
+//        CHECK( pIModel->get_root() != NULL);
+//        CHECK( pIModel->get_root()->is_document() == true );
+//        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pIModel->get_root() );
+//        CHECK( pDoc != NULL );
+//        CHECK( pDoc->get_num_content_items() == 1 );
+//        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+//        CHECK( pScore != NULL );
+//        CHECK( pScore->get_num_instruments() == 1 );
+//        ImoInstrument* pInstr = pScore->get_instrument(0);
+//        CHECK( pInstr != NULL );
+//        CHECK( pInstr->get_midi_channel() == 0 );
+//        CHECK( pInstr->get_midi_program() == 56 );
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
-        CHECK( pIModel->get_root() != NULL);
-        CHECK( pIModel->get_root()->is_document() == true );
-        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pIModel->get_root() );
-        CHECK( pDoc != NULL );
-        CHECK( pDoc->get_num_content_items() == 1 );
-        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
-        CHECK( pScore != NULL );
-        CHECK( pScore->get_num_instruments() == 1 );
-        ImoInstrument* pInstr = pScore->get_instrument(0);
-        CHECK( pInstr != NULL );
-        CHECK( pInstr->get_midi_channel() == 0 );
-        CHECK( pInstr->get_midi_program() == 56 );
-        cout << test_name() << endl;
-        cout << "midi: channel= " << pInstr->get_midi_channel()
-             << ", program= " << pInstr->get_midi_program() << endl;
-
-        delete pIModel;
-    }
+//        cout << "midi: channel= " << pInstr->get_midi_channel()
+//             << ", program= " << pInstr->get_midi_program() << endl;
+//
+//        delete pIModel;
+//    }
 
 //    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_MidiInfo_InstrErrorValue)
 //    {
@@ -2249,7 +2249,44 @@ SUITE(MxlAnalyserTest)
 
     TEST_FIXTURE(MxlAnalyserTestFixture, score_instrument_01)
     {
-        //@01. score_instrument
+        //@01. score_instrument. missing id
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        expected << "Line 0. score-instrument: missing mandatory attribute 'id'." << endl;
+        parser.parse_text(
+            "<score-partwise version='3.0'><part-list><score-part id='P1'>"
+                "<part-name>Music</part-name>"
+                "<score-instrument>"
+                    "<instrument-name>Marimba</instrument-name>"
+                "</score-instrument>"
+            "</score-part></part-list><part id='P1'></part></score-partwise>");
+        MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pIModel->get_root() != NULL);
+        CHECK( pIModel->get_root()->is_document() == true );
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pIModel->get_root() );
+        CHECK( pDoc != NULL );
+        CHECK( pDoc->get_num_content_items() == 1 );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore != NULL );
+        CHECK( pScore->get_num_instruments() == 1 );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        CHECK( pInstr != NULL );
+
+        delete pIModel;
+    }
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, score_instrument_02)
+    {
+        //@02. score_instrument has id
 
         stringstream errormsg;
         Document doc(m_libraryScope);
@@ -2280,15 +2317,277 @@ SUITE(MxlAnalyserTest)
         CHECK( pScore->get_num_instruments() == 1 );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         CHECK( pInstr != NULL );
-        CHECK( pInstr->get_midi_channel() == 0 );
-        CHECK( pInstr->get_midi_program() == 56 );
-        cout << test_name() << endl;
-        cout << "midi: channel= " << pInstr->get_midi_channel()
-             << ", program= " << pInstr->get_midi_program() << endl;
+        CHECK( pInstr->get_score_instr_id() == "P1-I1" );
+//        cout << test_name() << endl;
+//        cout << "score-instr: id= " << pInstr->get_score_instr_id() << endl;
 
         delete pIModel;
     }
 
+    TEST_FIXTURE(MxlAnalyserTestFixture, score_instrument_03)
+    {
+        //@03. score_instrument. missing instrument name
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        expected << "Line 0. <score-instrument>: missing mandatory element <instrument-name>." << endl;
+        parser.parse_text(
+            "<score-partwise version='3.0'><part-list><score-part id='P1'>"
+                "<part-name>Music</part-name>"
+                "<score-instrument id='P1-I1'>"
+                "</score-instrument>"
+            "</score-part></part-list><part id='P1'></part></score-partwise>");
+        MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pIModel->get_root() != NULL);
+        CHECK( pIModel->get_root()->is_document() == true );
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pIModel->get_root() );
+        CHECK( pDoc != NULL );
+        CHECK( pDoc->get_num_content_items() == 1 );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore != NULL );
+        CHECK( pScore->get_num_instruments() == 1 );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        CHECK( pInstr != NULL );
+        CHECK( pInstr->get_score_instr_id() == "P1-I1" );
+        CHECK( pInstr->get_score_instr_name() == "" );
+//        cout << test_name() << endl;
+//        cout << "score-instr: id= " << pInstr->get_score_instr_id()
+//             << ", name= " << pInstr->get_score_instr_name() << endl;
+
+        delete pIModel;
+    }
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, score_instrument_04)
+    {
+        //@04. score_instrument. instrument name
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        //expected << "" << endl;
+        parser.parse_text(
+            "<score-partwise version='3.0'><part-list><score-part id='P1'>"
+                "<part-name>Music</part-name>"
+                "<score-instrument id='P1-I1'>"
+                    "<instrument-name>Marimba</instrument-name>"
+                "</score-instrument>"
+            "</score-part></part-list><part id='P1'></part></score-partwise>");
+        MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pIModel->get_root() != NULL);
+        CHECK( pIModel->get_root()->is_document() == true );
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pIModel->get_root() );
+        CHECK( pDoc != NULL );
+        CHECK( pDoc->get_num_content_items() == 1 );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore != NULL );
+        CHECK( pScore->get_num_instruments() == 1 );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        CHECK( pInstr != NULL );
+        CHECK( pInstr->get_score_instr_id() == "P1-I1" );
+        CHECK( pInstr->get_score_instr_name() == "Marimba" );
+//        cout << test_name() << endl;
+//        cout << "score-instr: id= " << pInstr->get_score_instr_id()
+//             << ", name= " << pInstr->get_score_instr_name() << endl;
+
+        delete pIModel;
+    }
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, score_instrument_05)
+    {
+        //@05. score_instrument. instrument name and sound
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        //expected << "" << endl;
+        parser.parse_text(
+            "<score-partwise version='3.0'><part-list><score-part id='P1'>"
+                "<part-name>Music</part-name>"
+                "<score-instrument id='P1-I1'>"
+                    "<instrument-name>ARIA Player</instrument-name>"
+                    "<instrument-sound>wind.flutes.flute</instrument-sound>"
+                "</score-instrument>"
+            "</score-part></part-list><part id='P1'></part></score-partwise>");
+        MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pIModel->get_root() != NULL);
+        CHECK( pIModel->get_root()->is_document() == true );
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pIModel->get_root() );
+        CHECK( pDoc != NULL );
+        CHECK( pDoc->get_num_content_items() == 1 );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore != NULL );
+        CHECK( pScore->get_num_instruments() == 1 );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        CHECK( pInstr != NULL );
+        CHECK( pInstr->get_score_instr_id() == "P1-I1" );
+        CHECK( pInstr->get_score_instr_name() == "ARIA Player" );
+        CHECK( pInstr->get_score_instr_abbrev() == "" );
+        CHECK( pInstr->get_score_instr_sound() == "wind.flutes.flute" );
+//        cout << test_name() << endl;
+//        cout << "score-instr: id= " << pInstr->get_score_instr_id()
+//             << ", name= " << pInstr->get_score_instr_name()
+//             << ", abbrev= " << pInstr->get_score_instr_abbrev()
+//             << ", sound= " << pInstr->get_score_instr_sound() << endl;
+
+        delete pIModel;
+    }
+
+    //@ midi-instrument -----------------------------------------------------------------
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, score_instrument_40)
+    {
+        //@40. midi-instrument. missing id
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        expected << "Line 0. midi-instrument: missing mandatory attribute 'id'." << endl;
+        parser.parse_text(
+            "<score-partwise version='3.0'><part-list><score-part id='P1'>"
+                "<part-name>Music</part-name>"
+                "<score-instrument id='P1-I1'>"
+                    "<instrument-name>Marimba</instrument-name>"
+                "</score-instrument>"
+                "<midi-instrument>"
+                    "<midi-channel>1</midi-channel>"
+                "</midi-instrument>"
+            "</score-part></part-list><part id='P1'></part></score-partwise>");
+        MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pIModel->get_root() != NULL);
+        CHECK( pIModel->get_root()->is_document() == true );
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pIModel->get_root() );
+        CHECK( pDoc != NULL );
+        CHECK( pDoc->get_num_content_items() == 1 );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore != NULL );
+        CHECK( pScore->get_num_instruments() == 1 );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        CHECK( pInstr != NULL );
+        CHECK( pInstr->get_score_instr_id() == "P1-I1" );
+        CHECK( pInstr->get_score_instr_name() == "Marimba" );
+//        cout << test_name() << endl;
+//        cout << "score-instr: id= " << pInstr->get_score_instr_id()
+//             << ", name= " << pInstr->get_score_instr_name() << endl;
+
+        delete pIModel;
+    }
+    TEST_FIXTURE(MxlAnalyserTestFixture, score_instrument_41)
+    {
+        //@41. midi instrument. full information
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        //expected << "" << endl;
+        parser.parse_text(
+            "<score-partwise version='3.0'><part-list><score-part id='P1'>"
+                "<part-name>Flute 1</part-name>"
+                "<part-abbreviation>Fl. 1</part-abbreviation>"
+                "<score-instrument id='P1-I1'>"
+                    "<instrument-name>ARIA Player</instrument-name>"
+                    "<instrument-abbreviation>ARIA</instrument-abbreviation>"
+                    "<instrument-sound>wind.flutes.flute</instrument-sound>"
+//                    "<virtual-instrument>"
+//                        "<virtual-library>Garritan Instruments for Finale</virtual-library>"
+//                        "<virtual-name>001. Woodwinds/1. Flutes/Flute Plr1</virtual-name>"
+//                    "</virtual-instrument>"
+                "</score-instrument>"
+                "<midi-device>Bank 1</midi-device>"
+                "<midi-instrument id='P1-I1'>"
+                    "<midi-channel>1</midi-channel>"
+                    "<midi-program>1</midi-program>"
+                    "<volume>80</volume>"
+                    "<pan>-70</pan>"
+                "</midi-instrument>"
+            "</score-part></part-list><part id='P1'></part></score-partwise>"
+        );
+        MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+        cout << test_name() << endl;
+        cout << "[" << errormsg.str() << "]" << endl;
+        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pIModel->get_root() != NULL);
+        CHECK( pIModel->get_root()->is_document() == true );
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pIModel->get_root() );
+        CHECK( pDoc != NULL );
+        CHECK( pDoc->get_num_content_items() == 1 );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore != NULL );
+        CHECK( pScore->get_num_instruments() == 1 );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        CHECK( pInstr != NULL );
+        CHECK( pInstr->get_name().get_text() == "Flute 1" );
+        CHECK( pInstr->get_abbrev().get_text() == "Fl. 1" );
+        CHECK( pInstr->get_score_instr_id() == "P1-I1" );
+        CHECK( pInstr->get_score_instr_name() == "ARIA Player" );
+        CHECK( pInstr->get_score_instr_abbrev() == "ARIA" );
+        CHECK( pInstr->get_score_instr_sound() == "wind.flutes.flute" );
+//        CHECK( pInstr->get_score_instr_virtual_library() == "Garritan Instruments for Finale" );
+//	    CHECK( pInstr->get_score_instr_virtual_name() == "001. Woodwinds/1. Flutes/Flute Plr1" );
+        CHECK( pInstr->get_midi_port() == 0 );
+        //CHECK( pInstr->get_midi_device_id() == "Bank 1" );
+        CHECK( pInstr->get_midi_name() == "" );
+        CHECK( pInstr->get_midi_bank() == 0 );
+        CHECK( pInstr->get_midi_channel() == 0 );
+        CHECK( pInstr->get_midi_program() == 0 );
+        CHECK( pInstr->get_midi_unpitched() == 0 );
+        CHECK( pInstr->get_midi_volume() == 80.0 );
+        CHECK( pInstr->get_midi_pan() == -70.0 );
+        CHECK( pInstr->get_midi_elevation() == 0.0 );
+        cout << test_name() << endl;
+        cout << "instr.name= " << pInstr->get_name().get_text() << endl
+             << "instr.abbrev= " << pInstr->get_abbrev().get_text() << endl
+             << "id= " << pInstr->get_score_instr_id() << endl
+             << "name= " << pInstr->get_score_instr_name() << endl
+             << "abbrev= " << pInstr->get_score_instr_abbrev() << endl
+             << "sound= " << pInstr->get_score_instr_sound() << endl
+             << "virt.library= " << pInstr->get_score_instr_virtual_library() << endl
+             << "virt.name= " << pInstr->get_score_instr_virtual_name() << endl
+             << "port= " << pInstr->get_midi_port() << endl
+             << "device id= " << pInstr->get_midi_device_id() << endl
+             << "midi name= " << pInstr->get_midi_name() << endl
+             << "bank= " << pInstr->get_midi_bank() << endl
+             << "channel= " << pInstr->get_midi_channel() << endl
+             << "program= " << pInstr->get_midi_program() << endl
+             << "unpitched= " << pInstr->get_midi_unpitched() << endl
+             << "volume= " << pInstr->get_midi_volume() << endl
+             << "pan= " << pInstr->get_midi_pan() << endl
+             << "elevation= " << pInstr->get_midi_elevation() << endl;
+
+        delete pIModel;
+    }
 
     //@ time-modification ---------------------------------------------------------------
 


### PR DESCRIPTION
This PR fixes #82. Now all midi information is extracted from MusicXML files. But in playback, only channel and program are used. See #85