### PR TITLE
Fixes #81: Default MIDI channel when no midi information in file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,15 +22,19 @@
 - Blank space in LDP exporter has been normalized.
 - LDP exporter reviewed for following the same syntax rules than LDP 
   Analyser, thus ensuring a round trip in LDP export-import.
+- Fixed issue #81. Instead of assigning MIDI channel 0 to any instrument
+  without MIDI settings, now a different channel is assigned to each
+  instrument.
 - Fixed issue #82. MusicXML importer now deals with all midi information
-  in score-part.
-- Fixed issue #77: The score and sound do not match
+  in score-part (MusicXML 3.0) and is added to the internal model.
+- Fixed issue #77: In the MusicXML importer the pitch for notes with
+  accidentals was computed wrong.
 - Fixed issue #68: Assume some default value for clef in MusicXML importer
 - Fixed issue #69: Playback very slow for 3/8 tempo
 - Fixed issue #67: Fix beams in malformed MusicXML files.
 - Fixed issue #73: Highlight is not synced. when moving to next page.
 - Fixed issue #70: Score highlight does not work in some scores.
-- Fixed issue #10: note flags too long for short stems.
+- Fixed issue #10: Note flags too long for short stems.
 - Fixed spacing issues, related to clefs and prolog objects, detected 
   in regression tests.
 - Fixed an issue with justification, detected in regression tests. It

--- a/add-sources.cmake
+++ b/add-sources.cmake
@@ -126,6 +126,7 @@ set(INTERNAL_MODEL_FILES
     ${LOMSE_SRC_DIR}/internal_model/lomse_im_factory.cpp
     ${LOMSE_SRC_DIR}/internal_model/lomse_im_figured_bass.cpp
     ${LOMSE_SRC_DIR}/internal_model/lomse_im_note.cpp
+    ${LOMSE_SRC_DIR}/internal_model/lomse_jumps_table.cpp
     ${LOMSE_SRC_DIR}/internal_model/lomse_internal_model.cpp
     ${LOMSE_SRC_DIR}/internal_model/lomse_score_utilities.cpp
 )

--- a/include/lomse_jumps_table.h
+++ b/include/lomse_jumps_table.h
@@ -27,89 +27,58 @@
 // the project at cecilios@users.sourceforge.net
 //---------------------------------------------------------------------------------------
 
-#ifndef __LOMSE_MODEL_BUILDER_H__
-#define __LOMSE_MODEL_BUILDER_H__
+#ifndef __LOMSE_PLAYBACK_TABLE_H__        //to avoid nested includes
+#define __LOMSE_PLAYBACK_TABLE_H__
 
-#include <ostream>
+//#include "lomse_pitch.h"
+//#include "lomse_time.h"
 
-#include <map>
-#include <list>
+#include <vector>
+#include <string>
 using namespace std;
+
 
 namespace lomse
 {
 
 //forward declarations
-class InternalModel;
-class ImoDocument;
-class ImoKeySignature;
-class ImoNote;
-class ImoObj;
 class ImoScore;
-class ImoSoundInfo;
+class ImoInstrument;
+class ImoStaffObj;
+class ImoKeySignature;
+class ImoTimeSignature;
+class ImoNote;
+class StaffObjsCursor;
 
 
 //---------------------------------------------------------------------------------------
-// ModelBuilder. Implements the final step of LDP compiler: code generation.
-// Traverses the parse tree and creates the internal model
-class ModelBuilder
-{
-public:
-    ModelBuilder() {}
-    virtual ~ModelBuilder() {}
-
-    ImoDocument* build_model(InternalModel* IModel);
-    void structurize(ImoObj* pImo);
-
-};
-
-//---------------------------------------------------------------------------------------
-// PitchAssigner. Implements the algorithm to traverse the score and assign pitch to
-// notes, based on notated pitch, and taking into account key signature and notated
-// accidentals introduced by previous notes on the same measure.
-class PitchAssigner
+//JumpsTable: algorithm for creating and managing playback repetitions created by
+//repetition dots in barlines and by repetition marks (Da Capo, Al Segno, etc.)
+class JumpsTable
 {
 protected:
-    int m_accidentals[7];
+    ImoScore* m_pScore;
 
 public:
-    PitchAssigner() {}
-    virtual ~PitchAssigner() {}
+    JumpsTable(ImoScore* pScore);
+    virtual ~JumpsTable();
 
-    void assign_pitch(ImoScore* pScore);
+    void create_table();
 
+    inline int num_entries() { return 0; }  //int(m_events.size()); }
 
-protected:
-    void reset_accidentals(ImoKeySignature* pKey);
-    void update_context_accidentals(ImoNote* pNote);
-    void compute_pitch(ImoNote* pNote);
-
-};
-
-//---------------------------------------------------------------------------------------
-// MidiAssigner. Implements the algorithm to traverse the score instruments and assign
-// midi channel and midi port pitch to
-// notes, based on notated pitch, and taking into account key signature and notated
-// accidentals introduced by previous notes on the same measure.
-class MidiAssigner
-{
-protected:
-    list<ImoSoundInfo*> m_sounds;
-	list<string> m_ids;
-
-public:
-    MidiAssigner();
-    virtual ~MidiAssigner();
-
-	void assign_midi_data(ImoScore* pScore);
-
-protected:
-    void collect_sounds_info(ImoScore* pScore);
-    void assign_score_instr_id();
-    void assign_port_and_channel();
+//    //debug
+//    string dump_midi_events();
+//
+//
+//protected:
+//
+//    //debug
+//    string dump_events_table();
+//    string dump_measures_table();
 };
 
 
 }   //namespace lomse
 
-#endif      //__LOMSE_MODEL_BUILDER_H__
+#endif  // __LOMSE_PLAYBACK_TABLE_H__

--- a/include/lomse_linker.h
+++ b/include/lomse_linker.h
@@ -51,7 +51,7 @@ class ImoInstrGroup;
 class ImoInstrument;
 class ImoSoundInfo;
 class ImoListItem;
-class ImoMidiInfo;
+class ImoSoundInfo;
 class ImoObj;
 class ImoOptionInfo;
 class ImoPageInfo;
@@ -93,8 +93,7 @@ protected:
     ImoObj* add_bezier(ImoBezierInfo* pBezier);
     ImoObj* add_cursor(ImoCursorInfo* pCursor);
     ImoObj* add_listitem(ImoListItem* pItem);
-    ImoObj* add_midi_info(ImoMidiInfo* pInfo);
-    ImoObj* add_instr_info(ImoSoundInfo* pInfo);
+    ImoObj* add_sound_info(ImoSoundInfo* pInfo);
     ImoObj* add_param_info(ImoParamInfo* pParam);
     ImoObj* add_staff_info(ImoStaffInfo* pInfo);
     ImoObj* add_instrument(ImoInstrument* pInstrument);

--- a/src/exporters/lomse_ldp_exporter.cpp
+++ b/src/exporters/lomse_ldp_exporter.cpp
@@ -1054,7 +1054,7 @@ public:
         add_part_id();
         add_name_abbreviation();
         add_staves_info();
-        add_midi_info();
+        add_sound_info();
         add_music_data();
         end_element();
         return m_source.str();
@@ -1085,15 +1085,19 @@ protected:
         }
     }
 
-    void add_midi_info()
+    void add_sound_info()
     {
-        int instr = m_pObj->get_midi_program();
-        int channel = m_pObj->get_midi_channel();
-        if (instr != 0 || channel != 0)
+        if (m_pObj->get_num_sounds() > 0)
         {
-            start_element("infoMIDI", k_no_imoid);
-            m_source << " " << instr << " " << channel;
-            end_element(k_in_same_line);
+            ImoSoundInfo* pInfo = m_pObj->get_sound_info(0);
+            int instr = pInfo->get_midi_program();
+            int channel = pInfo->get_midi_channel();
+            if (instr != 0 || channel != 0)
+            {
+                start_element("infoMIDI", k_no_imoid);
+                m_source << " " << instr << " " << channel;
+                end_element(k_in_same_line);
+            }
         }
     }
 

--- a/src/exporters/lomse_lmd_exporter.cpp
+++ b/src/exporters/lomse_lmd_exporter.cpp
@@ -756,7 +756,7 @@ public:
         start_element("instrument", m_pObj);
         close_start_tag();
         add_num_staves();
-        add_midi_info();
+        add_sound_info();
         add_name_abbreviation();
         add_music_data();
         end_element();
@@ -774,7 +774,7 @@ protected:
      //       sSource += m_pVStaff->GetStaff(i+1)->SourceLMD(nIndent, fUndoData);
     }
 
-    void add_midi_info()
+    void add_sound_info()
     {
 	    //sSource.append(nIndent * lmLMD_INDENT_STEP, _T(' '));
 	    //sSource += wxString::Format(_T("(infoMIDI %d %d)\n"), m_nMidiInstr, m_nMidiChannel);

--- a/src/internal_model/lomse_im_factory.cpp
+++ b/src/internal_model/lomse_im_factory.cpp
@@ -78,7 +78,6 @@ ImoObj* ImFactory::inject(int type, Document* pDoc, ImoId id)
         case k_imo_image:               pObj = LOMSE_NEW ImoImage();              break;
         case k_imo_inline_wrapper:      pObj = LOMSE_NEW ImoInlineWrapper();      break;
         case k_imo_instr_group:         pObj = LOMSE_NEW ImoInstrGroup();         break;
-        case k_imo_instr_info:          pObj = LOMSE_NEW ImoSoundInfo();          break;
         case k_imo_instrument:          pObj = LOMSE_NEW ImoInstrument();         break;
         case k_imo_instruments:         pObj = LOMSE_NEW ImoInstruments();        break;
         case k_imo_instrument_groups:   pObj = LOMSE_NEW ImoInstrGroups();        break;
@@ -91,7 +90,6 @@ ImoObj* ImFactory::inject(int type, Document* pDoc, ImoId id)
         case k_imo_lyric:               pObj = LOMSE_NEW ImoLyric();              break;
         case k_imo_lyrics_text_info:    pObj = LOMSE_NEW ImoLyricsTextInfo();     break;
         case k_imo_metronome_mark:      pObj = LOMSE_NEW ImoMetronomeMark();      break;
-        case k_imo_midi_info:           pObj = LOMSE_NEW ImoMidiInfo();           break;
         case k_imo_multicolumn:         pObj = LOMSE_NEW ImoMultiColumn(pDoc);    break;
         case k_imo_music_data:          pObj = LOMSE_NEW ImoMusicData();          break;
         case k_imo_note:                pObj = LOMSE_NEW ImoNote();               break;
@@ -110,6 +108,8 @@ ImoObj* ImFactory::inject(int type, Document* pDoc, ImoId id)
         case k_imo_score_title:         pObj = LOMSE_NEW ImoScoreTitle();         break;
         case k_imo_slur:                pObj = LOMSE_NEW ImoSlur();               break;
         case k_imo_slur_dto:            pObj = LOMSE_NEW ImoSlurDto();            break;
+        case k_imo_sound_info:          pObj = LOMSE_NEW ImoSoundInfo();          break;
+        case k_imo_sounds:              pObj = LOMSE_NEW ImoSounds();             break;
         case k_imo_spacer:              pObj = LOMSE_NEW ImoSpacer();             break;
         case k_imo_staff_info:          pObj = LOMSE_NEW ImoStaffInfo();          break;
         case k_imo_style:               pObj = LOMSE_NEW ImoStyle();              break;

--- a/src/internal_model/lomse_jumps_table.cpp
+++ b/src/internal_model/lomse_jumps_table.cpp
@@ -27,89 +27,42 @@
 // the project at cecilios@users.sourceforge.net
 //---------------------------------------------------------------------------------------
 
-#ifndef __LOMSE_MODEL_BUILDER_H__
-#define __LOMSE_MODEL_BUILDER_H__
+#include "lomse_jumps_table.h"
 
-#include <ostream>
+//#include <algorithm>
+#include "lomse_internal_model.h"
+//#include "lomse_im_note.h"
+//#include "lomse_time.h"
+//#include "lomse_staffobjs_table.h"
+//#include "lomse_staffobjs_cursor.h"
+//#include "lomse_score_utilities.h"
+//
+//#include <boost/format.hpp>
 
-#include <map>
-#include <list>
 using namespace std;
 
 namespace lomse
 {
 
-//forward declarations
-class InternalModel;
-class ImoDocument;
-class ImoKeySignature;
-class ImoNote;
-class ImoObj;
-class ImoScore;
-class ImoSoundInfo;
-
+//=======================================================================================
+// JumpsTable implementation
+//=======================================================================================
+JumpsTable::JumpsTable(ImoScore* pScore)
+    : m_pScore(pScore)
+{
+}
 
 //---------------------------------------------------------------------------------------
-// ModelBuilder. Implements the final step of LDP compiler: code generation.
-// Traverses the parse tree and creates the internal model
-class ModelBuilder
+JumpsTable::~JumpsTable()
 {
-public:
-    ModelBuilder() {}
-    virtual ~ModelBuilder() {}
-
-    ImoDocument* build_model(InternalModel* IModel);
-    void structurize(ImoObj* pImo);
-
-};
+}
 
 //---------------------------------------------------------------------------------------
-// PitchAssigner. Implements the algorithm to traverse the score and assign pitch to
-// notes, based on notated pitch, and taking into account key signature and notated
-// accidentals introduced by previous notes on the same measure.
-class PitchAssigner
+void JumpsTable::create_table()
 {
-protected:
-    int m_accidentals[7];
-
-public:
-    PitchAssigner() {}
-    virtual ~PitchAssigner() {}
-
-    void assign_pitch(ImoScore* pScore);
-
-
-protected:
-    void reset_accidentals(ImoKeySignature* pKey);
-    void update_context_accidentals(ImoNote* pNote);
-    void compute_pitch(ImoNote* pNote);
-
-};
-
-//---------------------------------------------------------------------------------------
-// MidiAssigner. Implements the algorithm to traverse the score instruments and assign
-// midi channel and midi port pitch to
-// notes, based on notated pitch, and taking into account key signature and notated
-// accidentals introduced by previous notes on the same measure.
-class MidiAssigner
-{
-protected:
-    list<ImoSoundInfo*> m_sounds;
-	list<string> m_ids;
-
-public:
-    MidiAssigner();
-    virtual ~MidiAssigner();
-
-	void assign_midi_data(ImoScore* pScore);
-
-protected:
-    void collect_sounds_info(ImoScore* pScore);
-    void assign_score_instr_id();
-    void assign_port_and_channel();
-};
+    m_pScore->set_jumps_table(this);
+}
 
 
 }   //namespace lomse
 
-#endif      //__LOMSE_MODEL_BUILDER_H__

--- a/src/parser/ldp/lomse_ldp_analyser.cpp
+++ b/src/parser/ldp/lomse_ldp_analyser.cpp
@@ -2804,8 +2804,8 @@ public:
     void do_analysis()
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
-        ImoMidiInfo* pInfo = static_cast<ImoMidiInfo*>(
-                            ImFactory::inject(k_imo_midi_info, pDoc, get_node_id()) );
+        ImoSoundInfo* pInfo = static_cast<ImoSoundInfo*>(
+                            ImFactory::inject(k_imo_sound_info, pDoc, get_node_id()) );
 
         // num_instr
         if (!get_optional(k_number) || !set_midi_program(pInfo))
@@ -2829,7 +2829,7 @@ public:
 
 protected:
 
-    bool set_midi_program(ImoMidiInfo* pInfo)
+    bool set_midi_program(ImoSoundInfo* pInfo)
     {
         int value = get_integer_value(0);
         if (value < 0 || value > 127)
@@ -2839,7 +2839,7 @@ protected:
         return true;
     }
 
-    bool set_midi_channel(ImoMidiInfo* pInfo)
+    bool set_midi_channel(ImoSoundInfo* pInfo)
     {
         int value = get_integer_value(0);
         if (value < 0 || value > 15)
@@ -2932,7 +2932,10 @@ public:
         error_if_more_elements();
 
         if (!m_pAnalyser->is_instr_id_required())
+        {
             add_to_model(pInstrument);
+            add_sound_info_if_needed(pInstrument);
+        }
 
     }
 
@@ -2960,6 +2963,17 @@ protected:
         {
             for(; nStaves > 1; --nStaves)
                 pInstrument->add_staff();
+        }
+    }
+
+    void add_sound_info_if_needed(ImoInstrument* pInstr)
+    {
+        if (pInstr->get_num_sounds() == 0)
+        {
+            Document* pDoc = m_pAnalyser->get_document_being_analysed();
+            ImoSoundInfo* pInfo = static_cast<ImoSoundInfo*>(
+                                        ImFactory::inject(k_imo_sound_info, pDoc) );
+            pInstr->add_sound_info(pInfo);
         }
     }
 

--- a/src/parser/lmd/lomse_lmd_analyser.cpp
+++ b/src/parser/lmd/lomse_lmd_analyser.cpp
@@ -2337,8 +2337,9 @@ public:
     ImoObj* do_analysis()
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
-        ImoMidiInfo* pInfo = static_cast<ImoMidiInfo*>(
-                                    ImFactory::inject(k_imo_midi_info, pDoc) );
+        ImoSoundInfo* pInfo = static_cast<ImoSoundInfo*>(
+                                    ImFactory::inject(k_imo_sound_info, pDoc) );
+
 
         // num_instr
         if (!get_optional(k_number) || !set_midi_program(pInfo))
@@ -2363,7 +2364,7 @@ public:
 
 protected:
 
-    bool set_midi_program(ImoMidiInfo* pInfo)
+    bool set_midi_program(ImoSoundInfo* pInfo)
     {
         int value = get_integer_value(0);
         if (value < 0 || value > 127)
@@ -2373,7 +2374,7 @@ protected:
         return true;
     }
 
-    bool set_midi_channel(ImoMidiInfo* pInfo)
+    bool set_midi_channel(ImoSoundInfo* pInfo)
     {
         int value = get_integer_value(0);
         if (value < 0 || value > 15)
@@ -2459,7 +2460,10 @@ public:
         error_if_more_elements();
 
         if (!m_pAnalyser->is_instr_id_required())
+        {
             add_to_model(pInstrument);
+            add_sound_info_if_needed(pInstrument);
+        }
 
         return pInstrument;
     }
@@ -2501,6 +2505,17 @@ protected:
             return pText;
         }
         return NULL;
+    }
+
+    void add_sound_info_if_needed(ImoInstrument* pInstr)
+    {
+        if (pInstr->get_num_sounds() == 0)
+        {
+            Document* pDoc = m_pAnalyser->get_document_being_analysed();
+            ImoSoundInfo* pInfo = static_cast<ImoSoundInfo*>(
+                                        ImFactory::inject(k_imo_sound_info, pDoc) );
+            pInstr->add_sound_info(pInfo);
+        }
     }
 
 };

--- a/src/parser/lomse_linker.cpp
+++ b/src/parser/lomse_linker.cpp
@@ -76,12 +76,6 @@ ImoObj* Linker::add_child_to_model(ImoObj* pParent, ImoObj* pChild, int ldpChild
         case k_imo_listitem:
             return add_listitem(static_cast<ImoListItem*>(pChild));
 
-        case k_imo_midi_info:
-            return add_midi_info(static_cast<ImoMidiInfo*>(pChild));
-
-        case k_imo_instr_info:
-            return add_instr_info(static_cast<ImoSoundInfo*>(pChild));
-
         case k_imo_music_data:
             return add_child(k_imo_instrument, pChild);
 
@@ -99,6 +93,9 @@ ImoObj* Linker::add_child_to_model(ImoObj* pParent, ImoObj* pChild, int ldpChild
 
         case k_imo_score_title:
             return add_title(static_cast<ImoScoreTitle*>(pChild));
+
+        case k_imo_sound_info:
+            return add_sound_info(static_cast<ImoSoundInfo*>(pChild));
 
         case k_imo_staff_info:
             return add_staff_info(static_cast<ImoStaffInfo*>(pChild));
@@ -302,24 +299,12 @@ ImoObj* Linker::add_listitem(ImoListItem* pItem)
 }
 
 //---------------------------------------------------------------------------------------
-ImoObj* Linker::add_midi_info(ImoMidiInfo* pInfo)
+ImoObj* Linker::add_sound_info(ImoSoundInfo* pInfo)
 {
     if (m_pParent && m_pParent->is_instrument())
     {
         ImoInstrument* pInstr = static_cast<ImoInstrument*>(m_pParent);
-        pInstr->set_midi_info(pInfo);
-        return NULL;
-    }
-    return pInfo;
-}
-
-//---------------------------------------------------------------------------------------
-ImoObj* Linker::add_instr_info(ImoSoundInfo* pInfo)
-{
-    if (m_pParent && m_pParent->is_instrument())
-    {
-        ImoInstrument* pInstr = static_cast<ImoInstrument*>(m_pParent);
-        pInstr->set_instr_info(pInfo);
+        pInstr->add_sound_info(pInfo);
         return NULL;
     }
     return pInfo;

--- a/src/sound/lomse_midi_table.cpp
+++ b/src/sound/lomse_midi_table.cpp
@@ -110,9 +110,15 @@ void SoundEventsTable::program_sounds_for_instruments()
     for (int iInstr = 0; iInstr < numInstruments; iInstr++)
     {
         ImoInstrument* pInstr = m_pScore->get_instrument(iInstr);
-        int channel = pInstr->get_midi_channel();
+        int channel = 0;
+        int instr = 0;
+        if (pInstr->get_num_sounds() > 0)
+        {
+            ImoSoundInfo* pInfo = pInstr->get_sound_info(0);
+            channel = pInfo->get_midi_channel();
+            instr = pInfo->get_midi_program();
+        }
         m_channels[iInstr] = channel;
-        int instr = pInstr->get_midi_program();
         store_event(0, SoundEvent::k_prog_instr, channel, instr, 0, 0, NULL, 0);
     }
 }

--- a/src/tests/lomse_test_command.cpp
+++ b/src/tests/lomse_test_command.cpp
@@ -1019,9 +1019,9 @@ SUITE(DocCommandTest)
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(key C)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(time 6 8)" );
-        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 e. v1 p1 (beam 150 +))" );
-        CHECK_ENTRY0(it, 0,    0,      0,  48,     0, "(n g4 s v1 p1 (beam 150 =b))" );
-        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n c5 e v1 p1 (beam 150 -))" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n c4 e. v1 p1 (beam 152 +))" );
+        CHECK_ENTRY0(it, 0,    0,      0,  48,     0, "(n g4 s v1 p1 (beam 152 =b))" );
+        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n c5 e v1 p1 (beam 152 -))" );
         CHECK_ENTRY0(it, 0,    0,      0,  96,     0, "(n c4 e v1 p1 (beam 139 +))" );
         CHECK_ENTRY0(it, 0,    0,      0, 128,     0, "(n e4 e v1 p1 (beam 139 =))" );
         CHECK_ENTRY0(it, 0,    0,      0, 160,     0, "(n g4 e v1 p1 (beam 139 -))" );
@@ -1126,6 +1126,8 @@ SUITE(DocCommandTest)
             "(n c4 e v1 p1 (beam 139 +))(n e4 e v1 p1 (beam 139 =))(n g4 e v1 p1 (beam 139 -))"
             "(barline simple)"
             ")))");
+//        cout << test_name() << endl;
+//        cout << doc.to_string(true) << endl;
         doc.clear_dirty();
         DocCursor cursor(&doc);
         DocCommandExecuter executer(&doc);
@@ -1154,11 +1156,11 @@ SUITE(DocCommandTest)
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 e v1 p1 (beam 129 +))" );
         CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(n g4 e v1 p1 (beam 129 =))" );
         CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(n c5 e v1 p1 (beam 129 -))" );
-        CHECK_ENTRY0(it, 0,    0,      0,  96,     0, "(n d4 e. v1 p1 (beam 150 +))" );
-        CHECK_ENTRY0(it, 0,    0,      0, 144,     0, "(n e4 s v1 p1 (beam 150 =b))" );
-        CHECK_ENTRY0(it, 0,    0,      0, 160,     0, "(n g4 e v1 p1 (beam 150 -))" );
+        CHECK_ENTRY0(it, 0,    0,      0,  96,     0, "(n d4 e. v1 p1 (beam 152 +))" );
+        CHECK_ENTRY0(it, 0,    0,      0, 144,     0, "(n e4 s v1 p1 (beam 152 =b))" );
+        CHECK_ENTRY0(it, 0,    0,      0, 160,     0, "(n g4 e v1 p1 (beam 152 -))" );
         CHECK_ENTRY0(it, 0,    0,      0, 192,     0, "(barline simple)" );
-        //cout << pTable->dump() << endl;
+//        cout << pTable->dump() << endl;
      }
 
 
@@ -3125,8 +3127,8 @@ SUITE(DocCommandTest)
         CHECK( pSC->time() == 64 );
 
         CHECK( doc.to_string() == "(lenmusdoc (vers 0.0)(content (score (vers 2.0)"
-              "(instrument (staves 1)(musicData (clef G p1)(n e4 e v1 p1 (beam 127 +))"
-              "(n c4 e v1 p1 (beam 127 -)))))))" );
+              "(instrument (staves 1)(musicData (clef G p1)(n e4 e v1 p1 (beam 129 +))"
+              "(n c4 e v1 p1 (beam 129 -)))))))" );
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
         CHECK( pScore->get_staffobjs_table()->num_entries() == 3 );
 //        cout << doc.to_string() << endl;
@@ -3187,7 +3189,9 @@ SUITE(DocCommandTest)
         CHECK( pSC->is_at_end_of_empty_score() == false );
         CHECK( pSC->is_at_end_of_staff() == true );
 
-        CHECK( doc.to_string() == "(lenmusdoc (vers 0.0)(content (score (vers 2.0)(instrument (staves 1)(musicData (clef G p1)(n e4 e v1 p1 (beam 136 +))(n c4 e v1 p1 (beam 136 -)))))))" );
+        CHECK( doc.to_string() == "(lenmusdoc (vers 0.0)(content (score (vers 2.0)"
+              "(instrument (staves 1)(musicData (clef G p1)(n e4 e v1 p1 (beam 138 +))"
+              "(n c4 e v1 p1 (beam 138 -)))))))" );
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
         CHECK( pScore->get_staffobjs_table()->num_entries() == 3 );
 //        cout << doc.to_string() << endl;
@@ -3207,7 +3211,7 @@ SUITE(DocCommandTest)
         MySelectionSet sel(&doc);
         executer.execute(&cursor, pCmd, &sel);
 
-        pCmd = LOMSE_NEW CmdCursor(125L);     //point to first note
+        pCmd = LOMSE_NEW CmdCursor(127L);     //point to first note
         executer.execute(&cursor, pCmd, &sel);
         ImoObj* pNoteE4 = *cursor;
 

--- a/src/tests/lomse_test_document_cursor.cpp
+++ b/src/tests/lomse_test_document_cursor.cpp
@@ -136,7 +136,7 @@ SUITE(DocContentCursorTest)
         ++cursor;
         CHECK( *cursor == NULL );
         CHECK( cursor.get_pointee_id() == k_cursor_at_end );
-        CHECK( cursor.get_prev_id() == 108L );
+        CHECK( cursor.get_prev_id() == 110L );
     }
 
     TEST_FIXTURE(DocContentCursorTestFixture, next_remains_at_end)
@@ -148,11 +148,11 @@ SUITE(DocContentCursorTest)
         ++cursor;
         CHECK( *cursor == NULL );
         CHECK( cursor.get_pointee_id() == k_cursor_at_end );
-        CHECK( cursor.get_prev_id() == 108L );
+        CHECK( cursor.get_prev_id() == 110L );
         ++cursor;
         CHECK( *cursor == NULL );
         CHECK( cursor.get_pointee_id() == k_cursor_at_end );
-        CHECK( cursor.get_prev_id() == 108L );
+        CHECK( cursor.get_prev_id() == 110L );
     }
 
     TEST_FIXTURE(DocContentCursorTestFixture, prev)
@@ -187,7 +187,7 @@ SUITE(DocContentCursorTest)
         ++cursor;
         CHECK( *cursor == NULL );
         CHECK( cursor.get_pointee_id() == k_cursor_at_end );
-        CHECK( cursor.get_prev_id() == 108L );
+        CHECK( cursor.get_prev_id() == 110L );
         --cursor;
         CHECK( (*cursor)->is_paragraph() == true );
         CHECK( cursor.get_prev_id() == 80L );
@@ -216,7 +216,7 @@ SUITE(DocContentCursorTest)
         create_document_1();
         MyDocContentCursor cursor(m_pDoc);
         //cout << m_pDoc->to_string(k_save_ids) << endl;
-        cursor.point_to(108L);
+        cursor.point_to(110L);
         CHECK( *cursor != NULL );
         CHECK( (*cursor)->is_paragraph() == true );
         CHECK( cursor.get_prev_id() == 80L );
@@ -230,7 +230,7 @@ SUITE(DocContentCursorTest)
         cursor.point_to(175L);
         CHECK( *cursor == NULL );
         CHECK( cursor.get_pointee_id() == k_cursor_at_end );
-        CHECK( cursor.get_prev_id() == 108L );
+        CHECK( cursor.get_prev_id() == 110L );
     }
 
     TEST_FIXTURE(DocContentCursorTestFixture, direct_positioning_by_id_not_top_level)
@@ -241,7 +241,7 @@ SUITE(DocContentCursorTest)
         cursor.point_to(106L);       //time signature
         CHECK( *cursor == NULL );
         CHECK( cursor.get_pointee_id() == k_cursor_at_end );
-        CHECK( cursor.get_prev_id() == 108L );
+        CHECK( cursor.get_prev_id() == 110L );
     }
 
     TEST_FIXTURE(DocContentCursorTestFixture, direct_positioning_by_ptr_1)
@@ -249,18 +249,18 @@ SUITE(DocContentCursorTest)
         //012 point to, by ptr: goes to element if top level
         create_document_1();
         MyDocContentCursor cursor(m_pDoc);
-        cursor.point_to(108L);   //move to paragraph to get pointer to it
+        cursor.point_to(110L);   //move to paragraph to get pointer to it
         ImoBlockLevelObj* pImo = static_cast<ImoBlockLevelObj*>( *cursor );
-        cursor.point_to(170L);  //to end
+        cursor.point_to(174L);  //to end
         CHECK( *cursor == NULL );
         CHECK( cursor.get_pointee_id() == k_cursor_at_end );
-        CHECK( cursor.get_prev_id() == 108L );
+        CHECK( cursor.get_prev_id() == 110L );
 
         cursor.point_to(pImo);
 
         CHECK( *cursor != NULL );
         CHECK( *cursor == pImo );
-        CHECK( cursor.get_pointee_id() == 108L );
+        CHECK( cursor.get_pointee_id() == 110L );
         CHECK( cursor.get_prev_id() == 80L );
     }
 
@@ -277,7 +277,7 @@ SUITE(DocContentCursorTest)
 
         CHECK( *cursor == NULL );
         CHECK( cursor.get_pointee_id() == k_cursor_at_end );
-        CHECK( cursor.get_prev_id() == 108L );
+        CHECK( cursor.get_prev_id() == 110L );
     }
 
 //    TEST_FIXTURE(DocContentCursorTestFixture, prev_when_added_object)
@@ -570,8 +570,8 @@ SUITE(DocCursorTest)
 
         ++cursor;
         CHECK( (*cursor)->is_paragraph() == true );
-        CHECK( cursor.get_pointee_id() == 102L );
-        CHECK( cursor.get_parent_id() == 102L );
+        CHECK( cursor.get_pointee_id() == 104L );
+        CHECK( cursor.get_parent_id() == 104L );
         //cursor.dump_ids();
 
         ++cursor;
@@ -608,10 +608,10 @@ SUITE(DocCursorTest)
         //302. move backwards until first object and remains there. Several levels
         create_document_3();
         MyDocCursor cursor(m_pDoc);
-        cursor.point_to(102L);
+        cursor.point_to(104L);
         CHECK( (*cursor)->is_paragraph() == true );
-        CHECK( cursor.get_pointee_id() == 102L );
-        CHECK( cursor.get_parent_id() == 102L );
+        CHECK( cursor.get_pointee_id() == 104L );
+        CHECK( cursor.get_parent_id() == 104L );
         //cursor.dump_ids();
 
         --cursor;
@@ -669,8 +669,8 @@ SUITE(DocCursorTest)
 
         --cursor;
         CHECK( (*cursor)->is_paragraph() == true );
-        CHECK( cursor.get_pointee_id() == 108L );
-        CHECK( cursor.get_parent_id() == 108L );
+        CHECK( cursor.get_pointee_id() == 110L );
+        CHECK( cursor.get_parent_id() == 110L );
         CHECK( cursor.is_inside_terminal_node() == false );
     }
 
@@ -753,12 +753,12 @@ SUITE(DocCursorTest)
         create_document_1();
         MyDocCursor cursor(m_pDoc);
 
-        cursor.point_to(108L);   //paragraph
+        cursor.point_to(110L);   //paragraph
 
         CHECK( *cursor != NULL );
         CHECK( (*cursor)->is_paragraph() == true );
-        CHECK( cursor.get_pointee_id() == 108L );
-        CHECK( cursor.get_parent_id() == 108L );
+        CHECK( cursor.get_pointee_id() == 110L );
+        CHECK( cursor.get_parent_id() == 110L );
         CHECK( cursor.is_inside_terminal_node() == false );
         //cursor.dump_ids();
     }
@@ -772,12 +772,12 @@ SUITE(DocCursorTest)
         CHECK( cursor.is_inside_terminal_node() == true );
         CHECK( (*cursor)->is_clef() == true );
 
-        cursor.point_to(108L);   //paragraph
+        cursor.point_to(110L);   //paragraph
 
         CHECK( *cursor != NULL );
         CHECK( (*cursor)->is_paragraph() == true );
-        CHECK( cursor.get_pointee_id() == 108L );
-        CHECK( cursor.get_parent_id() == 108L );
+        CHECK( cursor.get_pointee_id() == 110L );
+        CHECK( cursor.get_parent_id() == 110L );
         CHECK( cursor.is_inside_terminal_node() == false );
     }
 
@@ -865,7 +865,7 @@ SUITE(DocCursorTest)
         //601. to_start. Not delegating moves to first top level
         create_document_1();
         MyDocCursor cursor(m_pDoc);
-        cursor.point_to(108L);   //paragraph
+        cursor.point_to(110L);   //paragraph
 
         cursor.to_start();
 
@@ -897,7 +897,7 @@ SUITE(DocCursorTest)
 
         DocCursorState state = cursor.get_state();
 
-        CHECK( state.get_parent_level_id() == 108L );
+        CHECK( state.get_parent_level_id() == 110L );
         CHECK( state.get_delegate_state() == NULL );
     }
 
@@ -1028,14 +1028,14 @@ SUITE(DocCursorTest)
         MyDocCursor cursor(m_pDoc);
         ++cursor;       //paragraph 108L
         DocCursorState state = cursor.get_state();
-        CHECK( state.get_parent_level_id() == 108L );
+        CHECK( state.get_parent_level_id() == 110L );
         CHECK( state.get_delegate_state() == NULL );
 
         cursor.to_start();      //move to antoher place
         cursor.restore_state(state);
 
-        CHECK( cursor.get_pointee_id() == 108L );
-        CHECK( cursor.get_parent_id() == 108L );
+        CHECK( cursor.get_pointee_id() == 110L );
+        CHECK( cursor.get_parent_id() == 110L );
         CHECK( cursor.is_inside_terminal_node() == false );
     }
 

--- a/src/tests/lomse_test_im_visitor.cpp
+++ b/src/tests/lomse_test_im_visitor.cpp
@@ -231,7 +231,7 @@ SUITE(ImVisitorTest)
 //             << ", num_in_nodes=" << v.num_in_nodes()
 //             << ", num_out_nodes=" << v.num_out_nodes() << endl;
         CHECK( v.max_depth() == 9 );
-        CHECK( v.num_in_nodes() == 103 );
+        CHECK( v.num_in_nodes() == 107 );
         CHECK( v.num_out_nodes() == v.num_in_nodes() );
     }
 

--- a/src/tests/lomse_test_jumps_table.cpp
+++ b/src/tests/lomse_test_jumps_table.cpp
@@ -1,0 +1,131 @@
+//---------------------------------------------------------------------------------------
+// This file is part of the Lomse library.
+// Lomse is copyrighted work (c) 2010-2017. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice, this
+//      list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright notice, this
+//      list of conditions and the following disclaimer in the documentation and/or
+//      other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+// SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// For any comment, suggestion or feature request, please contact the manager of
+// the project at cecilios@users.sourceforge.net
+//---------------------------------------------------------------------------------------
+
+#include <UnitTest++.h>
+#include <sstream>
+#include "lomse_build_options.h"
+
+//classes related to these tests
+#include "lomse_jumps_table.h"
+#include "lomse_document.h"
+
+#include <exception>
+using namespace UnitTest;
+using namespace std;
+using namespace lomse;
+
+
+////---------------------------------------------------------------------------------------
+////Derived class to access protected members
+//class MyJumpsTable : public JumpsTable
+//{
+//protected:
+//
+//public:
+//    MyJumpsTable(ImoScore* pScore)
+//        : JumpsTable(pScore)
+//    {
+//    }
+//    virtual ~MyJumpsTable() {}
+//
+//    //access to protected member methods
+//    bool my_are_there_staves_needing_clef()
+//    {
+//        find_staves_needing_clef();
+//
+//        vector<bool>::iterator it;
+//        for (it=m_fNeedsClef.begin(); it != m_fNeedsClef.end(); ++it)
+//        {
+//            if (*it==true)
+//                return true;
+//        }
+//        return false;
+//    }
+//    FPitch my_max_pitch(int idx)
+//    {
+//        return m_maxPitch[idx];
+//    }
+//    FPitch my_min_pitch(int idx)
+//    {
+//        return m_minPitch[idx];
+//    }
+//    int my_num_notes(int idx)
+//    {
+//        return m_numNotes[idx];
+//    }
+//
+//};
+
+//=======================================================================================
+// JumpsTable tests
+//=======================================================================================
+class JumpsTableTestFixture
+{
+public:
+    LibraryScope m_libraryScope;
+    string m_scores_path;
+
+    JumpsTableTestFixture()     //SetUp fixture
+        : m_libraryScope(cout)
+        , m_scores_path(TESTLIB_SCORES_PATH)
+    {
+        m_libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+    }
+
+    ~JumpsTableTestFixture()    //TearDown fixture
+    {
+    }
+
+    inline const char* test_name()
+    {
+        return UnitTest::CurrentTest::Details()->testName;
+    }
+
+};
+
+//---------------------------------------------------------------------------------------
+SUITE(JumpsTableTest)
+{
+
+    TEST_FIXTURE(JumpsTableTestFixture, jumps_table_01)
+    {
+        //@001. empty score creates empty table
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0)(instrument (musicData )))");
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_imodoc()->get_content_item(0) );
+
+		JumpsTable* pTable = LOMSE_NEW JumpsTable(pScore);
+		pTable->create_table();
+
+        CHECK( pTable->num_entries() == 0 );
+    }
+
+
+};
+

--- a/src/tests/lomse_test_ldp_analyser.cpp
+++ b/src/tests/lomse_test_ldp_analyser.cpp
@@ -3239,7 +3239,7 @@ SUITE(LdpAnalyserTest)
         //cout << "[" << expected.str() << "]" << endl;
         CHECK( errormsg.str() == expected.str() );
 
-        ImoMidiInfo* pInfo = dynamic_cast<ImoMidiInfo*>( pIModel->get_root() );
+        ImoSoundInfo* pInfo = dynamic_cast<ImoSoundInfo*>( pIModel->get_root() );
         CHECK( pInfo == NULL );
 
         delete tree->get_root();
@@ -3262,7 +3262,7 @@ SUITE(LdpAnalyserTest)
         //cout << "[" << expected.str() << "]" << endl;
         CHECK( errormsg.str() == expected.str() );
 
-        ImoMidiInfo* pInfo = dynamic_cast<ImoMidiInfo*>( pIModel->get_root() );
+        ImoSoundInfo* pInfo = dynamic_cast<ImoSoundInfo*>( pIModel->get_root() );
         CHECK( pInfo == NULL );
 
         delete tree->get_root();
@@ -3285,10 +3285,10 @@ SUITE(LdpAnalyserTest)
         //cout << "[" << expected.str() << "]" << endl;
         CHECK( errormsg.str() == expected.str() );
 
-        CHECK( pIModel->get_root()->is_midi_info() == true );
-        ImoMidiInfo* pInfo = dynamic_cast<ImoMidiInfo*>( pIModel->get_root() );
+        CHECK( pIModel->get_root()->is_sound_info() == true );
+        ImoSoundInfo* pInfo = dynamic_cast<ImoSoundInfo*>( pIModel->get_root() );
         CHECK( pInfo != NULL );
-        CHECK( pInfo->get_midi_channel() == 0 );
+        CHECK( pInfo->get_midi_channel() == -1 );
         CHECK( pInfo->get_midi_program() == 56 );
 
         delete tree->get_root();
@@ -3311,9 +3311,9 @@ SUITE(LdpAnalyserTest)
         //cout << "[" << expected.str() << "]" << endl;
         CHECK( errormsg.str() == expected.str() );
 
-        ImoMidiInfo* pInfo = dynamic_cast<ImoMidiInfo*>( pIModel->get_root() );
+        ImoSoundInfo* pInfo = dynamic_cast<ImoSoundInfo*>( pIModel->get_root() );
         CHECK( pInfo != NULL );
-        CHECK( pInfo->get_midi_channel() == 0 );
+        CHECK( pInfo->get_midi_channel() == -1 );
         CHECK( pInfo->get_midi_program() == 56 );
 
         delete tree->get_root();
@@ -3336,7 +3336,7 @@ SUITE(LdpAnalyserTest)
         //cout << "[" << expected.str() << "]" << endl;
         CHECK( errormsg.str() == expected.str() );
 
-        ImoMidiInfo* pInfo = dynamic_cast<ImoMidiInfo*>( pIModel->get_root() );
+        ImoSoundInfo* pInfo = dynamic_cast<ImoSoundInfo*>( pIModel->get_root() );
         CHECK( pInfo != NULL );
         CHECK( pInfo->get_midi_channel() == 10 );
         CHECK( pInfo->get_midi_program() == 56 );
@@ -3366,8 +3366,11 @@ SUITE(LdpAnalyserTest)
         CHECK( pInstr->get_num_staves() == 1 );
         CHECK( pInstr->get_name().get_text() == "" );
         CHECK( pInstr->get_abbrev().get_text() == "" );
-        CHECK( pInstr->get_midi_channel() == 12 );
-        CHECK( pInstr->get_midi_program() == 56 );
+        CHECK( pInstr->get_num_sounds() == 1 );
+        ImoSoundInfo* pInfo = pInstr->get_sound_info(0);
+        CHECK( pInfo != NULL );
+        CHECK( pInfo->get_midi_channel() == 12 );
+        CHECK( pInfo->get_midi_program() == 56 );
 
         delete tree->get_root();
         delete pIModel;

--- a/src/tests/lomse_test_mxl_analyser.cpp
+++ b/src/tests/lomse_test_mxl_analyser.cpp
@@ -2049,202 +2049,6 @@ SUITE(MxlAnalyserTest)
 //    }
 
 
-    //@ midi-instrument -----------------------------------------------------------------
-
-//    TEST_FIXTURE(MxlAnalyserTestFixture, midi_instrument_01)
-//    {
-//        //@01. midi_instrument
-//
-//        stringstream errormsg;
-//        Document doc(m_libraryScope);
-//        XmlParser parser;
-//        stringstream expected;
-//        //expected << "Line 0. <score-partwise>: missing mandatory element <part>." << endl;
-//        parser.parse_text(
-//            "<score-partwise version='3.0'><part-list><score-part id='P1'>"
-//                "<part-name>Music</part-name>"
-//                "<midi-instrument id='P1'>"
-//                    "<midi-channel>1</midi-channel>"
-//                    "<midi-program>56</midi-program>"
-//                "</midi-instrument>"
-//            "</score-part></part-list><part id='P1'></part></score-partwise>");
-//        MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
-//        XmlNode* tree = parser.get_tree_root();
-//        InternalModel* pIModel = a.analyse_tree(tree, "string:");
-////        cout << test_name() << endl;
-////        cout << "[" << errormsg.str() << "]" << endl;
-////        cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
-//        CHECK( pIModel->get_root() != NULL);
-//        CHECK( pIModel->get_root()->is_document() == true );
-//        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pIModel->get_root() );
-//        CHECK( pDoc != NULL );
-//        CHECK( pDoc->get_num_content_items() == 1 );
-//        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
-//        CHECK( pScore != NULL );
-//        CHECK( pScore->get_num_instruments() == 1 );
-//        ImoInstrument* pInstr = pScore->get_instrument(0);
-//        CHECK( pInstr != NULL );
-//        CHECK( pInstr->get_midi_channel() == 0 );
-//        CHECK( pInstr->get_midi_program() == 56 );
-//        cout << test_name() << endl;
-//        cout << "midi: channel= " << pInstr->get_midi_channel()
-//             << ", program= " << pInstr->get_midi_program() << endl;
-//
-//        delete pIModel;
-//    }
-
-//    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_MidiInfo_InstrErrorValue)
-//    {
-//        stringstream errormsg;
-//        Document doc(m_libraryScope);
-//        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
-//        stringstream expected;
-//        expected << "Line 0. Missing or invalid MIDI instrument (0..255). MIDI info ignored." << endl;
-//        parser.parse_text("(infoMIDI piano 1)");
-//        LdpTree* tree = parser.get_ldp_tree();
-//        LdpAnalyser a(errormsg, m_libraryScope, &doc);
-//        InternalModel* pIModel = a.analyse_tree(tree, "string:");
-//
-//        //cout << "[" << errormsg.str() << "]" << endl;
-//        //cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
-//
-//        ImoMidiInfo* pInfo = dynamic_cast<ImoMidiInfo*>( pIModel->get_root() );
-//        CHECK( pInfo == NULL );
-//
-//        delete tree->get_root();
-//        delete pIModel;
-//    }
-//
-//    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_MidiInfo_InstrErrorRange)
-//    {
-//        stringstream errormsg;
-//        Document doc(m_libraryScope);
-//        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
-//        stringstream expected;
-//        expected << "Line 0. Missing or invalid MIDI instrument (0..255). MIDI info ignored." << endl;
-//        parser.parse_text("(infoMIDI 315 1)");
-//        LdpTree* tree = parser.get_ldp_tree();
-//        LdpAnalyser a(errormsg, m_libraryScope, &doc);
-//        InternalModel* pIModel = a.analyse_tree(tree, "string:");
-//
-//        //cout << "[" << errormsg.str() << "]" << endl;
-//        //cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
-//
-//        ImoMidiInfo* pInfo = dynamic_cast<ImoMidiInfo*>( pIModel->get_root() );
-//        CHECK( pInfo == NULL );
-//
-//        delete tree->get_root();
-//        delete pIModel;
-//    }
-//
-//    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_MidiInfo_InstrumentOk)
-//    {
-//        stringstream errormsg;
-//        Document doc(m_libraryScope);
-//        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
-//        stringstream expected;
-//        //expected << "Line 0. " << endl;
-//        parser.parse_text("(infoMIDI 56)");
-//        LdpTree* tree = parser.get_ldp_tree();
-//        LdpAnalyser a(errormsg, m_libraryScope, &doc);
-//        InternalModel* pIModel = a.analyse_tree(tree, "string:");
-//
-//        //cout << "[" << errormsg.str() << "]" << endl;
-//        //cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
-//
-//        CHECK( pIModel->get_root()->is_midi_info() == true );
-//        ImoMidiInfo* pInfo = dynamic_cast<ImoMidiInfo*>( pIModel->get_root() );
-//        CHECK( pInfo != NULL );
-//        CHECK( pInfo->get_midi_channel() == 0 );
-//        CHECK( pInfo->get_midi_program() == 56 );
-//
-//        delete tree->get_root();
-//        delete pIModel;
-//    }
-//
-//    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_MidiInfo_ChannelErrorValue)
-//    {
-//        stringstream errormsg;
-//        Document doc(m_libraryScope);
-//        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
-//        stringstream expected;
-//        expected << "Line 0. Invalid MIDI channel (0..15). Channel info ignored." << endl;
-//        parser.parse_text("(infoMIDI 56 25)");
-//        LdpTree* tree = parser.get_ldp_tree();
-//        LdpAnalyser a(errormsg, m_libraryScope, &doc);
-//        InternalModel* pIModel = a.analyse_tree(tree, "string:");
-//
-//        //cout << "[" << errormsg.str() << "]" << endl;
-//        //cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
-//
-//        ImoMidiInfo* pInfo = dynamic_cast<ImoMidiInfo*>( pIModel->get_root() );
-//        CHECK( pInfo != NULL );
-//        CHECK( pInfo->get_midi_channel() == 0 );
-//        CHECK( pInfo->get_midi_program() == 56 );
-//
-//        delete tree->get_root();
-//        delete pIModel;
-//    }
-//
-//    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_MidiInfo_InstrumentChannelOk)
-//    {
-//        stringstream errormsg;
-//        Document doc(m_libraryScope);
-//        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
-//        stringstream expected;
-//        //expected << "Line 0. " << endl;
-//        parser.parse_text("(infoMIDI 56 10)");
-//        LdpTree* tree = parser.get_ldp_tree();
-//        LdpAnalyser a(errormsg, m_libraryScope, &doc);
-//        InternalModel* pIModel = a.analyse_tree(tree, "string:");
-//
-//        //cout << "[" << errormsg.str() << "]" << endl;
-//        //cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
-//
-//        ImoMidiInfo* pInfo = dynamic_cast<ImoMidiInfo*>( pIModel->get_root() );
-//        CHECK( pInfo != NULL );
-//        CHECK( pInfo->get_midi_channel() == 10 );
-//        CHECK( pInfo->get_midi_program() == 56 );
-//
-//        delete tree->get_root();
-//        delete pIModel;
-//    }
-//
-//    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Instrument_MidiInfo)
-//    {
-//        stringstream errormsg;
-//        Document doc(m_libraryScope);
-//        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
-//        stringstream expected;
-//        //expected << "" << endl;
-//        parser.parse_text("(instrument (infoMIDI 56 12)(musicData))");
-//        LdpTree* tree = parser.get_ldp_tree();
-//        LdpAnalyser a(errormsg, m_libraryScope, &doc);
-//        InternalModel* pIModel = a.analyse_tree(tree, "string:");
-//
-//        //cout << "[" << errormsg.str() << "]" << endl;
-//        //cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
-//
-//        ImoInstrument* pInstr = dynamic_cast<ImoInstrument*>( pIModel->get_root() );
-//        CHECK( pInstr != NULL );
-//        CHECK( pInstr->get_num_staves() == 1 );
-//        CHECK( pInstr->get_name().get_text() == "" );
-//        CHECK( pInstr->get_abbrev().get_text() == "" );
-//        CHECK( pInstr->get_midi_channel() == 12 );
-//        CHECK( pInstr->get_midi_program() == 56 );
-//
-//        delete tree->get_root();
-//        delete pIModel;
-//    }
-
-
     //@ score-instrument ----------------------------------------------------------------
 
     TEST_FIXTURE(MxlAnalyserTestFixture, score_instrument_01)
@@ -2280,6 +2084,9 @@ SUITE(MxlAnalyserTest)
         CHECK( pScore->get_num_instruments() == 1 );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         CHECK( pInstr != NULL );
+        CHECK( pInstr->get_num_sounds() == 0 );
+        ImoSoundInfo* pInfo = pInstr->get_sound_info(0);
+        CHECK( pInfo == NULL );
 
         delete pIModel;
     }
@@ -2317,9 +2124,12 @@ SUITE(MxlAnalyserTest)
         CHECK( pScore->get_num_instruments() == 1 );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         CHECK( pInstr != NULL );
-        CHECK( pInstr->get_score_instr_id() == "P1-I1" );
+        ImoSoundInfo* pInfo = pInstr->get_sound_info(0);
+        CHECK( pInfo != NULL );
+        CHECK( pInstr->get_num_sounds() == 1 );
+        CHECK( pInfo->get_score_instr_id() == "P1-I1" );
 //        cout << test_name() << endl;
-//        cout << "score-instr: id= " << pInstr->get_score_instr_id() << endl;
+//        cout << "score-instr: id= " << pInfo->get_score_instr_id() << endl;
 
         delete pIModel;
     }
@@ -2356,11 +2166,14 @@ SUITE(MxlAnalyserTest)
         CHECK( pScore->get_num_instruments() == 1 );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         CHECK( pInstr != NULL );
-        CHECK( pInstr->get_score_instr_id() == "P1-I1" );
-        CHECK( pInstr->get_score_instr_name() == "" );
+        CHECK( pInstr->get_num_sounds() == 1 );
+        ImoSoundInfo* pInfo = pInstr->get_sound_info(0);
+        CHECK( pInfo != NULL );
+        CHECK( pInfo->get_score_instr_id() == "P1-I1" );
+        CHECK( pInfo->get_score_instr_name() == "" );
 //        cout << test_name() << endl;
-//        cout << "score-instr: id= " << pInstr->get_score_instr_id()
-//             << ", name= " << pInstr->get_score_instr_name() << endl;
+//        cout << "score-instr: id= " << pInfo->get_score_instr_id()
+//             << ", name= " << pInfo->get_score_instr_name() << endl;
 
         delete pIModel;
     }
@@ -2398,11 +2211,14 @@ SUITE(MxlAnalyserTest)
         CHECK( pScore->get_num_instruments() == 1 );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         CHECK( pInstr != NULL );
-        CHECK( pInstr->get_score_instr_id() == "P1-I1" );
-        CHECK( pInstr->get_score_instr_name() == "Marimba" );
+        CHECK( pInstr->get_num_sounds() == 1 );
+        ImoSoundInfo* pInfo = pInstr->get_sound_info(0);
+        CHECK( pInfo != NULL );
+        CHECK( pInfo->get_score_instr_id() == "P1-I1" );
+        CHECK( pInfo->get_score_instr_name() == "Marimba" );
 //        cout << test_name() << endl;
-//        cout << "score-instr: id= " << pInstr->get_score_instr_id()
-//             << ", name= " << pInstr->get_score_instr_name() << endl;
+//        cout << "score-instr: id= " << pInfo->get_score_instr_id()
+//             << ", name= " << pInfo->get_score_instr_name() << endl;
 
         delete pIModel;
     }
@@ -2441,15 +2257,18 @@ SUITE(MxlAnalyserTest)
         CHECK( pScore->get_num_instruments() == 1 );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         CHECK( pInstr != NULL );
-        CHECK( pInstr->get_score_instr_id() == "P1-I1" );
-        CHECK( pInstr->get_score_instr_name() == "ARIA Player" );
-        CHECK( pInstr->get_score_instr_abbrev() == "" );
-        CHECK( pInstr->get_score_instr_sound() == "wind.flutes.flute" );
+        CHECK( pInstr->get_num_sounds() == 1 );
+        ImoSoundInfo* pInfo = pInstr->get_sound_info(0);
+        CHECK( pInfo != NULL );
+        CHECK( pInfo->get_score_instr_id() == "P1-I1" );
+        CHECK( pInfo->get_score_instr_name() == "ARIA Player" );
+        CHECK( pInfo->get_score_instr_abbrev() == "" );
+        CHECK( pInfo->get_score_instr_sound() == "wind.flutes.flute" );
 //        cout << test_name() << endl;
-//        cout << "score-instr: id= " << pInstr->get_score_instr_id()
-//             << ", name= " << pInstr->get_score_instr_name()
-//             << ", abbrev= " << pInstr->get_score_instr_abbrev()
-//             << ", sound= " << pInstr->get_score_instr_sound() << endl;
+//        cout << "score-instr: id= " << pInfo->get_score_instr_id()
+//             << ", name= " << pInfo->get_score_instr_name()
+//             << ", abbrev= " << pInfo->get_score_instr_abbrev()
+//             << ", sound= " << pInfo->get_score_instr_sound() << endl;
 
         delete pIModel;
     }
@@ -2490,37 +2309,40 @@ SUITE(MxlAnalyserTest)
         CHECK( pScore->get_num_instruments() == 1 );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         CHECK( pInstr != NULL );
-        CHECK( pInstr->get_score_instr_id() == "P1-I1" );
-        CHECK( pInstr->get_score_instr_name() == "Marimba" );
-        CHECK( pInstr->get_midi_port() == 0 );
-        CHECK( pInstr->get_midi_device_name() == "Bank 1" );
-        CHECK( pInstr->get_midi_name() == "" );
-        CHECK( pInstr->get_midi_bank() == 0 );
-        CHECK( pInstr->get_midi_channel() == 0 );
-        CHECK( pInstr->get_midi_program() == 0 );
-        CHECK( pInstr->get_midi_unpitched() == -1 );
-        CHECK( is_equal(pInstr->get_midi_volume(), 1.0f) );
-        CHECK( pInstr->get_midi_pan() == 0.0 );
-        CHECK( pInstr->get_midi_elevation() == 0.0 );
+        CHECK( pInstr->get_num_sounds() == 1 );
+        ImoSoundInfo* pInfo = pInstr->get_sound_info(0);
+        CHECK( pInfo != NULL );
+        CHECK( pInfo->get_score_instr_id() == "P1-I1" );
+        CHECK( pInfo->get_score_instr_name() == "Marimba" );
+        CHECK( pInfo->get_midi_port() == 0 );
+        CHECK( pInfo->get_midi_device_name() == "Bank 1" );
+        CHECK( pInfo->get_midi_name() == "" );
+        CHECK( pInfo->get_midi_bank() == 0 );
+        CHECK( pInfo->get_midi_channel() == -1 );
+        CHECK( pInfo->get_midi_program() == 0 );
+        CHECK( pInfo->get_midi_unpitched() == -1 );
+        CHECK( is_equal(pInfo->get_midi_volume(), 1.0f) );
+        CHECK( pInfo->get_midi_pan() == 0.0 );
+        CHECK( pInfo->get_midi_elevation() == 0.0 );
 //        cout << test_name() << endl;
-//        cout << "instr.name= " << pInstr->get_name().get_text() << endl
-//             << "instr.abbrev= " << pInstr->get_abbrev().get_text() << endl
-//             << "id= " << pInstr->get_score_instr_id() << endl
-//             << "name= " << pInstr->get_score_instr_name() << endl
-//             << "abbrev= " << pInstr->get_score_instr_abbrev() << endl
-//             << "sound= " << pInstr->get_score_instr_sound() << endl
-//             << "virt.library= " << pInstr->get_score_instr_virtual_library() << endl
-//             << "virt.name= " << pInstr->get_score_instr_virtual_name() << endl
-//             << "port= " << pInstr->get_midi_port() << endl
-//             << "device name= " << pInstr->get_midi_device_name() << endl
-//             << "midi name= " << pInstr->get_midi_name() << endl
-//             << "bank= " << pInstr->get_midi_bank() << endl
-//             << "channel= " << pInstr->get_midi_channel() << endl
-//             << "program= " << pInstr->get_midi_program() << endl
-//             << "unpitched= " << pInstr->get_midi_unpitched() << endl
-//             << "volume= " << pInstr->get_midi_volume() << endl
-//             << "pan= " << pInstr->get_midi_pan() << endl
-//             << "elevation= " << pInstr->get_midi_elevation() << endl;
+//        cout << "instr.name= " << pInfo->get_name().get_text() << endl
+//             << "instr.abbrev= " << pInfo->get_abbrev().get_text() << endl
+//             << "id= " << pInfo->get_score_instr_id() << endl
+//             << "name= " << pInfo->get_score_instr_name() << endl
+//             << "abbrev= " << pInfo->get_score_instr_abbrev() << endl
+//             << "sound= " << pInfo->get_score_instr_sound() << endl
+//             << "virt.library= " << pInfo->get_score_instr_virtual_library() << endl
+//             << "virt.name= " << pInfo->get_score_instr_virtual_name() << endl
+//             << "port= " << pInfo->get_midi_port() << endl
+//             << "device name= " << pInfo->get_midi_device_name() << endl
+//             << "midi name= " << pInfo->get_midi_name() << endl
+//             << "bank= " << pInfo->get_midi_bank() << endl
+//             << "channel= " << pInfo->get_midi_channel() << endl
+//             << "program= " << pInfo->get_midi_program() << endl
+//             << "unpitched= " << pInfo->get_midi_unpitched() << endl
+//             << "volume= " << pInfo->get_midi_volume() << endl
+//             << "pan= " << pInfo->get_midi_pan() << endl
+//             << "elevation= " << pInfo->get_midi_elevation() << endl;
 
         delete pIModel;
     }
@@ -2563,11 +2385,14 @@ SUITE(MxlAnalyserTest)
         CHECK( pScore->get_num_instruments() == 1 );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         CHECK( pInstr != NULL );
-        CHECK( pInstr->get_score_instr_id() == "P1-I1" );
-        CHECK( pInstr->get_score_instr_name() == "Marimba" );
+        CHECK( pInstr->get_num_sounds() == 1 );
+        ImoSoundInfo* pInfo = pInstr->get_sound_info(0);
+        CHECK( pInfo != NULL );
+        CHECK( pInfo->get_score_instr_id() == "P1-I1" );
+        CHECK( pInfo->get_score_instr_name() == "Marimba" );
 //        cout << test_name() << endl;
-//        cout << "score-instr: id= " << pInstr->get_score_instr_id()
-//             << ", name= " << pInstr->get_score_instr_name() << endl;
+//        cout << "score-instr: id= " << pInfo->get_score_instr_id()
+//             << ", name= " << pInfo->get_score_instr_name() << endl;
 
         delete pIModel;
     }
@@ -2622,41 +2447,90 @@ SUITE(MxlAnalyserTest)
         CHECK( pInstr != NULL );
         CHECK( pInstr->get_name().get_text() == "Flute 1" );
         CHECK( pInstr->get_abbrev().get_text() == "Fl. 1" );
-        CHECK( pInstr->get_score_instr_id() == "P1-I1" );
-        CHECK( pInstr->get_score_instr_name() == "ARIA Player" );
-        CHECK( pInstr->get_score_instr_abbrev() == "ARIA" );
-        CHECK( pInstr->get_score_instr_sound() == "wind.flutes.flute" );
-        CHECK( pInstr->get_score_instr_virtual_library() == "Garritan Instruments for Finale" );
-	    CHECK( pInstr->get_score_instr_virtual_name() == "001. Woodwinds/1. Flutes/Flute Plr1" );
-        CHECK( pInstr->get_midi_port() == 0 );
-        CHECK( pInstr->get_midi_device_name() == "Bank 1" );
-        CHECK( pInstr->get_midi_name() == "" );
-        CHECK( pInstr->get_midi_bank() == 0 );
-        CHECK( pInstr->get_midi_channel() == 0 );
-        CHECK( pInstr->get_midi_program() == 0 );
-        CHECK( pInstr->get_midi_unpitched() == 0 );
-        CHECK( is_equal(pInstr->get_midi_volume(), 0.8f) );
-        CHECK( pInstr->get_midi_pan() == -70.0 );
-        CHECK( pInstr->get_midi_elevation() == 0.0 );
+        CHECK( pInstr->get_num_sounds() == 1 );
+        ImoSoundInfo* pInfo = pInstr->get_sound_info(0);
+        CHECK( pInfo != NULL );
+        CHECK( pInfo->get_score_instr_id() == "P1-I1" );
+        CHECK( pInfo->get_score_instr_name() == "ARIA Player" );
+        CHECK( pInfo->get_score_instr_abbrev() == "ARIA" );
+        CHECK( pInfo->get_score_instr_sound() == "wind.flutes.flute" );
+        CHECK( pInfo->get_score_instr_virtual_library() == "Garritan Instruments for Finale" );
+	    CHECK( pInfo->get_score_instr_virtual_name() == "001. Woodwinds/1. Flutes/Flute Plr1" );
+        CHECK( pInfo->get_midi_port() == 0 );
+        CHECK( pInfo->get_midi_device_name() == "Bank 1" );
+        CHECK( pInfo->get_midi_name() == "" );
+        CHECK( pInfo->get_midi_bank() == 0 );
+        CHECK( pInfo->get_midi_channel() == 0 );
+        CHECK( pInfo->get_midi_program() == 0 );
+        CHECK( pInfo->get_midi_unpitched() == 0 );
+        CHECK( is_equal(pInfo->get_midi_volume(), 0.8f) );
+        CHECK( pInfo->get_midi_pan() == -70.0 );
+        CHECK( pInfo->get_midi_elevation() == 0.0 );
 //        cout << test_name() << endl;
 //        cout << "instr.name= " << pInstr->get_name().get_text() << endl
 //             << "instr.abbrev= " << pInstr->get_abbrev().get_text() << endl
-//             << "id= " << pInstr->get_score_instr_id() << endl
-//             << "name= " << pInstr->get_score_instr_name() << endl
-//             << "abbrev= " << pInstr->get_score_instr_abbrev() << endl
-//             << "sound= " << pInstr->get_score_instr_sound() << endl
-//             << "virt.library= " << pInstr->get_score_instr_virtual_library() << endl
-//             << "virt.name= " << pInstr->get_score_instr_virtual_name() << endl
-//             << "port= " << pInstr->get_midi_port() << endl
-//             << "device name= " << pInstr->get_midi_device_name() << endl
-//             << "midi name= " << pInstr->get_midi_name() << endl
-//             << "bank= " << pInstr->get_midi_bank() << endl
-//             << "channel= " << pInstr->get_midi_channel() << endl
-//             << "program= " << pInstr->get_midi_program() << endl
-//             << "unpitched= " << pInstr->get_midi_unpitched() << endl
-//             << "volume= " << pInstr->get_midi_volume() << endl
-//             << "pan= " << pInstr->get_midi_pan() << endl
-//             << "elevation= " << pInstr->get_midi_elevation() << endl;
+//             << "id= " << pInfo->get_score_instr_id() << endl
+//             << "name= " << pInfo->get_score_instr_name() << endl
+//             << "abbrev= " << pInfo->get_score_instr_abbrev() << endl
+//             << "sound= " << pInfo->get_score_instr_sound() << endl
+//             << "virt.library= " << pInfo->get_score_instr_virtual_library() << endl
+//             << "virt.name= " << pInfo->get_score_instr_virtual_name() << endl
+//             << "port= " << pInfo->get_midi_port() << endl
+//             << "device name= " << pInfo->get_midi_device_name() << endl
+//             << "midi name= " << pInfo->get_midi_name() << endl
+//             << "bank= " << pInfo->get_midi_bank() << endl
+//             << "channel= " << pInfo->get_midi_channel() << endl
+//             << "program= " << pInfo->get_midi_program() << endl
+//             << "unpitched= " << pInfo->get_midi_unpitched() << endl
+//             << "volume= " << pInfo->get_midi_volume() << endl
+//             << "pan= " << pInfo->get_midi_pan() << endl
+//             << "elevation= " << pInfo->get_midi_elevation() << endl;
+
+        delete pIModel;
+    }
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, score_instrument_42)
+    {
+        //@42. midi-instrument. id doesn't match any score-instrument
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        expected << "Line 0. id 'I1' doesn't match any <score-instrument>"
+                 << ". <midi-instrument> ignored." << endl;
+        parser.parse_text(
+            "<score-partwise version='3.0'><part-list><score-part id='P1'>"
+                "<part-name>Music</part-name>"
+                "<score-instrument id='P1-I1'>"
+                    "<instrument-name>Marimba</instrument-name>"
+                "</score-instrument>"
+                "<midi-instrument id='I1'>"
+                    "<midi-channel>1</midi-channel>"
+                "</midi-instrument>"
+            "</score-part></part-list><part id='P1'></part></score-partwise>");
+        MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pIModel->get_root() != NULL);
+        CHECK( pIModel->get_root()->is_document() == true );
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pIModel->get_root() );
+        CHECK( pDoc != NULL );
+        CHECK( pDoc->get_num_content_items() == 1 );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore != NULL );
+        CHECK( pScore->get_num_instruments() == 1 );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        CHECK( pInstr != NULL );
+        CHECK( pInstr->get_num_sounds() == 1 );
+        ImoSoundInfo* pInfo = pInstr->get_sound_info(0);
+        CHECK( pInfo != NULL );
+        CHECK( pInfo->get_score_instr_id() == "P1-I1" );
+        CHECK( pInfo->get_score_instr_name() == "Marimba" );
 
         delete pIModel;
     }

--- a/src/tests/lomse_test_score_cursor.cpp
+++ b/src/tests/lomse_test_score_cursor.cpp
@@ -227,14 +227,14 @@ public:
         //(barline#133L) ))
         //
         //(instrument (staves 2)(musicData
-        //(clef#136L G p1)(clef#137L F4 p2)(key#138L D)(time#139L 2 4)
-        //(n#140L f4 q v1 p1)
-        //(n#141L c3 s g+ v2 p2)(n#142L d3 s v2 p2)(n#143L e3 s v2 p2)(n#144L f3 s g- v2 p2)
-        //(n#154L g3 e g+ v2 p2)(n#155L d3 e g- v2 p2)
-        //(barline#161L)
-        //(n#82L a4 e. v1 p1)
-        //(n#163L c3 q v2 p2)(n#164L g3 q v2 p2)
-        //(barline#165L) ))
+        //(clef#138L G p1)(clef#139L F4 p2)(key#140L D)(time#141L 2 4)
+        //(n#142L f4 q v1 p1)
+        //(n#143L c3 s g+ v2 p2)(n#144L d3 s v2 p2)(n#145L e3 s v2 p2)(n#146L f3 s g- v2 p2)
+        //(n#156L g3 e g+ v2 p2)(n#157L d3 e g- v2 p2)
+        //(barline#163L)
+        //(n#164L a4 e. v1 p1)
+        //(n#165L c3 q v2 p2)(n#166L g3 q v2 p2)
+        //(barline#167L) ))
         m_pDoc = LOMSE_NEW Document(m_libraryScope);
         m_pDoc->from_string(
             "(score (vers 2.0)"
@@ -257,6 +257,8 @@ public:
             "            (barline)"
             "    )))" );
         m_pScore = static_cast<ImoScore*>( m_pDoc->get_imodoc()->get_content_item(0) );
+//        cout << test_name() << endl;
+//        cout << m_pDoc->to_string(true) << endl;
     }
 
     void create_document_8()
@@ -314,6 +316,11 @@ public:
     {
         ColStaffObjs* pCol = m_pScore->get_staffobjs_table();
         cout << pCol->dump();
+    }
+
+    inline const char* test_name()
+    {
+        return UnitTest::CurrentTest::Details()->testName;
     }
 
     LibraryScope m_libraryScope;
@@ -777,7 +784,7 @@ SUITE(ScoreCursorTest)
 
         cursor.move_next();     //to clef F4 on instr 2, staff 1
 //        cout << cursor.dump_cursor();
-        CHECK_CURRENT_STATE(cursor, 1, 0, 0, 0.0, 136L, 136L);
+        CHECK_CURRENT_STATE(cursor, 1, 0, 0, 0.0, 138L, 138L);
     }
 
     TEST_FIXTURE(ScoreCursorTestFixture, move_next_176)
@@ -787,7 +794,7 @@ SUITE(ScoreCursorTest)
         MyScoreCursor cursor(m_pDoc, m_pScore);
 //        cout << m_pDoc->to_string(true) << endl;
 //        dump_col_staff_objs();
-        cursor.point_to(164L);   //to last note instr 2, staff 2
+        cursor.point_to(166L);   //to last note instr 2, staff 2
         cursor.move_next();     //to barline 164L
 
         cursor.move_next();     //to end of score
@@ -811,37 +818,37 @@ SUITE(ScoreCursorTest)
 //        cout << m_pDoc->to_string(true) << endl;
 //        dump_col_staff_objs();
 
-        cursor.point_to(141L);   //first note in instr 2, staff 2
+        cursor.point_to(143L);   //first note in instr 2, staff 2
         cursor.set_current_voice(2);
-        CHECK_CURRENT_STATE(cursor, 1, 1, 0, 0.0, 141L, 141L);
+        CHECK_CURRENT_STATE(cursor, 1, 1, 0, 0.0, 143L, 143L);
 
         cursor.move_next();
-        CHECK_CURRENT_STATE(cursor, 1, 1, 0, 16.0, 142L, 142L);
+        CHECK_CURRENT_STATE(cursor, 1, 1, 0, 16.0, 144L, 144L);
 //        cout << cursor.dump_cursor();
 
         cursor.move_next();
-        CHECK_CURRENT_STATE(cursor, 1, 1, 0, 32.0, 143L, 143L);
+        CHECK_CURRENT_STATE(cursor, 1, 1, 0, 32.0, 145L, 145L);
 
         cursor.move_next();
-        CHECK_CURRENT_STATE(cursor, 1, 1, 0, 48.0, 144L, 144L);
+        CHECK_CURRENT_STATE(cursor, 1, 1, 0, 48.0, 146L, 146L);
 
         cursor.move_next();
-        CHECK_CURRENT_STATE(cursor, 1, 1, 0, 64.0, 154L, 154L);
+        CHECK_CURRENT_STATE(cursor, 1, 1, 0, 64.0, 156L, 156L);
 
         cursor.move_next();
-        CHECK_CURRENT_STATE(cursor, 1, 1, 0, 96.0, 155L, 155L);
+        CHECK_CURRENT_STATE(cursor, 1, 1, 0, 96.0, 157L, 157L);
 
         cursor.move_next();     //to barline 80L
-        CHECK_CURRENT_STATE(cursor, 1, 1, 0, 128.0, 161L, 161L);
+        CHECK_CURRENT_STATE(cursor, 1, 1, 0, 128.0, 163L, 163L);
 
         cursor.move_next();
-        CHECK_CURRENT_STATE(cursor, 1, 1, 1, 128.0, 163L, 163L);
+        CHECK_CURRENT_STATE(cursor, 1, 1, 1, 128.0, 165L, 165L);
 
         cursor.move_next();
-        CHECK_CURRENT_STATE(cursor, 1, 1, 1, 192.0, 164L, 164L);
+        CHECK_CURRENT_STATE(cursor, 1, 1, 1, 192.0, 166L, 166L);
 
         cursor.move_next();     //to barline 164L
-        CHECK_CURRENT_STATE(cursor, 1, 1, 1, 256.0, 165L, 165L);
+        CHECK_CURRENT_STATE(cursor, 1, 1, 1, 256.0, 167L, 167L);
 
         cursor.move_next();     //to end of score
         CHECK_CURRENT_STATE_AT_END_OF_SCORE(cursor, 1, 1, 2, 256.0f);
@@ -1381,8 +1388,8 @@ SUITE(ScoreCursorTest)
         MyScoreCursor cursor(m_pDoc, m_pScore);
         //cout << m_pDoc->to_string(true) << endl;
         //dump_col_staff_objs();
-        cursor.point_to(136L);   //clef instr 2, staff 1
-        CHECK_CURRENT_STATE(cursor, 1, 0, 0, 0.0, 136L, 136L);
+        cursor.point_to(138L);   //clef instr 2, staff 1
+        CHECK_CURRENT_STATE(cursor, 1, 0, 0, 0.0, 138L, 138L);
 
         cursor.move_prev();
 
@@ -1453,8 +1460,8 @@ SUITE(ScoreCursorTest)
         //235. from start of staff -> to end of prev staff -> to barline
         create_document_7();
         MyScoreCursor cursor(m_pDoc, m_pScore);
-        cursor.point_to(136L);   //start of instr 2, staff 1
-        CHECK_CURRENT_STATE(cursor, 1, 0, 0, 0.0, 136L, 136L);
+        cursor.point_to(138L);   //start of instr 2, staff 1
+        CHECK_CURRENT_STATE(cursor, 1, 0, 0, 0.0, 138L, 138L);
 
         cursor.move_prev();     //end of instr 1, staff 2
         CHECK_CURRENT_STATE_AT_END_OF_STAFF(cursor, 0, 1, 2, 256.0f);
@@ -1589,7 +1596,7 @@ SUITE(ScoreCursorTest)
 
         cursor.to_measure(1, 1, 1);
 
-        CHECK_CURRENT_STATE(cursor, 1, 1, 1, 128.0, 163L, 163L);
+        CHECK_CURRENT_STATE(cursor, 1, 1, 1, 128.0, 165L, 165L);
         //cout << cursor.dump_cursor();
     }
 
@@ -1922,7 +1929,7 @@ SUITE(ScoreCursorTest)
         //408. bug1. restore end of staff state: bad instrument
         create_document_7();
         MyScoreCursor cursor(m_pDoc, m_pScore);
-        cursor.point_to(136L);   //start of instr 2, staff 1
+        cursor.point_to(138L);   //start of instr 2, staff 1
         cursor.move_prev();     //end of instr 1, staff 2
         CHECK_CURRENT_STATE_AT_END_OF_STAFF(cursor, 0, 1, 2, 256.0f);
         SpElementCursorState spState = cursor.get_state();


### PR DESCRIPTION
Instead of assigning MIDI channel 0 to any instrument without MIDI settings, now a different channel is assigned to each instrument. Also some changes for starting other pending fixes. The main changes are:

* ImoInstrument now supports many ImoSoundInfo nodes.
* Parsing an &lt;score-instrument&gt; element now generates a new ImoSoundInfo node.
* &lt;midi-instrument&gt; element is now required to match an id in &lt;score-instrument&gt; list
* ImoMidiInfo has been replaced by ImoSoundInfo. ImoMidiInfo removed.
* ImoSoundInfo initialization: changed for no channel, no port.
* ModelBuilder: Added class MidiAssigner to do midi mapping when no midi information in any instrument.
* Added class JumpsTable, for starting to deal with repetitions in playback.