### PR TITLE
Import and render <coda>/<segno> repetition marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 [Since last version] 0.21.0
 =============================
 
+##### BACKWARDS INCOMPATIBLE CHANGES WITH 0.21.0
+
+- None.
+
+##### COMPATIBLE CHANGES
+
+- Changes for improving support for MusicXML:
+	- Import and render coda and segno symbols.
+
+
+
+Version [0.21.0] (9/Nov/2017)
+=============================
+
 ##### BACKWARDS INCOMPATIBLE CHANGES WITH 0.20.0
 
 - Building Lomse now requires to use c++11 or greater.
@@ -504,7 +518,8 @@ Version 0.10.b1
 - Initial public release, used in Phonascus 5.0 beta for Linux.
 
 
-[Since last version]: https://github.com/lenmus/lomse/compare/0.20.0...HEAD
+[Since last version]: https://github.com/lenmus/lomse/compare/0.21.0...HEAD
+[0.21.0]: https://github.com/lenmus/lomse/compare/0.20.0...0.21.0
 [0.20.0]: https://github.com/lenmus/lomse/compare/0.19.0...0.20.0
 [0.19.0]: https://github.com/lenmus/lomse/compare/0.18.0...0.19.0
 [0.18.0]: https://github.com/lenmus/lomse/compare/0.17.20...0.18.0

--- a/add-sources.cmake
+++ b/add-sources.cmake
@@ -78,6 +78,7 @@ set(GRAPHIC_MODEL_FILES
     ${LOMSE_SRC_DIR}/graphic_model/engravers/lomse_barline_engraver.cpp
     ${LOMSE_SRC_DIR}/graphic_model/engravers/lomse_chord_engraver.cpp
     ${LOMSE_SRC_DIR}/graphic_model/engravers/lomse_clef_engraver.cpp
+    ${LOMSE_SRC_DIR}/graphic_model/engravers/lomse_coda_segno_engraver.cpp
     ${LOMSE_SRC_DIR}/graphic_model/engravers/lomse_dynamics_mark_engraver.cpp
     ${LOMSE_SRC_DIR}/graphic_model/engravers/lomse_engraver.cpp
     ${LOMSE_SRC_DIR}/graphic_model/engravers/lomse_engrouters.cpp

--- a/include/lomse_coda_segno_engraver.h
+++ b/include/lomse_coda_segno_engraver.h
@@ -1,0 +1,74 @@
+//---------------------------------------------------------------------------------------
+// This file is part of the Lomse library.
+// Lomse is copyrighted work (c) 2010-2017. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice, this
+//      list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright notice, this
+//      list of conditions and the following disclaimer in the documentation and/or
+//      other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+// SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// For any comment, suggestion or feature request, please contact the manager of
+// the project at cecilios@users.sourceforge.net
+//---------------------------------------------------------------------------------------
+
+#ifndef __LOMSE_SEGNO_CODA_ENGRAVER_H__        //to avoid nested includes
+#define __LOMSE_SEGNO_CODA_ENGRAVER_H__
+
+#include "lomse_basic.h"
+#include "lomse_injectors.h"
+#include "lomse_engraver.h"
+
+namespace lomse
+{
+
+//forward declarations
+class ImoSymbolRepetitionMark;
+class GmoShape;
+class ScoreMeter;
+class GmoShapeCodaSegno;
+
+//---------------------------------------------------------------------------------------
+class CodaSegnoEngraver : public Engraver
+{
+protected:
+    ImoSymbolRepetitionMark* m_pRepetitionMark;
+    GmoShape* m_pParentShape;
+    GmoShapeCodaSegno* m_pCodaSegnoShape;
+
+public:
+    CodaSegnoEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
+                      int iInstr, int iStaff);
+    ~CodaSegnoEngraver() {}
+
+    GmoShapeCodaSegno* create_shape(ImoSymbolRepetitionMark* pRepetitionMark, UPoint pos,
+                                    Color color=Color(0,0,0),
+                                    GmoShape* pParentShape=NULL);
+
+protected:
+    UPoint compute_location(UPoint pos);
+    void center_on_parent();
+    int find_glyph();
+
+};
+
+
+}   //namespace lomse
+
+#endif    // __LOMSE_SEGNO_CODA_ENGRAVER_H__
+

--- a/include/lomse_gm_basic.h
+++ b/include/lomse_gm_basic.h
@@ -144,7 +144,9 @@ public:
                 k_shape_barline,
                 k_shape_beam, k_shape_brace,
                 k_shape_bracket, k_shape_button,
-                k_shape_clef, k_shape_dot, k_shape_dynamics_mark,
+                k_shape_clef,
+                k_shape_coda_segno,
+                k_shape_dot, k_shape_dynamics_mark,
                 k_shape_fermata, k_shape_flag, k_shape_image,
                 k_shape_invisible, k_shape_key_signature, k_shape_lyrics,
                 k_shape_metronome_glyph, k_shape_metronome_mark,
@@ -196,6 +198,7 @@ public:
     inline bool is_shape_bracket() { return m_objtype == k_shape_bracket; }
     inline bool is_shape_button() { return m_objtype == k_shape_button; }
     inline bool is_shape_clef() { return m_objtype == k_shape_clef; }
+    inline bool is_shape_coda_segno() { return m_objtype == k_shape_coda_segno; }
     inline bool is_shape_dot() { return m_objtype == k_shape_dot; }
     inline bool is_shape_dynamics_mark() { return m_objtype == k_shape_dynamics_mark; }
     inline bool is_shape_fermata() { return m_objtype == k_shape_fermata; }

--- a/include/lomse_internal_model.h
+++ b/include/lomse_internal_model.h
@@ -523,8 +523,9 @@ class ImoWrapperBox;
                         k_imo_dynamics_mark,
                         k_imo_fermata,
                         k_imo_ornament,
-                        k_imo_repetition_mark,
+                        k_imo_symbol_repetition_mark,
                         k_imo_technical,
+                        k_imo_text_repetition_mark,
 
                         // ImoArticulation (A)
                         k_imo_articulation,
@@ -887,7 +888,8 @@ public:
     inline bool is_point_dto() { return m_objtype == k_imo_point_dto; }
     inline bool is_rest() { return m_objtype == k_imo_rest; }
     inline bool is_relations() { return m_objtype == k_imo_relations; }
-    inline bool is_repetition_mark() { return m_objtype == k_imo_repetition_mark; }
+    inline bool is_repetition_mark() { return m_objtype == k_imo_text_repetition_mark
+                                           || m_objtype == k_imo_symbol_repetition_mark; }
 	inline bool is_score() { return m_objtype == k_imo_score; }
     inline bool is_score_line() { return m_objtype == k_imo_score_line; }
     inline bool is_score_player() { return m_objtype == k_imo_score_player; }
@@ -902,6 +904,7 @@ public:
     inline bool is_staff_info() { return m_objtype == k_imo_staff_info; }
     inline bool is_style() { return m_objtype == k_imo_style; }
     inline bool is_styles() { return m_objtype == k_imo_styles; }
+    inline bool is_symbol_repetition_mark() { return m_objtype == k_imo_symbol_repetition_mark; }
     inline bool is_system_break() { return m_objtype == k_imo_system_break; }
     inline bool is_system_info() { return m_objtype == k_imo_system_info; }
     inline bool is_table() { return m_objtype == k_imo_table; }
@@ -915,6 +918,7 @@ public:
     inline bool is_text_style() { return m_objtype == k_imo_text_style; }
     inline bool is_textblock_info() { return m_objtype == k_imo_textblock_info; }
     inline bool is_text_box() { return m_objtype == k_imo_text_box; }
+    inline bool is_text_repetition_mark() { return m_objtype == k_imo_text_repetition_mark; }
     inline bool is_tie() { return m_objtype == k_imo_tie; }
     inline bool is_tie_data() { return m_objtype == k_imo_tie_data; }
     inline bool is_tie_dto() { return m_objtype == k_imo_tie_dto; }
@@ -2877,6 +2881,58 @@ public:
 	inline bool is_sound_repeat() { return m_soundRepeat != k_repeat_none; }
 };
 
+////---------------------------------------------------------------------------------------
+//class ImoDirectionSymbol : public ImoAuxObj
+//{
+//protected:
+//    ImoTextInfo m_text;
+//
+//    friend class ImFactory;
+//    ImoDirectionSymbol() : ImoAuxObj(k_imo_score_text), m_text() {}
+//    ImoDirectionSymbol(int objtype) : ImoAuxObj(objtype), m_text() {}
+//
+//public:
+//    virtual ~ImoDirectionSymbol() {}
+//
+//    //getters
+//    inline string& get_text() { return m_text.get_text(); }
+//
+//    //setters
+//    inline void set_text(const std::string& value) { m_text.set_text(value); }
+//
+//};
+
+//---------------------------------------------------------------------------------------
+class ImoSymbolRepetitionMark : public ImoAuxObj
+{
+protected:
+    int m_symbol;       //a value from enum ESymbolRepetitionMark
+
+    friend class ImFactory;
+    ImoSymbolRepetitionMark()
+        : ImoAuxObj(k_imo_symbol_repetition_mark)
+        , m_symbol(ImoSymbolRepetitionMark::k_undefined)
+    {
+    }
+
+public:
+    virtual ~ImoSymbolRepetitionMark() {}
+
+    enum ESymbolRepetitionMark
+    {
+        k_undefined = 0,
+        k_coda,
+        k_segno,
+    };
+
+    //getters
+    inline int get_symbol() { return m_symbol; }
+
+    //setters
+    inline void set_symbol(int value) { m_symbol = value; }
+
+};
+
 //---------------------------------------------------------------------------------------
 class ImoDynamic : public ImoContent
 {
@@ -3281,7 +3337,7 @@ protected:
 
     friend class ImFactory;
     ImoTextRepetitionMark()
-        : ImoScoreText(k_imo_repetition_mark)
+        : ImoScoreText(k_imo_text_repetition_mark)
     {
     }
 

--- a/include/lomse_internal_model.h
+++ b/include/lomse_internal_model.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2017. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -2847,7 +2847,7 @@ protected:
     // marks or a <direction-type> children of type <segno>/<coda>, or a <words>
     // related to repetition marks, these members contains the type of mark.
     // Otherwise, contains k_repeat_none.
-	int	    m_wordsRepeat;
+	int	    m_displayRepeat;
 	int     m_soundRepeat;
 
 
@@ -2856,7 +2856,7 @@ protected:
         : ImoStaffObj(k_imo_direction)
         , m_space(0.0f)
         , m_placement(k_placement_default)
-        , m_wordsRepeat(k_repeat_none)
+        , m_displayRepeat(k_repeat_none)
         , m_soundRepeat(k_repeat_none)
      {
      }
@@ -2867,17 +2867,17 @@ public:
     //getters
     inline Tenths get_width() { return m_space; }
     inline int get_placement() { return m_placement; }
-    inline int get_words_repeat() { return m_wordsRepeat; }
+    inline int get_display_repeat() { return m_displayRepeat; }
     inline int get_sound_repeat() { return m_soundRepeat; }
 
     //setters
     inline void set_width(Tenths space) { m_space = space; }
     inline void set_placement(int placement) { m_placement = placement; }
-    inline void set_words_repeat(int repeat) { m_wordsRepeat = repeat; }
+    inline void set_display_repeat(int repeat) { m_displayRepeat = repeat; }
     inline void set_sound_repeat(int repeat) { m_soundRepeat = repeat; }
 
     //info
-	inline bool is_words_repeat() { return m_wordsRepeat != k_repeat_none; }
+	inline bool is_display_repeat() { return m_displayRepeat != k_repeat_none; }
 	inline bool is_sound_repeat() { return m_soundRepeat != k_repeat_none; }
 };
 

--- a/include/lomse_mxl_analyser.h
+++ b/include/lomse_mxl_analyser.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2017. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/include/lomse_shape_base.h
+++ b/include/lomse_shape_base.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2017. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/include/lomse_shapes.h
+++ b/include/lomse_shapes.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2017. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -336,6 +336,19 @@ protected:
         : GmoShapeGlyph(pCreatorImo, GmoObj::k_shape_technical, idx, nGlyph, pos, color,
                         libraryScope, fontSize )
         , VoiceRelatedShape()
+    {
+    }
+};
+
+//---------------------------------------------------------------------------------------
+class GmoShapeCodaSegno : public GmoShapeGlyph
+{
+protected:
+    friend class CodaSegnoEngraver;
+    GmoShapeCodaSegno(ImoObj* pCreatorImo, ShapeId idx, int nGlyph, UPoint pos,
+                      Color color, LibraryScope& libraryScope, double fontSize)
+        : GmoShapeGlyph(pCreatorImo, GmoObj::k_shape_coda_segno, idx, nGlyph, pos, color,
+                        libraryScope, fontSize )
     {
     }
 };

--- a/src/graphic_model/engravers/lomse_coda_segno_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_coda_segno_engraver.cpp
@@ -1,0 +1,111 @@
+//---------------------------------------------------------------------------------------
+// This file is part of the Lomse library.
+// Lomse is copyrighted work (c) 2010-2017. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice, this
+//      list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright notice, this
+//      list of conditions and the following disclaimer in the documentation and/or
+//      other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+// SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// For any comment, suggestion or feature request, please contact the manager of
+// the project at cecilios@users.sourceforge.net
+//---------------------------------------------------------------------------------------
+
+#include "lomse_coda_segno_engraver.h"
+
+#include "lomse_internal_model.h"
+#include "lomse_engraving_options.h"
+#include "lomse_score_meter.h"
+#include "lomse_shapes.h"
+#include "lomse_glyphs.h"
+
+
+namespace lomse
+{
+
+//---------------------------------------------------------------------------------------
+// CodaSegnoEngraver implementation
+//---------------------------------------------------------------------------------------
+CodaSegnoEngraver::CodaSegnoEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
+                                     int UNUSED(iInstr), int UNUSED(iStaff))
+    : Engraver(libraryScope, pScoreMeter)
+{
+}
+
+//---------------------------------------------------------------------------------------
+GmoShapeCodaSegno* CodaSegnoEngraver::create_shape(ImoSymbolRepetitionMark* pRepetitionMark,
+                                                   UPoint pos, Color color,
+                                                   GmoShape* pParentShape)
+{
+    m_pRepetitionMark = pRepetitionMark;
+    m_pParentShape = pParentShape;
+
+    int iGlyph = find_glyph();
+    double fontSize = determine_font_size();
+    UPoint position = compute_location(pos);
+    ShapeId idx = 0;
+    m_pCodaSegnoShape =
+        LOMSE_NEW GmoShapeCodaSegno(pRepetitionMark, idx, iGlyph, position,
+                                    color, m_libraryScope, fontSize);
+    center_on_parent();
+
+    return m_pCodaSegnoShape;
+}
+
+//---------------------------------------------------------------------------------------
+UPoint CodaSegnoEngraver::compute_location(UPoint pos)
+{
+    pos.y -= tenths_to_logical(20.0f);
+	return pos;
+}
+
+//---------------------------------------------------------------------------------------
+void CodaSegnoEngraver::center_on_parent()
+{
+    if (!m_pParentShape)
+        return;
+
+    //Center coda/segno on parent shape
+    LUnits uCenterPos = m_pParentShape->get_left() + m_pParentShape->get_width() / 2.0f;
+    LUnits xShift = uCenterPos -
+        (m_pCodaSegnoShape->get_left() + m_pCodaSegnoShape->get_width() / 2.0f);
+
+    if (xShift != 0.0f)
+    {
+        USize shift(xShift, 0.0f);
+        m_pCodaSegnoShape->shift_origin(shift);
+    }
+}
+
+//---------------------------------------------------------------------------------------
+int CodaSegnoEngraver::find_glyph()
+{
+    switch(m_pRepetitionMark->get_symbol())
+    {
+        case ImoSymbolRepetitionMark::k_coda:
+            return k_glyph_coda;
+        case ImoSymbolRepetitionMark::k_segno:
+            return k_glyph_segno;
+        default:
+            return k_glyph_coda;   //TODO: what to do if arrives here?
+    }
+}
+
+
+}  //namespace lomse

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -1107,7 +1107,7 @@ GmoShape* ShapesCreator::create_auxobj_shape(ImoAuxObj* pAO, int iInstr, int iSt
             return engrv.create_shape(pImo, pos);
         }
         case k_imo_score_text:
-        case k_imo_repetition_mark:
+        case k_imo_text_repetition_mark:
         {
             ImoScoreText* pImo = static_cast<ImoScoreText*>(pAO);
             TextEngraver engrv(m_libraryScope, m_pScoreMeter, pImo->get_text(),
@@ -1120,6 +1120,14 @@ GmoShape* ShapesCreator::create_auxobj_shape(ImoAuxObj* pAO, int iInstr, int iSt
             TechnicalEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr, iStaff);
             Color color = pImo->get_color();
             return engrv.create_shape(pImo, pos, color, pParentShape);
+        }
+        case k_imo_symbol_repetition_mark:
+        {
+//            ImoSymbolRepetitionMark* pImo = static_cast<ImoSymbolRepetitionMark*>(pAO);
+//            SymbolRepetitionMarkEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr, iStaff);
+//            Color color = pImo->get_color();
+//            return engrv.create_shape(pImo, pos, color, pParentShape);
+            return create_invisible_shape(pAO, iInstr, iStaff, pos, 0.0f);
         }
         default:
             return create_invisible_shape(pAO, iInstr, iStaff, pos, 0.0f);

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2017. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -71,6 +71,7 @@
 #include "lomse_lyric_engraver.h"
 #include "lomse_spacing_algorithm_gourlay.h"
 #include "lomse_volta_engraver.h"
+#include "lomse_coda_segno_engraver.h"
 
 namespace lomse
 {
@@ -1123,11 +1124,10 @@ GmoShape* ShapesCreator::create_auxobj_shape(ImoAuxObj* pAO, int iInstr, int iSt
         }
         case k_imo_symbol_repetition_mark:
         {
-//            ImoSymbolRepetitionMark* pImo = static_cast<ImoSymbolRepetitionMark*>(pAO);
-//            SymbolRepetitionMarkEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr, iStaff);
-//            Color color = pImo->get_color();
-//            return engrv.create_shape(pImo, pos, color, pParentShape);
-            return create_invisible_shape(pAO, iInstr, iStaff, pos, 0.0f);
+            ImoSymbolRepetitionMark* pImo = static_cast<ImoSymbolRepetitionMark*>(pAO);
+            CodaSegnoEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr, iStaff);
+            Color color = pImo->get_color();
+            return engrv.create_shape(pImo, pos, color, pParentShape);
         }
         default:
             return create_invisible_shape(pAO, iInstr, iStaff, pos, 0.0f);

--- a/src/graphic_model/layouters/lomse_spacing_algorithm_gourlay.cpp
+++ b/src/graphic_model/layouters/lomse_spacing_algorithm_gourlay.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2017. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/src/graphic_model/lomse_gm_basic.cpp
+++ b/src/graphic_model/lomse_gm_basic.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2017. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -183,6 +183,7 @@ const string& GmoObj::get_name(int objtype)
         m_typeToName[k_shape_bracket]           = "bracket        ";
         m_typeToName[k_shape_button]            = "button         ";
         m_typeToName[k_shape_clef]              = "clef           ";
+        m_typeToName[k_shape_coda_segno]        = "coda-segno     ";
         m_typeToName[k_shape_dot]               = "dot            ";
         m_typeToName[k_shape_dynamics_mark]     = "dynamics-mark  ";
         m_typeToName[k_shape_fermata]           = "fermata        ";

--- a/src/internal_model/lomse_im_factory.cpp
+++ b/src/internal_model/lomse_im_factory.cpp
@@ -101,7 +101,6 @@ ImoObj* ImFactory::inject(int type, Document* pDoc, ImoId id)
         case k_imo_para:                pObj = LOMSE_NEW ImoParagraph();          break;
         case k_imo_param_info:          pObj = LOMSE_NEW ImoParamInfo();          break;
         case k_imo_relations:           pObj = LOMSE_NEW ImoRelations();          break;
-        case k_imo_repetition_mark:     pObj = LOMSE_NEW ImoTextRepetitionMark(); break;
         case k_imo_rest:                pObj = LOMSE_NEW ImoRest();               break;
         case k_imo_score:               pObj = LOMSE_NEW ImoScore(pDoc);          break;
         case k_imo_score_line:          pObj = LOMSE_NEW ImoScoreLine();          break;
@@ -116,6 +115,7 @@ ImoObj* ImFactory::inject(int type, Document* pDoc, ImoId id)
         case k_imo_staff_info:          pObj = LOMSE_NEW ImoStaffInfo();          break;
         case k_imo_style:               pObj = LOMSE_NEW ImoStyle();              break;
         case k_imo_styles:              pObj = LOMSE_NEW ImoStyles(pDoc);         break;
+        case k_imo_symbol_repetition_mark:  pObj = LOMSE_NEW ImoSymbolRepetitionMark();   break;
         case k_imo_system_break:        pObj = LOMSE_NEW ImoSystemBreak();        break;
         case k_imo_system_info:         pObj = LOMSE_NEW ImoSystemInfo();         break;
         case k_imo_table:               pObj = LOMSE_NEW ImoTable();              break;
@@ -128,6 +128,7 @@ ImoObj* ImFactory::inject(int type, Document* pDoc, ImoId id)
         case k_imo_text_box:            pObj = LOMSE_NEW ImoTextBox();            break;
         case k_imo_text_info:           pObj = LOMSE_NEW ImoTextInfo();           break;
         case k_imo_text_item:           pObj = LOMSE_NEW ImoTextItem();           break;
+        case k_imo_text_repetition_mark:   pObj = LOMSE_NEW ImoTextRepetitionMark();   break;
         case k_imo_tie:                 pObj = LOMSE_NEW ImoTie();                break;
         case k_imo_tie_dto:             pObj = LOMSE_NEW ImoTieDto();             break;
         case k_imo_time_modification_dto:  pObj = LOMSE_NEW ImoTimeModificationDto();  break;

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -410,13 +410,14 @@ const string& ImoObj::get_name(int type)
         m_TypeToName[k_imo_dynamics_mark] = "dynamics-mark";
         m_TypeToName[k_imo_fermata] = "fermata";
         m_TypeToName[k_imo_line] = "line";
-        m_TypeToName[k_imo_repetition_mark] = "repetition-mark";
+        m_TypeToName[k_imo_ornament] = "ornament";
         m_TypeToName[k_imo_score_text] = "score-text";
         m_TypeToName[k_imo_score_line] = "score-line";
         m_TypeToName[k_imo_score_title] = "title";
-        m_TypeToName[k_imo_ornament] = "ornament";
+        m_TypeToName[k_imo_symbol_repetition_mark] = "symbol-repetition-mark";
         m_TypeToName[k_imo_technical] = "technical";
         m_TypeToName[k_imo_text_box] = "text-box";
+        m_TypeToName[k_imo_text_repetition_mark] = "text-repetition-mark";
 
         // ImoAuxRelObj (A)
         m_TypeToName[k_imo_lyric] = "lyric";
@@ -1519,7 +1520,7 @@ int ImoRelations::get_priority(int type)
         priority[k_imo_volta_bracket] = 4;
         priority[k_imo_slur] = 5;
         priority[k_imo_fermata] = 6;
-        priority[k_imo_repetition_mark] = 7;
+        priority[k_imo_text_repetition_mark] = 7;
 
         fMapInitialized = true;
     };

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2017. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -636,6 +636,7 @@ protected:
     //
     void get_attributes_for_text_formatting(ImoObj* pImo)
     {
+        //TODO
         //get_attributes_for_justify(pImo);
         get_attributes_for_print_style_align(pImo);
         //get_attributes_for_text_decoration(pImo);
@@ -661,6 +662,7 @@ protected:
     void get_attributes_for_print_style_align(ImoObj* pImo)
     {
         get_attributes_for_print_style(pImo);
+        //TODO
         //get_attributes_for_halign(pImo);
         //get_attributes_for_valign(pImo);
     }
@@ -678,6 +680,7 @@ protected:
     void get_attributes_for_print_style(ImoObj* pImo)
     {
         get_attributes_for_position(pImo);
+        //TODO
         //get_attributes_for_font(pImo);
         get_attribute_color(pImo);
     }
@@ -1806,14 +1809,17 @@ protected:
 };
 
 //@--------------------------------------------------------------------------------------
+//@ <attributes>
+//@
+//@ The attributes element contains musical information that typically changes
+//@ on measure boundaries. This includes key and time signatures, clefs,
+//@ transpositions, and staving.
+//@
 //@ <!ELEMENT attributes (%editorial;, divisions?, key*, time*,
 //@     staves?, part-symbol?, instruments?, clef*, staff-details*,
 //@     transpose*, directive*, measure-style*)>
 //@
-//@ Doc:    The attributes element contains musical information that typically changes
-//@         on measure boundaries. This includes key and time signatures, clefs,
-//@         transpositions, and staving.
-
+//
 class AtribbutesMxlAnalyser : public MxlElementAnalyser
 {
 public:
@@ -1835,19 +1841,22 @@ public:
         vector<ImoObj*> keys;
         vector<ImoObj*> clefs;
 
-        // [<divisions>]
+        //TODO
+        // %editorial;
+
+        // divisions?
         if (get_optional("divisions"))
             set_divisions();
 
-        // <key>*
+        // key*
         while (get_optional("key"))
             keys.push_back( m_pAnalyser->analyse_node(&m_childToAnalyse, NULL) );
 
-        // <time>*
+        // time*
         while (get_optional("time"))
             times.push_back( m_pAnalyser->analyse_node(&m_childToAnalyse, NULL) );
 
-        // [<staves>]
+        // staves?
         if (get_optional("staves"))
         {
             int staves = get_integer_value(1);
@@ -1856,35 +1865,35 @@ public:
                 pInstr->add_staff();
         }
 
-        // [<part-symbol>]
+        // part-symbol?
         if (get_optional("part-symbol"))
         {
             //TODO <part-symbol>
         }
 
-        // [<instruments>]
+        // instruments?
         if (get_optional("instruments"))
         {
             //TODO <instruments>
         }
 
-        // <clef>*
+        // clef*
         while (get_optional("clef"))
             clefs.push_back( m_pAnalyser->analyse_node(&m_childToAnalyse, NULL) );
 
-        // <staff-details>*
+        // staff-details*
         while (get_optional("staff-details"))
             ; //TODO <staff-details>
 
-        // <transpose>*
+        // transpose*
         while (get_optional("transpose"))
             ; //TODO <transpose>
 
-        // <directive>*
+        // directive*
         while (get_optional("directive"))
             ; //TODO <directive>
 
-        // <measure-style>*
+        // measure-style*
         while (get_optional("measure-style"))
             ; //TODO <measure-style>
 
@@ -2186,34 +2195,17 @@ public:
 };
 
 //@--------------------------------------------------------------------------------------
-//@ <clef> = <sign>[<line>][<clef-octave-change>]
-//@ attrb: none is mandatory:
-//    number  	    staff-number  	The optional number attribute refers to staff numbers
-//                                  within the part. A value of 1 is assumed if not present.
-//    additional  	yes-no  	    Sometimes clefs are added to the staff in non-standard
-//                                  line positions, either to indicate cue passages, or
-//                                  when there are multiple clefs present simultaneously
-//                                  on one staff. In this situation, the additional
-//                                  attribute is set to "yes" and the line value is ignored.
-//    size  	    symbol-size  	The size attribute is used for clefs where the additional
-//                                  attribute is "yes". It is typically used to indicate
-//                                  cue clefs. The after-barline attribute is set to "yes"
-//                                  in this situation. The attribute is ignored for
-//                                  mid-measure clefs.
-//    after-barline yes-no  	    Sometimes clefs at the start of a measure need to
-//                                  appear after the barline rather than before, as for
-//                                  cues or for use after a repeated section.
-//    default-x  	tenths
-//    default-y  	tenths
-//    relative-x  	tenths
-//    relative-y  	tenths
-//    font-family  	comma-separated-text
-//    font-style  	font-style
-//    font-size  	font-size
-//    font-weight  	font-weight
-//    color  	    color
-//    print-object 	yes-no
-
+//@ <clef>
+//@<!ELEMENT clef (sign, line?, clef-octave-change?)>
+//@<!ATTLIST clef
+//@    number CDATA #IMPLIED
+//@    additional %yes-no; #IMPLIED
+//@    size %symbol-size; #IMPLIED
+//@    after-barline %yes-no; #IMPLIED
+//@    %print-style;
+//@    %print-object;
+//@>
+//
 class ClefMxlAnalyser : public MxlElementAnalyser
 {
 protected:
@@ -2234,40 +2226,48 @@ public:
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoClef* pClef = static_cast<ImoClef*>( ImFactory::inject(k_imo_clef, pDoc) );
 
-        //attributes:
-
-        // staff number
+        // attrib: number CDATA #IMPLIED
         int nStaffNum = get_optional_int_attribute("number", 1);
         pClef->set_staff(nStaffNum - 1);
 
-        //content:
+        // attrib: additional %yes-no; #IMPLIED
+        //TODO
 
-        // <sign>
+        // attrib: size %symbol-size; #IMPLIED
+        //TODO
+
+        // attrib: after-barline %yes-no; #IMPLIED
+        //TODO
+
+        // attrib: %print-style;
+        get_attributes_for_print_style(pClef);
+
+        // attrib: %print-object;
+        //TODO
+
+            //content
+
+        // sign         <!ELEMENT sign (#PCDATA)>
+        //TODO sign is mandatory (? check)
         if (get_optional("sign"))
-            m_sign = get_string_value();    //m_childToAnalyse.value();
+            m_sign = get_string_value();
 
+        // line?        <!ELEMENT line (#PCDATA)>
         if (get_optional("line"))
-            m_line = get_integer_value(0);   //(m_childToAnalyse);
+            m_line = get_integer_value(0);
 
+        // clef-octave-change?      <!ELEMENT clef-octave-change (#PCDATA)>
         if (get_optional("clef-octave-change"))
-            m_octaveChange = get_integer_value(0);   //(m_childToAnalyse);
+            m_octaveChange = get_integer_value(0);
 
         int type = determine_clef_type();
         if (type == k_clef_undefined)
         {
-            //report_msg(m_pAnalyser->get_line_number(&m_analysedNode),
             error_msg2(
                     "Unknown clef '" + m_sign + "'. Assumed 'G' in line 2.");
             type = k_clef_G2;
         }
         pClef->set_clef_type(type);
-
-//        // [<symbolSize>]
-//        if (get_optional(k_symbolSize))
-//            set_symbol_size(pClef);
-//
-//        // [<staff>][visible][<location>]
-//        analyse_staffobjs_options(pClef);
 
         error_if_more_elements();
 
@@ -2393,6 +2393,14 @@ public:
 
 //@--------------------------------------------------------------------------------------
 //@ <coda>
+//@ Coda signs can be associated with a measure or a musical direction.
+//@ It is a visual indicator only; a sound element is needed for reliably playback.
+//@
+//@<!ELEMENT coda EMPTY>
+//@<!ATTLIST coda
+//@    %print-style-align;
+//@>
+//
 class CodaMxlAnalyser : public MxlElementAnalyser
 {
 public:
@@ -2402,8 +2410,28 @@ public:
 
     ImoObj* do_analysis()
     {
-		//TODO
-        return NULL;
+        ImoDirection* pDirection = NULL;
+        if (m_pAnchor && m_pAnchor->is_direction())
+            pDirection = static_cast<ImoDirection*>(m_pAnchor);
+        else
+        {
+            //TODO: deal with <coda> when child of <measure>
+            LOMSE_LOG_ERROR("pAnchor is NULL or it is not ImoDirection");
+            error_msg("<direction-type> <coda> is not child of <direction>. Ignored.");
+            return NULL;
+        }
+        pDirection->set_words_repeat(k_repeat_coda);
+
+        Document* pDoc = m_pAnalyser->get_document_being_analysed();
+        ImoSymbolRepetitionMark* pImo = static_cast<ImoSymbolRepetitionMark*>(
+            ImFactory::inject(k_imo_symbol_repetition_mark, pDoc) );
+        pImo->set_symbol(ImoSymbolRepetitionMark::k_coda);
+
+        // attrib: %print-style-align;
+        get_attributes_for_print_style_align(pImo);
+
+        pDirection->add_attachment(pDoc, pImo);
+        return pImo;
     }
 };
 
@@ -5205,6 +5233,14 @@ public:
 
 //@--------------------------------------------------------------------------------------
 //@ <segno>
+//@ Segno signs can be associated with a measure or a musical direction.
+//@ It is a visual indicator only; a sound element is needed for reliably playback.
+//@
+//@<!ELEMENT segno EMPTY>
+//@<!ATTLIST segno
+//@    %print-style-align;
+//@>
+//
 class SegnoMxlAnalyser : public MxlElementAnalyser
 {
 public:
@@ -5214,8 +5250,28 @@ public:
 
     ImoObj* do_analysis()
     {
-		//TODO
-        return NULL;
+        ImoDirection* pDirection = NULL;
+        if (m_pAnchor && m_pAnchor->is_direction())
+            pDirection = static_cast<ImoDirection*>(m_pAnchor);
+        else
+        {
+            //TODO: deal with <segno> when child of <measure>
+            LOMSE_LOG_ERROR("pAnchor is NULL or it is not ImoDirection");
+            error_msg("<direction-type> <segno> is not child of <direction>. Ignored.");
+            return NULL;
+        }
+        pDirection->set_words_repeat(k_repeat_segno);
+
+        Document* pDoc = m_pAnalyser->get_document_being_analysed();
+        ImoSymbolRepetitionMark* pImo = static_cast<ImoSymbolRepetitionMark*>(
+            ImFactory::inject(k_imo_symbol_repetition_mark, pDoc) );
+        pImo->set_symbol(ImoSymbolRepetitionMark::k_segno);
+
+        // attrib: %print-style-align;
+        get_attributes_for_print_style_align(pImo);
+
+        pDirection->add_attachment(pDoc, pImo);
+        return pImo;
     }
 };
 
@@ -6230,13 +6286,15 @@ public:
 
 //@--------------------------------------------------------------------------------------
 //@ <words>
-//<!ELEMENT words (#PCDATA)>
-//<!ATTLIST words
-//    %text-formatting;
-//>
-// Left justification is assumed if not specified.
-// Language is Italian ("it") by default.
-// Enclosure is none by default.
+//@ The words element specifies a standard text direction.
+//@ Left justification is assumed if not specified.
+//@ Language is Italian ("it") by default.
+//@ Enclosure is none by default.
+//@
+//@<!ELEMENT words (#PCDATA)>
+//@<!ATTLIST words
+//@    %text-formatting;
+//@>
 //
 class WordsMxlAnalyser : public MxlElementAnalyser
 {
@@ -6266,7 +6324,7 @@ public:
         if (repeat != k_repeat_none)
         {
             ImoTextRepetitionMark* pRM = static_cast<ImoTextRepetitionMark*>(
-                                        ImFactory::inject(k_imo_repetition_mark, pDoc) );
+                    ImFactory::inject(k_imo_text_repetition_mark, pDoc) );
             pRM->set_repeat_mark(repeat);
             pImo = pRM;
         }
@@ -6278,7 +6336,6 @@ public:
 
         //set default values
         pImo->set_language("it");
-        //pImo->set_user_location_y(-20.0f);
             //TODO:
             //Left justification is assumed if not specified.
             //Enclosure is none by default.
@@ -6778,7 +6835,7 @@ MxlElementAnalyser* MxlAnalyser::new_analyser(const string& name, ImoObj* pAncho
         case k_mxl_tag_barline:              return LOMSE_NEW BarlineMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
 //        case k_mxl_tag_bracket:              return LOMSE_NEW BracketMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_mxl_tag_clef:                 return LOMSE_NEW ClefMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
-//        case k_mxl_tag_coda:                 return LOMSE_NEW CodaMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
+        case k_mxl_tag_coda:                 return LOMSE_NEW CodaMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
 //        case k_mxl_tag_damp:                 return LOMSE_NEW DampMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
 //        case k_mxl_tag_damp_all:             return LOMSE_NEW DampAllMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
 //        case k_mxl_tag_dashes:               return LOMSE_NEW DashesMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
@@ -6815,7 +6872,7 @@ MxlElementAnalyser* MxlAnalyser::new_analyser(const string& name, ImoObj* pAncho
         case k_mxl_tag_score_instrument:     return LOMSE_NEW ScoreInstrumentMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_mxl_tag_score_part:           return LOMSE_NEW ScorePartMxlAnalyser(this, m_reporter, m_libraryScope);
         case k_mxl_tag_score_partwise:       return LOMSE_NEW ScorePartwiseMxlAnalyser(this, m_reporter, m_libraryScope);
-//        case k_mxl_tag_segno:                return LOMSE_NEW SegnoMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
+        case k_mxl_tag_segno:                return LOMSE_NEW SegnoMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_mxl_tag_slur:                 return LOMSE_NEW SlurMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_mxl_tag_sound:                return LOMSE_NEW SoundMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
 //        case k_mxl_tag_string_mute:          return LOMSE_NEW StringMmuteMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2017. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -457,7 +457,7 @@ protected:
     }
 
     //-----------------------------------------------------------------------------------
-    long get_long_value(long nDefault=0L)
+    long get_child_value_long(long nDefault=0L)
     {
         string number = m_childToAnalyse.value();
         long nNumber;
@@ -466,7 +466,7 @@ protected:
         {
             stringstream replacement;
             replacement << nDefault;
-            report_msg(m_pAnalyser->get_line_number(&m_analysedNode),
+            report_msg(m_pAnalyser->get_line_number(&m_childToAnalyse),
                 "Invalid integer number '" + number + "'. Replaced by '"
                 + replacement.str() + "'.");
             return nDefault;
@@ -476,9 +476,9 @@ protected:
     }
 
     //-----------------------------------------------------------------------------------
-    int get_integer_value(int nDefault)
+    int get_child_value_integer(int nDefault)
     {
-        return static_cast<int>( get_long_value(static_cast<int>(nDefault)) );
+        return static_cast<int>( get_child_value_long(static_cast<int>(nDefault)) );
     }
 
     //-----------------------------------------------------------------------------------
@@ -491,7 +491,7 @@ protected:
     }
 
     //-----------------------------------------------------------------------------------
-    float get_float_value(float rDefault=0.0f)
+    float get_child_value_float(float rDefault=0.0f)
     {
         string number = m_childToAnalyse.value();
         float rNumber;
@@ -500,7 +500,7 @@ protected:
         {
             stringstream replacement;
             replacement << rDefault;
-            report_msg(m_pAnalyser->get_line_number(&m_analysedNode),
+            report_msg(m_pAnalyser->get_line_number(&m_childToAnalyse),
                 "Invalid real number '" + number + "'. Replaced by '"
                 + replacement.str() + "'.");
             return rDefault;
@@ -518,7 +518,7 @@ protected:
     }
 
     //-----------------------------------------------------------------------------------
-    bool get_bool_value(bool fDefault=false)
+    bool get_child_value_bool(bool fDefault=false)
     {
         string value = string(m_childToAnalyse.value());
         if (value == "true" || value == "yes")
@@ -529,7 +529,7 @@ protected:
         {
             stringstream replacement;
             replacement << fDefault;
-            report_msg(m_pAnalyser->get_line_number(&m_analysedNode),
+            report_msg(m_pAnalyser->get_line_number(&m_childToAnalyse),
                 "Invalid boolean value '" + value + "'. Replaced by '"
                 + replacement.str() + "'.");
             return fDefault;
@@ -537,7 +537,7 @@ protected:
     }
 
     //-----------------------------------------------------------------------------------
-    int get_yes_no_value(int nDefault)
+    int get_child_value_yes_no(int nDefault)
     {
         string value = m_childToAnalyse.value();
         if (value == "yes")
@@ -546,14 +546,14 @@ protected:
             return k_yesno_no;
         else
         {
-            report_msg(m_pAnalyser->get_line_number(&m_analysedNode),
+            report_msg(m_pAnalyser->get_line_number(&m_childToAnalyse),
                 "Invalid yes/no value '" + value + "'. Replaced by default.");
             return nDefault;
         }
     }
 
     //-----------------------------------------------------------------------------------
-    string get_string_value()
+    string get_child_value_string()
     {
         return m_childToAnalyse.value();
     }
@@ -881,7 +881,7 @@ protected:
     int analyse_optional_staff(int nDefault)
     {
         if (get_optional("staff"))
-            return get_integer_value(nDefault);
+            return get_child_value_integer(nDefault);
         else
             return nDefault;
     }
@@ -996,7 +996,7 @@ protected:
 //    ImoStyle* get_text_style_child(const string& defaulName="Default style")
 //    {
 //        m_childToAnalyse = get_child(m_childToAnalyse, 1);
-//        string styleName = get_string_value();
+//        string styleName = get_child_value_string();
 //        ImoStyle* pStyle = NULL;
 //
 //        ImoScore* pScore = m_pAnalyser->get_score_being_analysed();
@@ -1048,123 +1048,6 @@ protected:
 //        }
 //        delete pImo;
 //        return size;
-//    }
-//
-//    //-----------------------------------------------------------------------------------
-//    float get_location_child()
-//    {
-//        return get_float_value(0.0f);
-//    }
-//
-//    //-----------------------------------------------------------------------------------
-//    float get_width_child(float rDefault=1.0f)
-//    {
-//        return get_float_value(rDefault);
-//    }
-//
-//    //-----------------------------------------------------------------------------------
-//    float get_height_child(float rDefault=1.0f)
-//    {
-//        return get_float_value(rDefault);
-//    }
-
-    //-----------------------------------------------------------------------------------
-    float get_float_child(float rDefault=1.0f)
-    {
-        return get_float_value(rDefault);
-    }
-
-//    //-----------------------------------------------------------------------------------
-//    float get_lenght_child(float rDefault=0.0f)
-//    {
-//        return get_float_value(rDefault);
-//    }
-//
-//    //-----------------------------------------------------------------------------------
-//    ImoStyle* get_doc_text_style(const string& styleName)
-//    {
-//        ImoStyle* pStyle = NULL;
-//
-//        ImoDocument* pDoc = m_pAnalyser->get_root_imo_document();
-//        if (pDoc)
-//        {
-//            pStyle = pDoc->find_style(styleName);
-//            if (!pStyle)
-//            {
-//                report_msg(m_pAnalyser->get_line_number(&m_analysedNode),
-//                        "Style '" + styleName + "' is not defined. Default style will be used.");
-//                pStyle = pDoc->get_style_or_default(styleName);
-//            }
-//        }
-//
-//        return pStyle;
-//    }
-//
-//    //-----------------------------------------------------------------------------------
-//    ELineStyle get_line_style_child()
-//    {
-//        m_childToAnalyse = get_child(m_childToAnalyse, 1);
-//        const std::string& value = m_childToAnalyse.value();
-//        if (value == "none")
-//            return k_line_none;
-//        else if (value == "dot")
-//            return k_line_dot;
-//        else if (value == "solid")
-//            return k_line_solid;
-//        else if (value == "longDash")
-//            return k_line_long_dash;
-//        else if (value == "shortDash")
-//            return k_line_short_dash;
-//        else if (value == "dotDash")
-//            return k_line_dot_dash;
-//        else
-//        {
-//            report_msg(m_pAnalyser->get_line_number(&m_analysedNode),
-//                "Element 'lineStyle': Invalid value '" + value
-//                + "'. Replaced by 'solid'." );
-//            return k_line_solid;
-//        }
-//    }
-//
-//    //-----------------------------------------------------------------------------------
-//    ELineCap get_line_cap_child()
-//    {
-//        m_childToAnalyse = get_child(m_childToAnalyse, 1);
-//        const std::string& value = m_childToAnalyse.value();
-//        if (value == "none")
-//            return k_cap_none;
-//        else if (value == "arrowhead")
-//            return k_cap_arrowhead;
-//        else if (value == "arrowtail")
-//            return k_cap_arrowtail;
-//        else if (value == "circle")
-//            return k_cap_circle;
-//        else if (value == "square")
-//            return k_cap_square;
-//        else if (value == "diamond")
-//            return k_cap_diamond;
-//        else
-//        {
-//            report_msg(m_pAnalyser->get_line_number(&m_analysedNode),
-//                "Element 'lineCap': Invalid value '" + value
-//                + "'. Replaced by 'none'." );
-//            return k_cap_none;
-//        }
-//    }
-//
-//    //-----------------------------------------------------------------------------------
-//    void check_visible(ImoInlinesContainer* pCO)
-//    {
-//        string value = m_childToAnalyse.value();
-//        if (value == "visible")
-//            pCO->set_visible(true);
-//        else if (value == "noVisible")
-//            pCO->set_visible(false);
-//        else
-//        {
-//            error_invalid_child();
-//            pCO->set_visible(true);
-//        }
 //    }
 
 };
@@ -1859,7 +1742,7 @@ public:
         // staves?
         if (get_optional("staves"))
         {
-            int staves = get_integer_value(1);
+            int staves = get_child_value_integer(1);
             ImoInstrument* pInstr = dynamic_cast<ImoInstrument*>(m_pAnchor->get_parent_imo());
             for(; staves > 1; --staves)
                 pInstr->add_staff();
@@ -1932,7 +1815,7 @@ protected:
         // representation. If maximum compatibility with Standard MIDI 1.0 files is
         // important, do not have the divisions value exceed 16383.
 
-        int divisions = get_integer_value(4);
+        int divisions = get_child_value_integer(4);
         m_pAnalyser->set_current_divisions( float(divisions) );
     }
 
@@ -2250,15 +2133,15 @@ public:
         // sign         <!ELEMENT sign (#PCDATA)>
         //TODO sign is mandatory (? check)
         if (get_optional("sign"))
-            m_sign = get_string_value();
+            m_sign = get_child_value_string();
 
         // line?        <!ELEMENT line (#PCDATA)>
         if (get_optional("line"))
-            m_line = get_integer_value(0);
+            m_line = get_child_value_integer(0);
 
         // clef-octave-change?      <!ELEMENT clef-octave-change (#PCDATA)>
         if (get_optional("clef-octave-change"))
-            m_octaveChange = get_integer_value(0);
+            m_octaveChange = get_child_value_integer(0);
 
         int type = determine_clef_type();
         if (type == k_clef_undefined)
@@ -2420,7 +2303,7 @@ public:
             error_msg("<direction-type> <coda> is not child of <direction>. Ignored.");
             return NULL;
         }
-        pDirection->set_words_repeat(k_repeat_coda);
+        pDirection->set_display_repeat(k_repeat_coda);
 
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoSymbolRepetitionMark* pImo = static_cast<ImoSymbolRepetitionMark*>(
@@ -2944,18 +2827,18 @@ public:
         // <duration>
         if (!get_mandatory("duration"))
             return NULL;
-        int duration = get_integer_value(0);
+        int duration = get_child_value_integer(0);
         TimeUnits shift = m_pAnalyser->duration_to_timepos(duration);
 
         //<voice>
         if (fFwd && get_optional("voice"))
         {
-            int voice = get_integer_value( m_pAnalyser->get_current_voice() );
+            int voice = get_child_value_integer( m_pAnalyser->get_current_voice() );
 
             // staff?
             int staff = 1;
             if (get_optional("staff"))
-                staff = get_integer_value(1) - 1;
+                staff = get_child_value_integer(1) - 1;
 
             Document* pDoc = m_pAnalyser->get_document_being_analysed();
             ImoRest* pImo = static_cast<ImoRest*>(
@@ -3077,11 +2960,11 @@ public:
 
         // <fifths> (num)
         if (get_mandatory("fifths"))
-            fifths = get_integer_value(0);
+            fifths = get_child_value_integer(0);
 
         // <mode>
         if (get_optional("mode"))
-            fMajor = (get_string_value() == "major");
+            fMajor = (get_child_value_string() == "major");
 
 
         error_if_more_elements();
@@ -3721,7 +3604,7 @@ public:
         // <duration>, except for grace notes
         int duration = 0;
         if (!fIsGrace && get_optional("duration"))
-            duration = get_integer_value(0);
+            duration = get_child_value_integer(0);
 
         //tie, except for cue notes
         //AWARE: <tie> is for sound
@@ -3740,7 +3623,7 @@ public:
         // [<voice>]
         int voice = m_pAnalyser->get_current_voice();
         if (get_optional("voice"))
-            voice = get_integer_value( voice );
+            voice = get_child_value_integer( voice );
         set_voice(pNR, voice);
 
         // [<type>]
@@ -3781,7 +3664,7 @@ public:
 
         // [<staff>]
         if (get_optional("staff"))
-            pNR->set_staff(get_integer_value(1) - 1);
+            pNR->set_staff(get_child_value_integer(1) - 1);
 
         // <beam>*
         while (get_optional("beam"))
@@ -3959,7 +3842,7 @@ protected:
         //@           %print-style;
         //@>
         EAccidentals accidentals = k_no_accidentals;
-        string acc = m_childToAnalyse.value();  //get_string_value();
+        string acc = m_childToAnalyse.value();  //get_child_value_string();
         if (acc == "sharp")
             accidentals = k_sharp;
         else if (acc == "natural")
@@ -5260,7 +5143,7 @@ public:
             error_msg("<direction-type> <segno> is not child of <direction>. Ignored.");
             return NULL;
         }
-        pDirection->set_words_repeat(k_repeat_segno);
+        pDirection->set_display_repeat(k_repeat_segno);
 
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoSymbolRepetitionMark* pImo = static_cast<ImoSymbolRepetitionMark*>(
@@ -5462,19 +5345,19 @@ public:
 
 //        // attrib: %line-type;
 //        if (get_mandatory(k_number))
-//            pInfo->set_slur_number( get_integer_value(0) );
+//            pInfo->set_slur_number( get_child_value_integer(0) );
 
 //        // attrib: %dashed-formatting;
 //        if (get_mandatory(k_number))
-//            pInfo->set_slur_number( get_integer_value(0) );
+//            pInfo->set_slur_number( get_child_value_integer(0) );
 
 //        // attrib: %position;
 //        if (get_mandatory(k_number))
-//            pInfo->set_slur_number( get_integer_value(0) );
+//            pInfo->set_slur_number( get_child_value_integer(0) );
 
 //        // attrib: %placement;
 //        if (get_mandatory(k_number))
-//            pInfo->set_slur_number( get_integer_value(0) );
+//            pInfo->set_slur_number( get_child_value_integer(0) );
 
         // attrib: %orientation;
         if (has_attribute("orientation"))
@@ -5738,19 +5621,19 @@ public:
 
 //        // attrib: %line-type;
 //        if (get_mandatory(k_number))
-//            pInfo->set_tie_number( get_integer_value(0) );
+//            pInfo->set_tie_number( get_child_value_integer(0) );
 
 //        // attrib: %dashed-formatting;
 //        if (get_mandatory(k_number))
-//            pInfo->set_tie_number( get_integer_value(0) );
+//            pInfo->set_tie_number( get_child_value_integer(0) );
 
 //        // attrib: %position;
 //        if (get_mandatory(k_number))
-//            pInfo->set_tie_number( get_integer_value(0) );
+//            pInfo->set_tie_number( get_child_value_integer(0) );
 
 //        // attrib: %placement;
 //        if (get_mandatory(k_number))
-//            pInfo->set_tie_number( get_integer_value(0) );
+//            pInfo->set_tie_number( get_child_value_integer(0) );
 
         // attrib: %orientation;
         if (has_attribute("orientation"))
@@ -5766,7 +5649,7 @@ public:
 
 //        // attrib: %position;
 //        if (get_mandatory(k_number))
-//            pInfo->set_tie_number( get_integer_value(0) );
+//            pInfo->set_tie_number( get_child_value_integer(0) );
 
 //        // attrib: %bezier;
 //        analyse_optional(k_bezier, pInfo);
@@ -5857,12 +5740,12 @@ public:
 
         // <beats> (num)
         if (get_mandatory("beats"))
-            pTime->set_top_number( get_integer_value(2) );
+            pTime->set_top_number( get_child_value_integer(2) );
 
         // <beat-type> (num)
         if (pTime->get_type() != ImoTimeSignature::k_single_number
              && get_mandatory("beat-type"))
-            pTime->set_bottom_number( get_integer_value(4) );
+            pTime->set_bottom_number( get_child_value_integer(4) );
 
         add_to_model(pTime);
         return pTime;
@@ -6317,7 +6200,7 @@ public:
 
         string text = m_analysedNode.value();
         int repeat = is_repetion_mark(text);
-        pDirection->set_words_repeat(repeat);
+        pDirection->set_display_repeat(repeat);
 
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoScoreText* pImo;

--- a/src/tests/lomse_test_mxl_analyser.cpp
+++ b/src/tests/lomse_test_mxl_analyser.cpp
@@ -3291,7 +3291,7 @@ SUITE(MxlAnalyserTest)
         CHECK( pSO != NULL );
         CHECK( pSO->get_num_attachments() == 1 );
         CHECK( pSO->get_placement() == k_placement_default );
-        CHECK( pSO->get_words_repeat() == k_repeat_to_coda );
+        CHECK( pSO->get_display_repeat() == k_repeat_to_coda );
         CHECK( pSO->get_sound_repeat() == k_repeat_none );
 
         ImoTextRepetitionMark* pAO = dynamic_cast<ImoTextRepetitionMark*>( pSO->get_attachment(0) );
@@ -3330,7 +3330,7 @@ SUITE(MxlAnalyserTest)
         CHECK( pSO != NULL );
         CHECK( pSO->get_num_attachments() == 1 );
         CHECK( pSO->get_placement() == k_placement_default );
-        CHECK( pSO->get_words_repeat() == k_repeat_none );
+        CHECK( pSO->get_display_repeat() == k_repeat_none );
         CHECK( pSO->get_sound_repeat() == k_repeat_none );
 
         ImoScoreText* pAO = dynamic_cast<ImoScoreText*>( pSO->get_attachment(0) );
@@ -3450,6 +3450,80 @@ SUITE(MxlAnalyserTest)
         CHECK (type_of_repetion_mark(" to coda ") == k_repeat_to_coda );
         CHECK (type_of_repetion_mark(" to  coda ") == k_repeat_to_coda );
         CHECK (type_of_repetion_mark("tocoda") == k_repeat_to_coda );
+    }
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, MxlAnalyser_direction_segno_630)
+    {
+        //@00630  <segno>. Minimum content parsed ok
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser(errormsg);
+        stringstream expected;
+        parser.parse_text("<direction>"
+            "<direction-type><segno/></direction-type>"
+        "</direction>"
+        );
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pIModel->get_root() != NULL);
+        CHECK( pIModel->get_root()->is_direction() == true );
+        ImoDirection* pSO = dynamic_cast<ImoDirection*>( pIModel->get_root() );
+        CHECK( pSO != NULL );
+        CHECK( pSO->get_num_attachments() == 1 );
+        CHECK( pSO->get_placement() == k_placement_default );
+        CHECK( pSO->get_display_repeat() == k_repeat_segno );
+        CHECK( pSO->get_sound_repeat() == k_repeat_none );
+
+        ImoSymbolRepetitionMark* pAO = dynamic_cast<ImoSymbolRepetitionMark*>( pSO->get_attachment(0) );
+        CHECK( pAO != NULL );
+        CHECK( pAO->get_symbol() == ImoSymbolRepetitionMark::k_segno );
+
+        a.do_not_delete_instruments_in_destructor();
+        delete pIModel;
+    }
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, MxlAnalyser_direction_coda_640)
+    {
+        //@00640  <coda>. Minimum content parsed ok
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser(errormsg);
+        stringstream expected;
+        parser.parse_text("<direction>"
+            "<direction-type><coda/></direction-type>"
+        "</direction>"
+        );
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        InternalModel* pIModel = a.analyse_tree(tree, "string:");
+
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pIModel->get_root() != NULL);
+        CHECK( pIModel->get_root()->is_direction() == true );
+        ImoDirection* pSO = dynamic_cast<ImoDirection*>( pIModel->get_root() );
+        CHECK( pSO != NULL );
+        CHECK( pSO->get_num_attachments() == 1 );
+        CHECK( pSO->get_placement() == k_placement_default );
+        CHECK( pSO->get_display_repeat() == k_repeat_coda );
+        CHECK( pSO->get_sound_repeat() == k_repeat_none );
+
+        ImoSymbolRepetitionMark* pAO = dynamic_cast<ImoSymbolRepetitionMark*>( pSO->get_attachment(0) );
+        CHECK( pAO != NULL );
+        CHECK( pAO->get_symbol() == ImoSymbolRepetitionMark::k_coda );
+
+        a.do_not_delete_instruments_in_destructor();
+        delete pIModel;
     }
 
 


### PR DESCRIPTION
With this PR Segno and Coda symbols are now imported from MusicXML files and properly rendered.
This PR is another step for fixing #79. 