### PR TITLE
Implement auto-scroll during playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@
   as repetions implied by textual repetition marks (i.e. Da Capo, 
   To Coda, etc, ...) (issue #79).
 
+- Auto-scroll during playback (issue #88): When playing back an score
+  it is necessary to ensure that current played notes are visible. 
+  Therefore, as the playback advances, the score should auto-scroll to
+  maintaint the viewport on the notes being played back. The implemented
+  solution defines a new Lomse event, *EventUpdateViewport*, that
+  informs about the need to change the viewport and provides the
+  coordinates for the new viewport origin. It is up to the user
+  application to do it or not.
+
 - Technical changes:
 	- As c++11 and std::regex support is required, CMakeLists.txt has
 	  been updated:

--- a/include/lomse_box_system.h
+++ b/include/lomse_box_system.h
@@ -50,6 +50,7 @@ protected:
 	vector<GmoShapeStaff*> m_staffShapes;
 	vector<int> m_firstStaff;       //index to first staff for each instrument
     TimeGridTable* m_pGridTable;
+    int m_iPage;        //number of score page (0..n-1) in which this system is contained
 
 public:
     GmoBoxSystem(ImoObj* pCreatorImo);
@@ -68,6 +69,8 @@ public:
     GmoShapeStaff* get_staff_shape(int iInstr, int iStaff);
     int instr_number_for_staff(int absStaff);
     int staff_number_for(int absStaff, int iInstr);
+    inline void set_page_number(int iPage) { m_iPage = iPage; }
+	inline int get_page_number() { return m_iPage; }
 
     //Staff shapes
     GmoShapeStaff* add_staff_shape(GmoShapeStaff* pShape);

--- a/include/lomse_events.h
+++ b/include/lomse_events.h
@@ -246,9 +246,9 @@ typedef SharedPtr<EventPaint>  SpEventPaint;
 
 
 //---------------------------------------------------------------------------------------
-// EventViewportChanged: inform user application about the need to repaint the screen
-// due to a viewport change automatically done by Lomse during score playback
-class EventViewportChanged : public EventPaint
+// EventUpdateViewport: inform user application about the need to change the viewport
+// during score playback so that current played notes are visible
+class EventUpdateViewport : public EventView
 {
 protected:
     VRect m_damagedRectangle;
@@ -256,22 +256,20 @@ protected:
     Pixels m_y;
 
 public:
-    EventViewportChanged(WpInteractor wpInteractor, VRect damagedRectangle,
-                         Pixels x, Pixels y)
-        : EventPaint(k_update_viewport_event, wpInteractor, damagedRectangle)
+    EventUpdateViewport(WpInteractor wpInteractor, Pixels x, Pixels y)
+        : EventView(k_update_viewport_event, wpInteractor)
         , m_x(x)
         , m_y(y)
     {
     }
-    virtual ~EventViewportChanged() {}
+    virtual ~EventUpdateViewport() {}
 
-    inline VRect get_damaged_rectangle() { return m_damagedRectangle; }
     inline Pixels get_new_viewport_x() { return m_x; }
     inline Pixels get_new_viewport_y() { return m_y; }
     void get_new_viewport(Pixels* x, Pixels* y)  { *x = m_x; *y = m_x; }
 };
 
-typedef SharedPtr<EventViewportChanged>  SpEventViewportChanged;
+typedef SharedPtr<EventUpdateViewport>  SpEventUpdateViewport;
 
 
 //---------------------------------------------------------------------------------------

--- a/include/lomse_events.h
+++ b/include/lomse_events.h
@@ -77,6 +77,7 @@ enum EEventType
     k_view_level_event = 0,
 
         k_update_window_event,      //ask user app to update window with current bitmap
+        k_update_viewport_event,    //ask user app to update window with current bitmap
 
         k_update_UI_event,          //possible need for UI updates
             k_selection_set_change,     //selected objects changed
@@ -188,7 +189,7 @@ public:
         , m_pDoc(pDoc)
     {
     }
-    ~EventDoc() {}
+    virtual ~EventDoc() {}
 
     inline Document* get_document() { return m_pDoc; }
 };
@@ -230,12 +231,42 @@ public:
         , m_damagedRectangle(damagedRectangle)
     {
     }
-    ~EventPaint() {}
+    virtual ~EventPaint() {}
 
     inline VRect get_damaged_rectangle() { return m_damagedRectangle; }
 };
 
 typedef SharedPtr<EventPaint>  SpEventPaint;
+
+
+//---------------------------------------------------------------------------------------
+// EventViewportChanged: inform user application about the need to repaint the screen
+// due to a viewport change automatically done by Lomse during score playback
+class EventViewportChanged : public EventView
+{
+protected:
+    VRect m_damagedRectangle;
+    Pixels m_x;
+    Pixels m_y;
+
+public:
+    EventViewportChanged(WpInteractor wpInteractor, VRect damagedRectangle,
+                         Pixels x, Pixels y)
+        : EventView(k_update_viewport_event, wpInteractor)
+        , m_damagedRectangle(damagedRectangle)
+        , m_x(x)
+        , m_y(y)
+    {
+    }
+    virtual ~EventViewportChanged() {}
+
+    inline VRect get_damaged_rectangle() { return m_damagedRectangle; }
+    inline Pixels get_new_viewport_x() { return m_x; }
+    inline Pixels get_new_viewport_y() { return m_y; }
+    void get_new_viewport(Pixels* x, Pixels* y)  { *x = m_x; *y = m_x; }
+};
+
+typedef SharedPtr<EventViewportChanged>  SpEventViewportChanged;
 
 
 //---------------------------------------------------------------------------------------

--- a/include/lomse_events.h
+++ b/include/lomse_events.h
@@ -225,6 +225,12 @@ class EventPaint : public EventView
 protected:
     VRect m_damagedRectangle;
 
+    EventPaint(EEventType type, WpInteractor wpInteractor, VRect damagedRectangle)
+        : EventView(type, wpInteractor)
+        , m_damagedRectangle(damagedRectangle)
+    {
+    }
+
 public:
     EventPaint(WpInteractor wpInteractor, VRect damagedRectangle)
         : EventView(k_update_window_event, wpInteractor)
@@ -242,7 +248,7 @@ typedef SharedPtr<EventPaint>  SpEventPaint;
 //---------------------------------------------------------------------------------------
 // EventViewportChanged: inform user application about the need to repaint the screen
 // due to a viewport change automatically done by Lomse during score playback
-class EventViewportChanged : public EventView
+class EventViewportChanged : public EventPaint
 {
 protected:
     VRect m_damagedRectangle;
@@ -252,8 +258,7 @@ protected:
 public:
     EventViewportChanged(WpInteractor wpInteractor, VRect damagedRectangle,
                          Pixels x, Pixels y)
-        : EventView(k_update_viewport_event, wpInteractor)
-        , m_damagedRectangle(damagedRectangle)
+        : EventPaint(k_update_viewport_event, wpInteractor, damagedRectangle)
         , m_x(x)
         , m_y(y)
     {

--- a/include/lomse_gm_basic.h
+++ b/include/lomse_gm_basic.h
@@ -527,12 +527,15 @@ public:
 class GmoBoxScorePage : public GmoBox
 {
 protected:
-    int             m_nFirstSystem;     //0..n-1
-    int             m_nLastSystem;      //0..n-1
+    int m_nFirstSystem;     //0..n-1
+    int m_nLastSystem;      //0..n-1
+    int m_iPage;            //0..n-1
 
 public:
     GmoBoxScorePage(ImoScore* pScore);
     virtual ~GmoBoxScorePage();
+
+    inline void set_page_number(int iPage) { m_iPage = iPage; }
 
 	//systems
     void add_system(GmoBoxSystem* pSystem, int iSystem);
@@ -541,6 +544,7 @@ public:
         return (m_nFirstSystem == -1 ? 0 : m_nLastSystem - m_nFirstSystem + 1);
     }
 	GmoBoxSystem* get_system(int iSystem);		//nSystem = 0..n-1
+	inline int get_page_number() { return m_iPage; }
 
     //hit tests related
     int nearest_system_to_point(LUnits y);

--- a/include/lomse_gm_basic.h
+++ b/include/lomse_gm_basic.h
@@ -381,6 +381,7 @@ public:
 
     //parent
     GmoBox* get_parent_box() { return m_pParentBox; }
+    GmoBoxDocPage* get_parent_doc_page();
 
     //contained shapes
     inline int get_num_shapes() { return static_cast<int>( m_shapes.size() ); }
@@ -439,7 +440,6 @@ protected:
     GmoBox(int objtype, ImoObj* pCreatorImo);
     void delete_boxes();
     void delete_shapes();
-    GmoBoxDocPage* get_parent_box_page();
     void draw_border(Drawer* pDrawer, RenderOptions& opt);
     bool must_draw_bounds(RenderOptions& opt);
     Color get_box_color();
@@ -480,7 +480,7 @@ public:
 class GmoBoxDocPage : public GmoBox
 {
 protected:
-    int m_numPage;
+    int m_numPage;      //1..n
     std::list<GmoShape*> m_allShapes;		//contained shapes, ordered by layer and creation order
 
 public:
@@ -529,7 +529,7 @@ class GmoBoxScorePage : public GmoBox
 protected:
     int m_nFirstSystem;     //0..n-1
     int m_nLastSystem;      //0..n-1
-    int m_iPage;            //0..n-1
+    int m_iPage;            //0..n-1        number of this score page
 
 public:
     GmoBoxScorePage(ImoScore* pScore);

--- a/include/lomse_graphic_view.h
+++ b/include/lomse_graphic_view.h
@@ -40,6 +40,7 @@
 //other
 #include <vector>
 #include <list>
+#include <mutex>
 using namespace std;
 
 
@@ -127,6 +128,7 @@ protected:
     //current viewport origin and size
     Pixels m_vxOrg, m_vyOrg;
     VSize  m_viewportSize;
+    std::mutex m_viewportMutex;
 
     //caret and other visual effects
     Caret*              m_pCaret;
@@ -285,6 +287,7 @@ protected:
     void layout_selection_highlight();
     void delete_all_handlers();
     void add_handler(int iHandler, GmoObj* pOwnerGmo);
+    void do_change_viewport(Pixels x, Pixels y);
 
 };
 

--- a/include/lomse_graphic_view.h
+++ b/include/lomse_graphic_view.h
@@ -176,6 +176,7 @@ public:
 
     //scrolling support
     virtual void get_view_size(Pixels* xWidth, Pixels* yHeight) = 0;
+    virtual void change_viewport_if_necessary(ImoId id);
 
     //selection rectangle
     void start_selection_rectangle(LUnits x1, LUnits y1);

--- a/include/lomse_interactor.h
+++ b/include/lomse_interactor.h
@@ -259,7 +259,7 @@ public:
 
     //for auto-scroll during playback
     virtual void change_viewport_if_necessary(ImoId id);
-    virtual void request_viewport_change(Pixels x, Pixels y, VRect damagedRect);
+    virtual void request_viewport_change(Pixels x, Pixels y);
 
     //for performance measurements
     void timing_start_measurements();

--- a/include/lomse_interactor.h
+++ b/include/lomse_interactor.h
@@ -257,6 +257,10 @@ public:
     //mandatory overrides from Observable
     EventNotifier* get_event_notifier() { return this; }
 
+    //for auto-scroll during playback
+    virtual void change_viewport_if_necessary(ImoId id);
+    virtual void request_viewport_change(Pixels x, Pixels y, VRect damagedRect);
+
     //for performance measurements
     void timing_start_measurements();
     void timing_graphic_model_build_end();

--- a/include/lomse_score_player.h
+++ b/include/lomse_score_player.h
@@ -62,8 +62,8 @@ class Metronome;
 
 //---------------------------------------------------------------------------------------
 typedef boost::thread SoundThread;
-typedef boost::mutex SoundMutex;
-typedef boost::unique_lock<boost::mutex> SoundLock;
+//typedef boost::mutex SoundMutex;
+//typedef boost::unique_lock<boost::mutex> SoundLock;
 typedef boost::condition_variable SoundFlag;
 
 
@@ -100,7 +100,7 @@ protected:
     bool                m_fFinalEventSent;      //to avoid duplicating final event
     ImoScore*           m_pScore;       //score to play
     SoundEventsTable*   m_pTable;
-    SoundMutex          m_mutex;        //for pause/continue play back
+//    SoundMutex          m_mutex;        //for pause/continue play back
     SoundFlag           m_canPlay;      //playback is not paused
 
     //metronome: MIDI parameters

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -356,6 +356,7 @@ void ScoreLayouter::reposition_system_if_page_has_changed()
         m_pCurBoxSystem->shift_origin_and_content(shift);
         m_pCurSysLyt->on_origin_shift(shift.height);
     }
+    m_pCurBoxSystem->set_page_number(m_iCurPage);
 }
 
 //---------------------------------------------------------------------------------------
@@ -379,6 +380,7 @@ void ScoreLayouter::page_initializations(GmoBox* pContainerBox)
 {
     m_iCurPage++;
     m_pCurBoxPage = dynamic_cast<GmoBoxScorePage*>( pContainerBox );
+    m_pCurBoxPage->set_page_number(m_iCurPage);
     is_first_system_in_page(true);
     m_startTop = m_pCurBoxPage->get_top();
 }

--- a/src/graphic_model/lomse_box_score_page.cpp
+++ b/src/graphic_model/lomse_box_score_page.cpp
@@ -42,6 +42,7 @@ GmoBoxScorePage::GmoBoxScorePage(ImoScore* pScore)
     : GmoBox(GmoObj::k_box_score_page, pScore)
     , m_nFirstSystem(-1)
     , m_nLastSystem(-1)
+    , m_iPage(0)
 {
 }
 

--- a/src/graphic_model/lomse_gm_basic.cpp
+++ b/src/graphic_model/lomse_gm_basic.cpp
@@ -375,18 +375,18 @@ void GmoBox::add_shapes_to_tables_in(GmoBoxDocPage* pPage)
 //---------------------------------------------------------------------------------------
 void GmoBox::add_shapes_to_tables()
 {
-    GmoBoxDocPage* pPage = get_parent_box_page();
+    GmoBoxDocPage* pPage = get_parent_doc_page();
     GmoBox* pBox = this;        //gcc complains if next method is invoked directly
     pBox->add_shapes_to_tables_in(pPage);
 }
 
 //---------------------------------------------------------------------------------------
-GmoBoxDocPage* GmoBox::get_parent_box_page()
+GmoBoxDocPage* GmoBox::get_parent_doc_page()
 {
     if (this->is_box_doc_page())
         return dynamic_cast<GmoBoxDocPage*>(this);
     else
-        return get_parent_box()->get_parent_box_page();
+        return get_parent_box()->get_parent_doc_page();
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/mvc/lomse_graphic_view.cpp
+++ b/src/mvc/lomse_graphic_view.cpp
@@ -236,11 +236,23 @@ void GraphicView::add_handler(int iHandler, GmoObj* pOwnerGmo)
 void GraphicView::new_viewport(Pixels x, Pixels y)
 {
     LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    do_change_viewport(x, y);
+}
+
+//---------------------------------------------------------------------------------------
+void GraphicView::do_change_viewport(Pixels x, Pixels y)
+{
+    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    std::lock_guard<std::mutex> lock(m_viewportMutex);
 
     m_vxOrg = x;
     m_vyOrg = y;
     m_transform.tx = double(-x);
     m_transform.ty = double(-y);
+
+    //ensure drawer has the new information, for pixels <-> LUnits conversions
+    m_pDrawer->set_viewport(m_vxOrg, m_vyOrg);
+    m_pDrawer->set_transform(m_transform);
 }
 
 //---------------------------------------------------------------------------------------
@@ -253,6 +265,9 @@ GraphicModel* GraphicView::get_graphic_model()
 void GraphicView::change_viewport_if_necessary(ImoId id)
 {
     //AWARE: This code is executed in the sound thread
+
+    std::lock_guard<std::mutex> lock(m_viewportMutex);
+    static Pixels m_yNew = 0;
 
     GraphicModel* pGModel = get_graphic_model();
     if (!pGModel)
@@ -275,13 +290,19 @@ void GraphicView::change_viewport_if_necessary(ImoId id)
     double xPos = xSysLeft;
     double yTop = ySysTop;
     model_point_to_screen(&xPos, &yTop, iPage);
-    Pixels vxSys = Pixels(xPos);
+    //Pixels vxSys = Pixels(xPos);
     Pixels vySysTop = Pixels(yTop);
+
+//    stringstream s;
+//    s << "vySysTop=" << vySysTop << ", vp.height=" << m_viewportSize.height
+//      << ", iPage=" << iPage << ", id=" << id;
+//    LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_score_player, s.str());
 
     //determine if scroll needed
     Pixels xNew = 0;
     Pixels yNew = 0;
     bool fDoScroll = false;
+    //AWARE: vySystop is shift from current viewport origin
     if (vySysTop < 0 || vySysTop > m_viewportSize.height)
     {
         //top of system before or after viewport. Move top of system to top of view
@@ -294,8 +315,14 @@ void GraphicView::change_viewport_if_necessary(ImoId id)
         double xPos = xSysLeft;
         double yBottom = ySysTop + double(pBoxSystem->get_height());
         model_point_to_screen(&xPos, &yBottom, iPage);
-        Pixels vxSys = Pixels(xPos);
+        //Pixels vxSys = Pixels(xPos);
         Pixels vySysBottom = Pixels(yBottom);
+
+//        stringstream s;
+//        s << "vySysBottom=" << vySysBottom << ", vp.height=" << m_viewportSize.height;
+//        LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_score_player, s.str());
+
+        //AWARE: vySysBottom is shift from current viewport origin
         if (vySysBottom > m_viewportSize.height && vySysTop > 0)
         {
             //bottom of system out of sight. Move top of system to top of view
@@ -307,7 +334,23 @@ void GraphicView::change_viewport_if_necessary(ImoId id)
 
     //request scroll if required
     if (fDoScroll)
-        m_pInteractor->request_viewport_change(xNew, yNew);
+    {
+//        stringstream s;
+//        s << "Requesting scroll to yNew=" << yNew << ", m_vyOrg=" << m_vyOrg;
+//        LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_score_player, s.str());
+        if (m_yNew != yNew)
+            m_pInteractor->request_viewport_change(xNew, yNew);
+//        else
+//            LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_score_player, "Optimization: no request");
+        m_yNew = yNew;
+    }
+//    else
+//    {
+//        stringstream s;
+//        s << "No scroll required. m_vyOrg=" << m_vyOrg;
+//        LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_score_player, s.str());
+//    }
+
 }
 
 ////---------------------------------------------------------------------------------------
@@ -731,11 +774,8 @@ void GraphicView::zoom_in(Pixels x, Pixels y)
 
     //move origin back to (rx, ry) so this point remains un-moved
     m_transform *= agg::trans_affine_translation(rx, ry);
-    m_vxOrg = -Pixels(m_transform.tx);
-    m_vyOrg = -Pixels(m_transform.ty);
 
-    //ensure drawer has the new transform, for pixels <-> LUnits conversions
-    m_pDrawer->set_transform(m_transform);
+    do_change_viewport(-Pixels(m_transform.tx), -Pixels(m_transform.ty));
 }
 
 //---------------------------------------------------------------------------------------
@@ -754,8 +794,8 @@ void GraphicView::zoom_out(Pixels x, Pixels y)
 
     //move origin back to (rx, ry) so this point remains un-moved
     m_transform *= agg::trans_affine_translation(rx, ry);
-    m_vxOrg = -Pixels(m_transform.tx);
-    m_vyOrg = -Pixels(m_transform.ty);
+
+    do_change_viewport(-Pixels(m_transform.tx), -Pixels(m_transform.ty));
 }
 
 //---------------------------------------------------------------------------------------
@@ -784,8 +824,8 @@ void GraphicView::zoom_fit_full(Pixels screenWidth, Pixels screenHeight)
 
     //move origin back to (rx, ry) so this point remains un-moved
     m_transform *= agg::trans_affine_translation(rx, ry);
-    m_vxOrg = -Pixels(m_transform.tx);
-    m_vyOrg = -Pixels(m_transform.ty);
+
+    do_change_viewport(-Pixels(m_transform.tx), -Pixels(m_transform.ty));
 
     set_viewport_for_page_fit_full(screenWidth);
 }
@@ -811,8 +851,8 @@ void GraphicView::zoom_fit_width(Pixels screenWidth)
 
     //move origin back to (rx, ry) so this point remains un-moved
     m_transform *= agg::trans_affine_translation(rx, ry);
-    m_vxOrg = -Pixels(m_transform.tx);
-    m_vyOrg = -Pixels(m_transform.ty);
+
+    do_change_viewport(-Pixels(m_transform.tx), -Pixels(m_transform.ty));
 
     set_viewport_at_page_center(screenWidth);
 }
@@ -831,8 +871,7 @@ void GraphicView::set_viewport_at_page_center(Pixels screenWidth)
     Pixels left = (pageWidth - screenWidth) / 2;
 
     //force new viewport
-    m_vxOrg = left;
-    m_transform.tx = double(-left);
+    do_change_viewport(left, m_vyOrg);
 }
 
 //---------------------------------------------------------------------------------------
@@ -850,8 +889,8 @@ void GraphicView::set_scale(double scale, Pixels x, Pixels y)
 
     //move origin back to (rx, ry) so this point remains un-moved
     m_transform *= agg::trans_affine_translation(rx, ry);
-    m_vxOrg = -Pixels(m_transform.tx);
-    m_vyOrg = -Pixels(m_transform.ty);
+
+    do_change_viewport(-Pixels(m_transform.tx), -Pixels(m_transform.ty));
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/mvc/lomse_graphic_view.cpp
+++ b/src/mvc/lomse_graphic_view.cpp
@@ -252,7 +252,7 @@ GraphicModel* GraphicView::get_graphic_model()
 //---------------------------------------------------------------------------------------
 void GraphicView::change_viewport_if_necessary(ImoId id)
 {
-    //AWARE: This code is executed in MIDI thread
+    //AWARE: This code is executed in the sound thread
 
     GraphicModel* pGModel = get_graphic_model();
     if (!pGModel)
@@ -278,11 +278,6 @@ void GraphicView::change_viewport_if_necessary(ImoId id)
     Pixels vxSys = Pixels(xPos);
     Pixels vySysTop = Pixels(yTop);
 
-    stringstream s;
-    s << "vwp.top=" << m_vyOrg << ", vwp.height=" << m_viewportSize.height
-      << ", ySysTop=" << ySysTop << ", vySysTop=" << vySysTop << ", iPage=" << iPage;
-    LOMSE_LOG_DEBUG(lomse::Logger::k_events | lomse::Logger::k_score_player, s.str());
-
     //determine if scroll needed
     Pixels xNew = 0;
     Pixels yNew = 0;
@@ -293,7 +288,6 @@ void GraphicView::change_viewport_if_necessary(ImoId id)
         xNew = m_vxOrg;
         yNew = m_vyOrg + vySysTop;
         fDoScroll = true;
-        LOMSE_LOG_DEBUG(lomse::Logger::k_events, "Top of system before or after viewport");
     }
     else
     {
@@ -308,33 +302,12 @@ void GraphicView::change_viewport_if_necessary(ImoId id)
             xNew = m_vxOrg;
             yNew = m_vyOrg + vySysTop;
             fDoScroll = true;
-            LOMSE_LOG_DEBUG(lomse::Logger::k_events, "Bottom of system out of sight");
         }
     }
 
-    //do scroll if required
+    //request scroll if required
     if (fDoScroll)
-    {
-        new_viewport(xNew, yNew);
-        redraw_bitmap();
-
-        yTop = double(pBoxSystem->get_top());
-        model_point_to_screen(&xPos, &yTop, iPage);
-        Pixels newySys = Pixels(yTop);
-        stringstream s;
-        s << "vwp.top=" << m_vyOrg << ", vwp.height=" << m_viewportSize.height
-          << ", yTop=" << pBoxSystem->get_top() << ", newySys=" << newySys;
-        LOMSE_LOG_DEBUG(lomse::Logger::k_events | lomse::Logger::k_score_player, s.str());
-
-
-        //view rectangle
-        Pixels x2 = int(m_pRenderBuf->width());
-        Pixels y2 = int(m_pRenderBuf->height());
-        VRect damagedRect = VRect(VPoint(0, 0), VPoint(x2, y2));
-
-        m_pInteractor->request_viewport_change(m_vxOrg, yTop, damagedRect);
-    }
-
+        m_pInteractor->request_viewport_change(xNew, yNew);
 }
 
 ////---------------------------------------------------------------------------------------

--- a/src/mvc/lomse_interactor.cpp
+++ b/src/mvc/lomse_interactor.cpp
@@ -1009,19 +1009,17 @@ void Interactor::get_viewport(Pixels* x, Pixels* y)
 }
 
 //---------------------------------------------------------------------------------------
-void Interactor::request_viewport_change(Pixels x, Pixels y, VRect damagedRect)
+void Interactor::request_viewport_change(Pixels x, Pixels y)
 {
-    //AWARE: This code is executed in MIDI thread
+    //AWARE: This code is executed in the sound thread
 
     LOMSE_LOG_DEBUG(lomse::Logger::k_events | lomse::Logger::k_score_player, "");
 
     SpInteractor sp = get_shared_ptr_from_this();
     WpInteractor wpIntor(sp);
-    SpEventView pEvent( LOMSE_NEW EventViewportChanged(wpIntor, damagedRect, x, y) );
+    SpEventView pEvent( LOMSE_NEW EventUpdateViewport(wpIntor, x, y) );
 
     m_libScope.post_event(pEvent);
-
-//    notify_observers(pEvent, this);
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/mvc/lomse_interactor.cpp
+++ b/src/mvc/lomse_interactor.cpp
@@ -1011,15 +1011,17 @@ void Interactor::get_viewport(Pixels* x, Pixels* y)
 //---------------------------------------------------------------------------------------
 void Interactor::request_viewport_change(Pixels x, Pixels y, VRect damagedRect)
 {
+    //AWARE: This code is executed in MIDI thread
+
     LOMSE_LOG_DEBUG(lomse::Logger::k_events | lomse::Logger::k_score_player, "");
 
     SpInteractor sp = get_shared_ptr_from_this();
     WpInteractor wpIntor(sp);
     SpEventView pEvent( LOMSE_NEW EventViewportChanged(wpIntor, damagedRect, x, y) );
 
-//    m_libScope.post_event(pEvent);
+    m_libScope.post_event(pEvent);
 
-    notify_observers(pEvent, this);
+//    notify_observers(pEvent, this);
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/mvc/lomse_interactor.cpp
+++ b/src/mvc/lomse_interactor.cpp
@@ -1009,6 +1009,20 @@ void Interactor::get_viewport(Pixels* x, Pixels* y)
 }
 
 //---------------------------------------------------------------------------------------
+void Interactor::request_viewport_change(Pixels x, Pixels y, VRect damagedRect)
+{
+    LOMSE_LOG_DEBUG(lomse::Logger::k_events | lomse::Logger::k_score_player, "");
+
+    SpInteractor sp = get_shared_ptr_from_this();
+    WpInteractor wpIntor(sp);
+    SpEventView pEvent( LOMSE_NEW EventViewportChanged(wpIntor, damagedRect, x, y) );
+
+//    m_libScope.post_event(pEvent);
+
+    notify_observers(pEvent, this);
+}
+
+//---------------------------------------------------------------------------------------
 void Interactor::start_selection_rectangle(Pixels x1, Pixels y1)
 {
     GraphicView* pGView = dynamic_cast<GraphicView*>(m_pView);
@@ -1096,6 +1110,15 @@ void Interactor::discard_all_highlight()
     GraphicView* pGView = dynamic_cast<GraphicView*>(m_pView);
     if (pGView)
         pGView->remove_all_highlight();
+}
+
+//---------------------------------------------------------------------------------------
+void Interactor::change_viewport_if_necessary(ImoId id)
+{
+    LOMSE_LOG_DEBUG(lomse::Logger::k_events | lomse::Logger::k_score_player, "");
+    GraphicView* pGView = dynamic_cast<GraphicView*>(m_pView);
+    if (pGView)
+        pGView->change_viewport_if_necessary(id);
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/sound/lomse_score_player.cpp
+++ b/src/sound/lomse_score_player.cpp
@@ -664,10 +664,7 @@ void ScorePlayer::do_play(int nEvStart, int nEvEnd, bool fVisualTracking,
                 if (fVisualTracking && events[i]->pSO->is_visible())
                 {
                     ImoId id = events[i]->pSO->get_id();
-//                    stringstream s;
-//                    s << "VISUAL ON. Num.items=" << pEvent->get_num_items();
-//                    LOMSE_LOG_DEBUG(lomse::Logger::k_events | lomse::Logger::k_score_player, s.str());
-                    if (pEvent->get_num_items() < 2)    //first even is "advance tempo line"
+                    if (pEvent->get_num_items() == 2)    //first even is "advance tempo line"
                         m_pInteractor->change_viewport_if_necessary(id);
                     pEvent->add_item(k_highlight_on_event, id);
                 }

--- a/src/sound/lomse_score_player.cpp
+++ b/src/sound/lomse_score_player.cpp
@@ -664,8 +664,7 @@ void ScorePlayer::do_play(int nEvStart, int nEvEnd, bool fVisualTracking,
                 if (fVisualTracking && events[i]->pSO->is_visible())
                 {
                     ImoId id = events[i]->pSO->get_id();
-                    if (pEvent->get_num_items() == 2)    //first even is "advance tempo line"
-                        m_pInteractor->change_viewport_if_necessary(id);
+                    m_pInteractor->change_viewport_if_necessary(id);
                     pEvent->add_item(k_highlight_on_event, id);
                 }
 
@@ -697,8 +696,11 @@ void ScorePlayer::do_play(int nEvStart, int nEvEnd, bool fVisualTracking,
             {
                 //set visual highlight
                 if (fVisualTracking)
-                    pEvent->add_item(k_highlight_on_event, events[i]->pSO->get_id());
-
+                {
+                    ImoId id = events[i]->pSO->get_id();
+                    m_pInteractor->change_viewport_if_necessary(id);
+                    pEvent->add_item(k_highlight_on_event, id);
+                }
             }
             else if (events[i]->EventType == SoundEvent::k_visual_off)
             {

--- a/src/sound/lomse_score_player.cpp
+++ b/src/sound/lomse_score_player.cpp
@@ -664,9 +664,9 @@ void ScorePlayer::do_play(int nEvStart, int nEvEnd, bool fVisualTracking,
                 if (fVisualTracking && events[i]->pSO->is_visible())
                 {
                     ImoId id = events[i]->pSO->get_id();
-                    stringstream s;
-                    s << "VISUAL ON. Num.items=" << pEvent->get_num_items();
-                    LOMSE_LOG_DEBUG(lomse::Logger::k_events | lomse::Logger::k_score_player, s.str());
+//                    stringstream s;
+//                    s << "VISUAL ON. Num.items=" << pEvent->get_num_items();
+//                    LOMSE_LOG_DEBUG(lomse::Logger::k_events | lomse::Logger::k_score_player, s.str());
                     if (pEvent->get_num_items() < 2)    //first even is "advance tempo line"
                         m_pInteractor->change_viewport_if_necessary(id);
                     pEvent->add_item(k_highlight_on_event, id);

--- a/src/sound/lomse_score_player.cpp
+++ b/src/sound/lomse_score_player.cpp
@@ -662,7 +662,15 @@ void ScorePlayer::do_play(int nEvStart, int nEvEnd, bool fVisualTracking,
 
                 //generate implicit visual on event
                 if (fVisualTracking && events[i]->pSO->is_visible())
-                    pEvent->add_item(k_highlight_on_event, events[i]->pSO->get_id());
+                {
+                    ImoId id = events[i]->pSO->get_id();
+                    stringstream s;
+                    s << "VISUAL ON. Num.items=" << pEvent->get_num_items();
+                    LOMSE_LOG_DEBUG(lomse::Logger::k_events | lomse::Logger::k_score_player, s.str());
+                    if (pEvent->get_num_items() < 2)    //first even is "advance tempo line"
+                        m_pInteractor->change_viewport_if_necessary(id);
+                    pEvent->add_item(k_highlight_on_event, id);
+                }
 
             }
             else if (events[i]->EventType == SoundEvent::k_note_off)


### PR DESCRIPTION
This PR fixes issue #88

When playing back an score it is necessary to ensure that current played notes are visible. Therefore, as the playback advances, the score should auto-scroll to maintain the viewport on the notes being played back.

The implemented solution defines a new Lomse event, *EventUpdateViewport*, that informs about the need to change the viewport and provides the coordinates for the new viewport origin. It is up to the user application to do it or not. This solution gives flexibility for changing/improving the auto-scroll algorithm without affecting user applications. And gives freedom to the user application to use the auto-scroll facility or to ignore the new events.

The implemented solution works as follows:

When the *ScorePlayer* object detects that the next note/rest to play will not be visible, it will generate an *EventUpdateViewport* event and pass it to the user application. The new *EventUpdateViewport* should be handled in the same way the *EventScoreHighlight* is currently handled.

When your application handles *EventUpdateViewport* events it is **very important** to return control to Lomse as soon as possible. This is because, currently, Lomse does not implement an event subsystem with its own thread. Instead Lomse sends events to your application by invoking a callback. This implies that your application code for handling the event is processed by the Lomse sound thread. As this thread is dealing with sound generation, your application **must** return control to Lomse as soon as possible, so that the sound thread can continue processing sound events. Otherwise, sound can be stalled! The suggested way for handling *EventUpdateViewport* and *EventScoreHighlight* events is to generate an application event and to enqueue it in the application events system.

For instance, in an application written using the wxWidgets framework you could have a global method for receiving all Lomse events, convert them in application events, and return control to Lomse:

```
void MainFrame::on_lomse_event(SpEventInfo pEvent)
{
    DocumentWindow* pCanvas = get_active_document_window();

    switch (pEvent->get_event_type())
    {
        case k_highlight_event:
        {
            if (pCanvas)
            {
				//generate score highlight event
                SpEventScoreHighlight pEv(
                    static_pointer_cast<EventScoreHighlight>(pEvent) );
                MyScoreHighlightEvent event(pEv);
                ::wxPostEvent(pCanvas, event);
            }
            break;
        }

        case k_update_viewport_event:
        {
            if (pCanvas)
            {
				//generate update viewport event
                SpEventUpdateViewport pEv(
                    static_pointer_cast<EventUpdateViewport>(pEvent) );
                MyUpdateViewportEvent event(pEv);
                ::wxPostEvent(pCanvas, event);
            }
            break;
        }
	...
```

Later, for processing the application event, your application should just use the *Interactor* for requesting to change the viewport to the new origin provided by the Lomse event. In addition it should to update scrollbars or other information/widgets used by the application. For instance:

```
	void DocumentWindow::on_update_viewport(MyUpdateViewportEvent& event)
	{
		SpEventUpdateViewport pEv = event.get_lomse_event();
		WpInteractor wpInteractor = pEv->get_interactor();
		int xPos = pEv->get_new_viewport_x();
		int yPos = pEv->get_new_viewport_y();
		WpInteractor wpInteractor = pEv->get_interactor();
		if (SpInteractor sp = wpInteractor.lock())
		{
			sp->new_viewport(xPos, yPos);

		    //reposition scroll thumb
		    SetScrollPos(wxVERTICAL, yPos);
		}
	}
```


As you can see, handling *EventUpdateViewport* events in your application is a round trip to, finally, delegate its handling on Lomse! But this round trip has an important gain: the code for doing all viewport update and repainting the window is executed in your application thread instead of in Lomse playback thread. And any concurrency or sound delay problems automatically disappear! Also, it gives flexibility for ignoring these events and do not use the auto-scroll facility.

The current algorithm for auto-scroll is very simple and only takes into account the vertical position. That is, it assumes that the viewport is wide enough for displaying the full music score width. And only moves the viewport up or down for ensuring that currently played back system is visible.

I've noticed that the documentation for the Lomse API doesn't not yet include documentation about Lomse events and how to handle them. I will try to write this documentation as soon as possible.

