### PR TITLE
Refactor some events and improve documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,55 @@
 # Lomse Library. Log of changes
 
 
-[Since last version] 0.21.0
+[Since last version] 0.22.0
+=============================
+
+##### BACKWARDS INCOMPATIBLE CHANGES WITH 0.22.0
+
+- None.
+
+##### COMPATIBLE CHANGES
+
+- None.
+
+
+
+Version [0.22.0] (9/Jan/2018)
 =============================
 
 ##### BACKWARDS INCOMPATIBLE CHANGES WITH 0.21.0
 
-- None.
+While documenting Lomse events some issues where found (see issue #111)
+and it was decided to refactor some events. Unfortunatelly most of these
+changes create incompatibilities due to renames. In particular:
+
+- Some useless event classification methods in EventInfo have been removed.
+
+- EventPlayScore has been renamed:
+	- EventPlayScore of types k_do_play_score_event, k_pause_score_event and
+      k_stop_playback_event renamed as EventPlayCtrl.
+    - EventPlayScore of type k_end_of_playback_event renamed as EventEndOfPlayback
+
+- Removed event types k_highlight_on_event, k_highlight_off_event,
+  k_end_of_higlight_event and k_advance_tempo_line_event, and replaced by
+  an enum in EventScoreHighlight. 
+
+- Event EventMouse (type k_show_contextual_menu_event) renamed as
+  EventContextualMenu (type k_show_contextual_menu_event)
+
+- Created EventMouse, type k_link_clicked_event. It replaces on_click
+  events on ImoLink because the way in which they are sent to the user
+  application is different and, therefore, it is confusing how to handle
+  them. The new event type is also more specific.
+
+- Removed EventView and created bases classes EventAction and EventPlayback
+
+- Method Interactor::send_end_of_play_event()" renamed as 
+  "on_end_of_play_event()" to avoid raising questions on users about 
+  the contradiction of having to ask the Interactor to
+  "send_end_of_play_event" when an end of play event has been received
+  and is being processed.
+
 
 ##### COMPATIBLE CHANGES
 
@@ -539,7 +582,8 @@ Version 0.10.b1
 - Initial public release, used in Phonascus 5.0 beta for Linux.
 
 
-[Since last version]: https://github.com/lenmus/lomse/compare/0.21.0...HEAD
+[Since last version]: https://github.com/lenmus/lomse/compare/0.22.0...HEAD
+[0.22.0]: https://github.com/lenmus/lomse/compare/0.21.0...0.22.0
 [0.21.0]: https://github.com/lenmus/lomse/compare/0.20.0...0.21.0
 [0.20.0]: https://github.com/lenmus/lomse/compare/0.19.0...0.20.0
 [0.19.0]: https://github.com/lenmus/lomse/compare/0.18.0...0.19.0

--- a/build-version.cmake
+++ b/build-version.cmake
@@ -7,7 +7,7 @@
 #-------------------------------------------------------------------------------------
 
 set( LOMSE_VERSION_MAJOR 0 )
-set( LOMSE_VERSION_MINOR 21 )
+set( LOMSE_VERSION_MINOR 22 )
 set( LOMSE_VERSION_PATCH 0 )
 
 # build version string for installer name

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
-lomse (0.21.0) stable; urgency=low
+lomse (0.22.0) stable; urgency=low
 
   * Latest release
 
- -- Cecilio Salmeron <s.cecilio@gmail.com>  Thu, 09 Nov 2017 16:17:51 +0100
+ -- Cecilio Salmeron <s.cecilio@gmail.com>  Tue, 09 Jan 2018 16:38:47 +0100
 

--- a/docs/api/doxyfile
+++ b/docs/api/doxyfile
@@ -19,7 +19,7 @@
 
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "Lomse library. API documentation"
-PROJECT_NUMBER         = 0.21.0
+PROJECT_NUMBER         = 0.22.0
 PROJECT_BRIEF          =
 PROJECT_LOGO           = ./images/logo_100x195.png
 OUTPUT_DIRECTORY       = ../../../api-docs

--- a/docs/api/mainpages/callbacks.h
+++ b/docs/api/mainpages/callbacks.h
@@ -1,5 +1,5 @@
 /**
-@page lomse-callbacks How Lomse callbacks work
+@page page-callbacks How Lomse callbacks work
 
 It is very important to understand how a callback works and how to use a class method as callback.
 

--- a/docs/api/mainpages/code-license.h
+++ b/docs/api/mainpages/code-license.h
@@ -1,5 +1,5 @@
 /**
-@page samples-license License for code samples
+@page page-code-license License for code samples
 
 
 The code samples and code examples included in this API documentation are intended to show how the Lomse library can be used and so, to be copied. Therefore, they are licensed under the following terms:

--- a/docs/api/mainpages/coordinates-viewport.h
+++ b/docs/api/mainpages/coordinates-viewport.h
@@ -1,5 +1,5 @@
 /**
-@page viewport-overview Coordinate systems, units, scaling and viewport
+@page page-coordinates-viewport Coordinate systems, units, scaling and viewport
 
 @tableofcontents
 

--- a/docs/api/mainpages/edit-overview.h
+++ b/docs/api/mainpages/edit-overview.h
@@ -1,12 +1,12 @@
 /**
 
-@page document-edition-overview Editing documents overview
+@page page-edit-overview Editing documents overview
 
 @tableofcontents
 
 @section edit-overview How to modify a document
 
-When a source document (in LDP or MusicXML format) is loaded, it is not stored as text or as an XML Document Object Model (<i>DOM</i>). Instead, the document is parsed and an @IM is built. The @IM is, mainly, a tree structure in memory. The root element of the @IM tree represents the whole document. And the children of the root element represent the basic blocks for building a document: headers, paragraphs, music scores, lists, etc. For an overview of the @IM see @ref internal-model-overview.
+When a source document (in LDP or MusicXML format) is loaded, it is not stored as text or as an XML Document Object Model (<i>DOM</i>). Instead, the document is parsed and an @IM is built. The @IM is, mainly, a tree structure in memory. The root element of the @IM tree represents the whole document. And the children of the root element represent the basic blocks for building a document: headers, paragraphs, music scores, lists, etc. For an overview of the @IM see @ref page-internal-model.
 
 Once the @IM is created, for modifying the document your application has two options, either
 -# use the edition commands API; or
@@ -18,7 +18,7 @@ Once the @IM is created, for modifying the document your application has two opt
 
 Of course, both APIs are compatible and can be used by your application for offering different services.
 
-The rest of this page describes the high level API using edition commands. For a description of the low level API see @ref direct-im-modification.
+The rest of this page describes the high level API using edition commands. For a description of the low level API see @ref page-im-modification.
 
 
 @section edit-high-level The high-level API: edition commands

--- a/docs/api/mainpages/file-formats.h
+++ b/docs/api/mainpages/file-formats.h
@@ -1,10 +1,10 @@
 /**
 
-@page file-formats File formats supoported by Lomse
+@page page-file-formats File formats supoported by Lomse
 
 @tableofcontents
 
-@section file-formats-overview Supported file formats
+@section page-file-formats-overview Supported file formats
 
 Lomse supports the following file formats:
 

--- a/docs/api/mainpages/introduction.h
+++ b/docs/api/mainpages/introduction.h
@@ -1,6 +1,6 @@
 /**
 
-@page lomse-introduction Introduction
+@page page-introduction Introduction
 
 @ingroup pages
 
@@ -61,7 +61,7 @@ Lomse is platform independent code and knows nothing about how to create a windo
 
 These operations are usually triggered by your application when handling some operating system events, such as <b>window paint</b> events.
 
-The details and methods you have to use for displaying documents are described in @ref render-overview.
+The details and methods you have to use for displaying documents are described in @ref page-render-overview.
 
 
 
@@ -69,7 +69,7 @@ The details and methods you have to use for displaying documents are described i
 
 As Lomse is platform independent code, it knows nothing about how to print in the operating system used by your application. Therefore, it is your application responsibility to implement printing. Lomse just offers some supporting methods so that implementing printing does not require much work. In fact, implementing printing in your application is just printing bitmaps.
 
-The details and methods you have to use for printing are described in @ref print-api.
+The details and methods you have to use for printing are described in @ref page-printing.
 
 
 
@@ -85,7 +85,7 @@ Most edition commands require a reference point in the document. For this, Lomse
 
 For moving the cursor to another position and for selecting or deselecting objects your application just issue specific edition commands, such as <i>advance cursor</i>, <i>move cursor to start of score</i> or <i>select object</i>.
 
-And this is, basically, the document edition API. It is very simple and gives full freedom to your application for implementing the GUI as you'd like, or for not a having a GUI! For more details see  @ref document-edition-overview.
+And this is, basically, the document edition API. It is very simple and gives full freedom to your application for implementing the GUI as you'd like, or for not a having a GUI! For more details see  @ref page-edit-overview.
 
 
 
@@ -93,7 +93,7 @@ And this is, basically, the document edition API. It is very simple and gives fu
 
 Lomse is platform independent code and cannot generate sounds for your specific platform. Therefore, lomse implements playback by generating real-time events and sending them to your application. It is responsibility of your application to handle these events and do whatever is needed, i.e. transform sound events into real sounds or doing whatever you would like with the sound events.
 
-The details and classes you have to use for scores playback are described in @ref sound-generation.
+The details and classes you have to use for scores playback are described in @ref page-sound-generation.
 
 */
 

--- a/docs/api/mainpages/library-license.h
+++ b/docs/api/mainpages/library-license.h
@@ -1,5 +1,5 @@
 /**
-@page library-license Library license
+@page page-library-license Library license
 
 Lomse is free software: you can redistribute it and/or modify it under the terms of the BSD 2-Clause license. This is a human-readable summary of (and not a substitute for) the license:
 

--- a/docs/api/mainpages/overview.h
+++ b/docs/api/mainpages/overview.h
@@ -15,28 +15,28 @@ Please be aware that Lomse is a work in progress, not having yet reached version
 
 ## License
 
-Lomse is distributed under the BSD 2-clause license, a permissive open source license to allow Lomse to be used in any projects, whether open source or proprietary. This license is a GPL compatible license, so you can use Lomse in GPL licensed projects (see @ref library-license).
+Lomse is distributed under the BSD 2-clause license, a permissive open source license to allow Lomse to be used in any projects, whether open source or proprietary. This license is a GPL compatible license, so you can use Lomse in GPL licensed projects (see @ref page-library-license).
 
-The code samples and code examples included in this API documentation are intended to show how the Lomse library can be used and so, intended to be copied. Therefore, they are released into the public domain (see @ref samples-license).
+The code samples and code examples included in this API documentation are intended to show how the Lomse library can be used and so, intended to be copied. Therefore, they are released into the public domain (see @ref page-code-license).
 
 
 ## Lomse usage
 
-If you are new to Lomse, @b please read the @subpage lomse-introduction and then read the topic or topics you are interested in:
+If you are new to Lomse, @b please read the @subpage page-introduction and then read the topic or topics you are interested in:
 
-- @subpage render-overview
-- @subpage print-api
-- @subpage document-edition-overview
-- @subpage sound-generation
-- @subpage tasks-page
+- @subpage page-render-overview
+- @subpage page-printing
+- @subpage page-edit-overview
+- @subpage page-sound-generation
+- @subpage page-tasks
 
 ## Other topics
 
-- @subpage file-formats
-- @subpage internal-model-overview
-- @subpage viewport-overview
-- @subpage lomse-callbacks
-- @subpage lomse-events
+- @subpage page-file-formats
+- @subpage page-internal-model
+- @subpage page-coordinates-viewport
+- @subpage page-callbacks
+- @subpage page-events
 
 
 */

--- a/docs/api/mainpages/printing.h
+++ b/docs/api/mainpages/printing.h
@@ -1,6 +1,6 @@
 /**
 
-@page print-api Printing documents overview
+@page page-printing Printing documents overview
 
 @tableofcontents
 

--- a/docs/api/mainpages/render-overview.h
+++ b/docs/api/mainpages/render-overview.h
@@ -1,5 +1,5 @@
 /**
-@page render-overview Rendering documents overview
+@page page-render-overview Rendering documents overview
 
 @tableofcontents
 

--- a/docs/api/mainpages/sound-generation.h
+++ b/docs/api/mainpages/sound-generation.h
@@ -1,10 +1,10 @@
 /**
 
-@page sound-generation Scores playback overview
+@page page-sound-generation Scores playback overview
 
 @tableofcontents
 
-@section sound-generation-overview How Lomse playback works
+@section page-sound-generation-overview How Lomse playback works
 
 Lomse is platform independent code and cannot generate sounds for your specific platform. Therefore, lomse implements playback by generating real-time events and sending them to your application. It is responsibility of your application to handle these events and do whatever is needed, i.e. transform sound events into real sounds or doing whatever you would like with the sound events.
 

--- a/docs/api/mainpages/tasks.h
+++ b/docs/api/mainpages/tasks.h
@@ -1,5 +1,5 @@
 /**
-@page tasks-page Interaction with your application GUI
+@page page-tasks Interaction with your application GUI
 
 @tableofcontents
 

--- a/include/lomse_doorway.h
+++ b/include/lomse_doorway.h
@@ -157,7 +157,7 @@ public:
         @param pt2Func  A pointer to the method in previous object that Lomse will
             invoke when an event is generated in Lomse.
 
-        See @subpage lomse-callbacks.
+        See @subpage page-callbacks.
 
         For example, to prepare our application for handling @em score @em highlight
         events we could define a callback method:
@@ -207,7 +207,7 @@ public:
         @param pt2Func  A pointer to the method in previous object that Lomse will
             invoke when a requests is generated in Lomse.
 
-        See @subpage lomse-callbacks
+        See @subpage page-callbacks
         for an explanation of Lomse callbacks and its parameters.
 
         For example:
@@ -282,7 +282,7 @@ public:
             MidiServerBase. Once this method is invoked, Lomse will route all midi
             events originated in score play back to this object.
 
-        @see @subpage sound-generation
+        @see @subpage page-sound-generation
 	*/
     ScorePlayer* create_score_player(MidiServerBase* pSoundServer);
 
@@ -301,7 +301,7 @@ public:
             Presenter will automatically cause deletion of all MVC involved objects:
             the Document, all existing Views and Interactors, etc.
 
-        @see @subpage render-overview
+        @see @subpage page-render-overview
 	*/
     Presenter* new_document(int viewType);
 
@@ -327,7 +327,7 @@ public:
             Presenter will automatically cause deletion of all MVC involved objects:
             the Document, all existing Views and Interactors, etc.
 
-        @see @subpage render-overview
+        @see @subpage page-render-overview
 	*/
     Presenter* new_document(int viewType, const string& source, int format,
                             ostream& reporter = cout);
@@ -349,7 +349,7 @@ public:
             Presenter will automatically cause deletion of all MVC involved objects:
             the Document, all existing Views and Interactors, etc.
 
-        @see @subpage render-overview
+        @see @subpage page-render-overview
 	*/
     Presenter* open_document(int viewType, const string& filename,
                              ostream& reporter = cout);
@@ -372,7 +372,7 @@ public:
             Presenter will automatically cause deletion of all MVC involved objects:
             the Document, all existing Views and Interactors, etc.
 
-        @see @subpage render-overview
+        @see @subpage page-render-overview
 	*/
     Presenter* open_document(int viewType, LdpReader& reader,
                              ostream& reporter = cout);

--- a/include/lomse_events.h
+++ b/include/lomse_events.h
@@ -81,38 +81,38 @@ enum EEventType
 {
     k_null_event = -1,
 
-    k_view_level_event = 0,
+    //EventDoc
+        k_doc_modified_event,       ///< Informs that the Document has been modified
 
-        k_update_window_event,      ///<  ask user app to update window with current bitmap
-        k_update_viewport_event,    ///< ask user app to update window with current bitmap
+    //EventPaint
+        k_update_window_event,      ///< Request to update window with current bitmap
 
-        k_update_UI_event,          ///< possible need for UI updates
-            k_selection_set_change,     ///< selected objects changed
-            k_pointed_object_change,    ///< cursor pointing to a different object
+    //EventAction
+        //EventMouse
+        k_mouse_in_event,               ///< mouse enters in an object
+        k_mouse_out_event,              ///< mouse goes out from an object
+        k_on_click_event,               ///< click on object
+        k_link_clicked_event,           ///< left mouse click on a link (ImoLink object)
+        k_show_contextual_menu_event,   ///< right click on object: contextual menu request
+        //EventControlPointMoved
+        k_control_point_moved_event,    ///< user moves a handler: handler released event
+        //EventUpdateUI             ///< possible need for UI updates
+        k_selection_set_change,         ///< selected objects changed
+        k_pointed_object_change,        ///< cursor pointing to a different object
+        //EventPlayCtrl
+        k_do_play_score_event,          ///< Request to start/resume playback
+        k_pause_score_event,            ///< Request to pause playback
+        k_stop_playback_event,          ///< Request to stop playback
 
-        k_mouse_event,
-            k_mouse_in_event,               ///< mouse goes over an object
-            k_mouse_out_event,              ///< mouse goes out from an object
-            k_on_click_event,               ///< Document, ImoContentObj: click on object
-            k_show_contextual_menu_event,   ///< Click event: object selected and menu request
+    //EventPlayback
+        //EventScoreHighlight
+        k_highlight_event,              ///< Wrapper event containing a list of real events
+        //EventUpdateViewport
+        k_update_viewport_event,        ///< Suggest to change viewport
+        //EventEndOfPlayback
+        k_end_of_playback_event,        ///< Playback ended.
 
-        k_command_event,
-            k_control_point_moved_event,    ///< user moves a handler: handler released event
 
-        k_highlight_event,          ///< score playbaxk (highlight)
-            k_highlight_on_event,           ///< add highlight to a note/rest
-            k_highlight_off_event,          ///< remove highlight from a note/rest
-            k_end_of_higlight_event,        ///< end of score play back. Remove all highlight.
-            k_advance_tempo_line_event,
-
-        k_play_score_event,         ///< score playback (sound)
-            k_do_play_score_event,          ///< start/resume playback
-            k_pause_score_event,            ///< pause playback
-            k_stop_playback_event,          ///< stop playback
-            k_end_of_playback_event,        ///< end of playback
-
-    k_doc_level_event = 1000,
-        k_doc_modified_event,
 };
 
 //---------------------------------------------------------------------------------------
@@ -135,52 +135,32 @@ public:
         to an Observable object it returns nullptr. */
     virtual Observable* get_source() { return nullptr; }
 
-
     /// Returns the event type. It is a value from enmun #EEventType.
     inline EEventType get_event_type() { return m_type; }
 
-    /// @name For checking event type
+    /// @name Helpers for checking event type
     //@{
-    inline bool is_view_level_event() { return m_type >= k_view_level_event
-                                            && m_type < k_doc_level_event;
-                                      }
-    inline bool is_update_UI_event() { return m_type == k_selection_set_change
-                                       || m_type == k_pointed_object_change;
-                                     }
+    inline bool is_doc_modified_event() { return m_type == k_doc_modified_event; }
     inline bool is_update_window_event() { return m_type == k_update_window_event; }
-    inline bool is_update_viewport_event() { return m_type == k_update_viewport_event; }
-    inline bool is_mouse_event() { return m_type == k_on_click_event
-                                       || m_type == k_mouse_in_event
-                                       || m_type == k_mouse_out_event
-                                       || m_type == k_show_contextual_menu_event
-                                       || m_type == k_control_point_moved_event;
-                                 }
-    inline bool is_command_event() { return m_type == k_control_point_moved_event; }
-    inline bool is_play_score_event() { return m_type == k_do_play_score_event
-                                            || m_type == k_pause_score_event
-                                            || m_type == k_stop_playback_event
-                                            || m_type == k_end_of_playback_event;
-                                      }
     inline bool is_mouse_in_event() { return m_type == k_mouse_in_event; }
     inline bool is_mouse_out_event() { return m_type == k_mouse_out_event; }
     inline bool is_on_click_event() { return m_type == k_on_click_event; }
+    inline bool is_link_clicked_event() { return m_type == k_link_clicked_event; }
     inline bool is_show_contextual_menu_event() { return m_type == k_show_contextual_menu_event; }
     inline bool is_control_point_moved_event() { return m_type == k_control_point_moved_event; }
-    inline bool is_highlight_event() { return m_type == k_highlight_event; }
-    inline bool is_highlight_on_event() { return m_type == k_highlight_on_event; }
-    inline bool is_highlight_off_event() { return m_type == k_highlight_off_event; }
-    inline bool is_end_of_higlight_event() { return m_type == k_end_of_higlight_event; }
-    inline bool is_advance_tempo_line_event() { return m_type == k_advance_tempo_line_event; }
-    inline bool is_end_of_playback_event() { return m_type == k_end_of_playback_event; }
+    inline bool is_selection_set_change() { return m_type == k_selection_set_change; }
+    inline bool is_pointed_object_change() { return m_type == k_pointed_object_change; }
     inline bool is_do_play_score_event() { return m_type == k_do_play_score_event; }
     inline bool is_pause_score_event() { return m_type == k_pause_score_event; }
     inline bool is_stop_playback_event() { return m_type == k_stop_playback_event; }
-
-        //document level events
-    inline bool is_doc_level_event() { return m_type >= k_doc_level_event; }
-    inline bool is_doc_modified_event() { return m_type == k_doc_modified_event; }
+    inline bool is_highlight_event() { return m_type == k_highlight_event; }
+    inline bool is_update_viewport_event() { return m_type == k_update_viewport_event; }
+    inline bool is_end_of_playback_event() { return m_type == k_end_of_playback_event; }
     //@}
 
+protected:
+    friend class Interactor;
+    inline void set_type(EEventType type) { m_type = type; }
 };
 
 /** A shared pointer for an EventInfo.
@@ -191,7 +171,23 @@ typedef SharedPtr<EventInfo>  SpEventInfo;
 
 
 //---------------------------------------------------------------------------------------
-/** Base class for all Document related events.
+/** An event generated by the Document, not related to any specific View.
+
+    The only type for this event is <b>k_doc_modified_event</b> that is generated when
+    the Document is modified. This event is observed by the Interactor in order to
+    generate EvenPaint events when necessary. Therefore, your application normally
+    will not have to handle this event.
+
+    For handling it in your application, you will have to register a handler function
+    at the Document:
+    @code
+    pDoc->add_event_handler(k_doc_modified_event, MyHandler);
+    @endcode
+
+    You can always check if a Document has been modified by invoking method
+    Document::is_dirty().
+
+    See @ref handling-events
 */
 class EventDoc : public EventInfo
 {
@@ -220,36 +216,6 @@ typedef SharedPtr<EventDoc>  SpEventDoc;
 
 
 //---------------------------------------------------------------------------------------
-/** Base class for all View related events.
-*/
-class EventView : public EventInfo
-{
-protected:
-    WpInteractor m_wpInteractor;
-
-    EventView(EEventType type, WpInteractor wpInteractor)
-        : EventInfo(type)
-        , m_wpInteractor(wpInteractor)
-    {
-    }
-
-public:
-    /// Destructor
-    virtual ~EventView() {}
-
-    /** Returns a weak pointer to the Interactor object managing the
-        View in which the event is generated. */
-    inline WpInteractor get_interactor() { return m_wpInteractor; }
-};
-
-/** A shared pointer for an EventView.
-    @ingroup typedefs
-    @#include <lomse_events.h>
-*/
-typedef SharedPtr<EventView>  SpEventView;
-
-
-//---------------------------------------------------------------------------------------
 // EventPaint
 /** An event to inform user application about the need to repaint the screen.
 
@@ -258,11 +224,13 @@ typedef SharedPtr<EventView>  SpEventView;
 	inform the user application that it must immediately update the content of the
 	window associated to the lomse View, by displaying the current bitmap. User
 	application must put immediately the content of the currently rendered buffer
-	into the window without calling any Lomse methods (i.e. force_redraw).
+	into the window without calling any Lomse methods (i.e. force_redraw) or generating
+	application events. .
 
 	For receiving these events you will have to register a callback when
-	the View is created. For processing these events your application
-	just blits the new bitmap onto the window.
+	the View is created. For processing these events take into account that this event
+	is decoupled by design: user must do repaint immediately, without more delays; your
+	application should just blit the new bitmap onto the window.
 
     <b>Example</b>
 
@@ -316,13 +284,15 @@ typedef SharedPtr<EventView>  SpEventView;
 	}
 	@endcode
 */
-class EventPaint : public EventView
+class EventPaint : public EventInfo
 {
 protected:
+    WpInteractor m_wpInteractor;
     VRect m_damagedRectangle;
 
     EventPaint(EEventType type, WpInteractor wpInteractor, VRect damagedRectangle)
-        : EventView(type, wpInteractor)
+        : EventInfo(type)
+        , m_wpInteractor(wpInteractor)
         , m_damagedRectangle(damagedRectangle)
     {
     }
@@ -330,12 +300,17 @@ protected:
 public:
     /// Constructor
     EventPaint(WpInteractor wpInteractor, VRect damagedRectangle)
-        : EventView(k_update_window_event, wpInteractor)
+        : EventInfo(k_update_window_event)
+        , m_wpInteractor(wpInteractor)
         , m_damagedRectangle(damagedRectangle)
     {
     }
     /// Destructor
     virtual ~EventPaint() {}
+
+    /** Returns a weak pointer to the Interactor object managing the
+        View in which the event is generated. */
+    inline WpInteractor get_interactor() { return m_wpInteractor; }
 
     /** Returns the damaged rectangle, that is, the rectangle that needs repaint. */
     inline VRect get_damaged_rectangle() { return m_damagedRectangle; }
@@ -346,6 +321,80 @@ public:
     @#include <lomse_events.h>
 */
 typedef SharedPtr<EventPaint>  SpEventPaint;
+
+
+//---------------------------------------------------------------------------------------
+/** Base class for all events representing a user mouse action that
+    has been interpreted by Lomse as a command to change the Document or the GUI.
+*/
+class EventAction : public EventInfo
+{
+protected:
+    WpInteractor m_wpInteractor;
+    WpDocument m_wpDoc;
+
+    /// Constructor
+    EventAction(EEventType type, WpInteractor wpInteractor, WpDocument wpDoc)
+        : EventInfo(type)
+        , m_wpInteractor(wpInteractor)
+        , m_wpDoc(wpDoc)
+    {
+    }
+
+public:
+    /// Destructor
+    virtual ~EventAction() {}
+
+    /** Returns a weak pointer to the Interactor object managing the
+        View in which the event is generated. */
+    inline WpInteractor get_interactor() { return m_wpInteractor; }
+
+    /** Returns a weak pointer to the Document object related to this event. */
+    inline WpDocument get_document() { return m_wpDoc; }
+
+    ///Returns @true if the event is still valid and can be processed.
+    bool is_still_valid() {
+        return !m_wpDoc.expired() && !m_wpInteractor.expired();
+    }
+};
+
+/** A shared pointer for an EventAction.
+    @ingroup typedefs
+    @#include <lomse_events.h>
+*/
+typedef SharedPtr<EventAction>  SpEventAction;
+
+
+//---------------------------------------------------------------------------------------
+/** Base class for all events generated events generated by SoundPlayer in the sound
+    thread, during playback.
+*/
+class EventPlayback : public EventInfo
+{
+protected:
+    WpInteractor m_wpInteractor;
+
+    /// Constructor
+    EventPlayback(EEventType type, WpInteractor wpInteractor)   //, WpDocument wpDoc)
+        : EventInfo(type)
+        , m_wpInteractor(wpInteractor)
+    {
+    }
+
+public:
+    /// Destructor
+    virtual ~EventPlayback() {}
+
+    /** Returns a weak pointer to the Interactor object managing the
+        View in which the event is generated. */
+    inline WpInteractor get_interactor() { return m_wpInteractor; }
+};
+
+/** A shared pointer for an EventPlayback.
+    @ingroup typedefs
+    @#include <lomse_events.h>
+*/
+typedef SharedPtr<EventPlayback>  SpEventPlayback;
 
 
 //---------------------------------------------------------------------------------------
@@ -425,7 +474,7 @@ typedef SharedPtr<EventPaint>  SpEventPaint;
 	}
 	@endcode
 */
-class EventUpdateViewport : public EventView
+class EventUpdateViewport : public EventPlayback
 {
 protected:
     VRect m_damagedRectangle;
@@ -435,7 +484,7 @@ protected:
 public:
     /// Constructor
     EventUpdateViewport(WpInteractor wpInteractor, Pixels x, Pixels y)
-        : EventView(k_update_viewport_event, wpInteractor)
+        : EventPlayback(k_update_viewport_event, wpInteractor)
         , m_x(x)
         , m_y(y)
     {
@@ -460,29 +509,28 @@ typedef SharedPtr<EventUpdateViewport>  SpEventUpdateViewport;
 
 //---------------------------------------------------------------------------------------
 // EventUpdateUI
-/** EventUpdateUI events are generated to signal changes on the Document that could
-    require changes on the user application GUI, such as enabling or disabling tools,
-    menu items and buttons.
+/** %EventUpdateUI events are generated to inform about actions related to the Document
+    that could require changes on the user application GUI, such as enabling or
+    disabling tools, menu items and buttons.
 
-    EventUpdateUI events of type **k_selection_set_change** are generated when
+    %EventUpdateUI events of type **k_selection_set_change** are generated when
     Document objects are selected or deselected. The rationale is that some application
     tools should be enabled or disabled depending on the kind of selected objects.
 
-    EventUpdateUI events of type **k_pointed_object_change** are generated when the
+    %EventUpdateUI events of type **k_pointed_object_change** are generated when the
     document cursor is updated, as the object pointed by the cursor has changed. Again,
     the rationale is that some application tools should be enabled or disabled depending
     on the nature of the pointed object.
 
-    Although EventUpdateUI events are related to a Document, they are sent directly to
-    the application global handler (the one set by invoking
-    LomseDoorway::set_notify_callback() ), because it is assumed that these events are
-    of interest only for the application main frame.
+    %EventUpdateUI events are sent directly to the application global handler (the one
+    set by invoking LomseDoorway::set_notify_callback() ). For handling these events
+    you should generate application events, place them in the application events loop
+    and return control to Lomse.
 
     <b>Example</b>
 
 	For instance, in an application written using the wxWidgets framework you
-	could handle the EventUpdateUI by converting them in application events, placing
-	them in the application events loop and returning control to Lomse:
+	could handle the %EventUpdateUI as follows:
 
 	@code
 	void MainFrame::on_lomse_event(SpEventInfo pEvent)
@@ -541,21 +589,20 @@ typedef SharedPtr<EventUpdateViewport>  SpEventUpdateViewport;
     }
     @endcode
 */
-class EventUpdateUI : public EventView
+class EventUpdateUI : public EventAction
 {
 protected:
-    WpDocument m_wpDoc;
     SelectionSet* m_pSelection;
     DocCursor* m_pCursor;
 
-    EventUpdateUI(EEventType type) : EventView(type, WpInteractor()) {}    //for unit tests
+    //for unit tests
+    EventUpdateUI(EEventType type) : EventAction(type, WpInteractor(), WpDocument()) {}
 
 public:
     /// Constructor
     EventUpdateUI(EEventType type, WpInteractor wpInteractor, WpDocument wpDoc,
                   SelectionSet* pSelection, DocCursor* pCursor)
-        : EventView(type, wpInteractor)
-        , m_wpDoc(wpDoc)
+        : EventAction(type, wpInteractor, wpDoc)
         , m_pSelection(pSelection)
         , m_pCursor(pCursor)
     {
@@ -568,12 +615,6 @@ public:
     /** Returns a ptr to current DocCursor object, so that user application can
         determine where is the cursor pointing.    */
     inline DocCursor* get_cursor() { return m_pCursor; }
-
-    ///Returns @true if the event is still valid and can be processed.
-    bool is_still_valid() {
-        return !m_wpDoc.expired() && !m_wpInteractor.expired();
-    }
-
 };
 
 /** A shared pointer for an EventUpdateUI.
@@ -599,6 +640,20 @@ typedef SharedPtr<EventUpdateUI>  SpEventUpdateUI;
 
     In particular, EventMouse events generation and suggested processing is as follows:
 
+    <b>Types k_mouse_in_event and k_mouse_out_event</b>
+
+    They are generated in the following situations:
+    - TaskOnlyClicks selected: Move mouse generates mouse-in-out events as mouse flies
+        over the different box areas. Probably your application should ignore these
+        events.
+    - TaskSelection selected: As mouse moves without clicking EventMouse of types
+        k_mouse_in_event & k_mouse_out_event are generated as mouse flies over the
+        different box areas. Probably your application should ignore these events.
+    - TaskDataEntry selected: As mouse moves, mouse in and out events are generated,
+        as mouse flies over the different box areas. Your application can handle these
+        events and react to them as convenient (i.e. highlighting the implied
+        insertion point/area).
+
     <b>Type k_on_click_event</b>
 
     They are generated in the following situations:
@@ -620,7 +675,31 @@ typedef SharedPtr<EventUpdateUI>  SpEventUpdateUI;
         command for inserting the object at the position implied by the event click
         point.
 
+    <b>Type k_link_clicked_event</b>
+
+    This event type is generated to inform about a left mouse click on a link (ImoLink)
+    object.
+
+    This event is generated when an %EventMouse of type k_on_click_event is being
+    processing by Lomse to determine possible actions to do before passing the event
+    to the user application. When Lomse determines that it is a left click on an ImoLink
+    object, the event is passed to the user as an event of type k_link_clicked_event
+    instead of a generic k_on_click_event.
+
+    @note
+	- Notice that an ImoLink object is different from an hyperlink control (an
+    ImoControl containing an HyperlinkCtrl object). Hyperlink controls are only used in
+    user applications that generate dynamic content (user defined GUI control objects
+    embedded in the %Document) and can not be created from files.
+	- A link (ImoLink) is only generated by a LMD @<link@> tag. Therefore, your application
+	will never receive events of this type when processing MusicXML or LDP files.
+
     <b>Type k_show_contextual_menu_event</b>
+
+    An %EventMouse of type k_show_contextual_menu_event informs about a mouse right
+    button click on an ImoObj that has been interpreted by Lomse as a request for
+    displaying its <i>contextual menu</i> (it is up to your application the decide what
+    is this menu, if any, and what to do whit this event).
 
     They are generated in the following situations:
     - TaskSelection selected: Right click down, selects object and sends EventUpdateUI
@@ -630,38 +709,23 @@ typedef SharedPtr<EventUpdateUI>  SpEventUpdateUI;
     - TaskDataEntry selected: Right click sends a EventMouse
         (k_show_contextual_menu_event) to request to show the contextual menu associated
         to the pointed object, if any.
-
-    <b>Types k_mouse_in_event and k_mouse_out_event</b>
-
-    They are generated in the following situations:
-    - TaskOnlyClicks selected: Move mouse generates mouse-in-out events as mouse flies
-        over the different box areas. Probably your application should ignore these
-        events.
-    - TaskSelection selected: As mouse moves without clicking EventMouse of types
-        k_mouse_in_event & k_mouse_out_event are generated as mouse flies over the
-        different box areas. Probably your application should ignore these events.
-    - TaskDataEntry selected: As mouse moves, mouse in and out events are generated,
-        as mouse flies over the different box areas. Your application can handle these
-        events and react to them as convenient (i.e. highlighting the implied
-        insertion point/area).
 */
-class EventMouse : public EventView
+class EventMouse : public EventAction
 {
 protected:
-    WpDocument m_wpDoc;
     ImoId m_imoId;
     Pixels m_x;
     Pixels m_y;
     unsigned m_flags;
 
-    EventMouse(EEventType type) : EventView(type, WpInteractor()) {}    //for unit tests
+    //for unit tests
+    EventMouse(EEventType type) : EventAction(type, WpInteractor(), WpDocument()) {}
 
 public:
     /// Constructor
     EventMouse(EEventType type, WpInteractor wpInteractor, ImoId id,
                Pixels x, Pixels y, unsigned flags, WpDocument wpDoc)
-        : EventView(type, wpInteractor)
-        , m_wpDoc(wpDoc)
+        : EventAction(type, wpInteractor, wpDoc)
         , m_imoId(id)
         , m_x(x)
         , m_y(y)
@@ -698,9 +762,6 @@ public:
         took place. The different flags are described by enum #EEventFlag    */
     inline unsigned get_flags() { return m_flags; }
 
-    ///Returns @true if the event is still valid and can be processed.
-    bool is_still_valid();
-
 };
 
 /** A shared pointer for an EventMouse.
@@ -711,90 +772,21 @@ typedef SharedPtr<EventMouse>  SpEventMouse;
 
 
 //---------------------------------------------------------------------------------------
-// EventPlayScore
-//k_end_of_playback is generated in the sound thread and posted to main application
-//handler. It is never posted to the Document observers.
-//
-//Your app generates an application event and returns control to Lomse
-//
-//Your application, later, processes the application event and ask Interactor to inform
-//PlayerGui, for any housekeeping it has to do.
-//
+// EventPlayCtrl
 /** An object holding information about an score player control event. The event type informs
 	the user application about the specific action.
 
-	@warning Events of type <tt>k_end_of_playback_event</tt> are generated by the View
-		to inform about the end of playback, just in case your application would like to do
-		any action, such as enabling or disabling GUI buttons related to playback.
-
-		All other types for this event (<tt>k_do_play_score_event</tt>,
-		<tt>k_pause_score_event</tt> and <tt>k_stop_playback_event</tt>) are generated
-		only from LDP documents with embedded controls (buttons, links, etc.). In
-		particular these event are generated by the ScorePlayerCtrl object associated to an
-		ImoScorePlayer object embedded in the Document. More information on these
-		sub-events later.
-
-	Events of type <tt>k_end_of_playback_event</tt> should be handled by
-	They are typically used for enabling and disabling GUI buttons related to playback.
-	For instance, in an application written using the wxWidgets framework, you
-	could handle these sub-events as follows:
-
-	@code
-	void MainFrame::on_lomse_event(SpEventInfo pEvent)
-	{
-		DocumentWindow* pCanvas = get_active_document_window();
-
-		switch (pEvent->get_event_type())
-		{
-			...
-			case k_end_of_playback_event:
-			{
-			    if (pCanvas)
-			    {
-					//generate end of playback event
-			        SpEventPlayScore pEv( static_pointer_cast<EventPlayScore>(pEvent) );
-			        MyEndOfPlaybackEvent event(pEv);
-			        ::wxPostEvent(pCanvas, event);
-			    }
-			    break;
-			}
-		...
-	@endcode
-
-	Later, your application should just process the application event as convenient.
-	The recommended action is to use the Interactor to take care of all
-	details:
-
-	@code
-	void DocumentWindow::on_end_of_playback(MyEndOfPlaybackEvent& event)
-	{
-		SpEventPlayScore pEv = event.get_lomse_event();
-		WpInteractor wpInteractor = pEv->get_interactor();
-		if (SpInteractor spInteractor = wpInteractor.lock())
-		{
-		    spInteractor->send_end_of_play_event(pEv->get_score(), pEv->get_player());
-		    spInteractor->set_operating_mode(is_edition_enabled() ? Interactor::k_mode_edition
-		                                                          : Interactor::k_mode_read_only);
-		}
-	}
-	@endcode
-
-
-	<b>ScorePlayerCtrl generated events</b>
-
-	All other types for this event (<tt>k_do_play_score_event</tt>,
-	<tt>k_pause_score_event</tt> and <tt>k_stop_playback_event</tt>) are generated
-	only from LDP documents with embedded controls (buttons, links, etc.). In
-	particular, these event are generated by the ScorePlayerCtrl object associated to an
-	ImoScorePlayer object embedded in the Document. These events inform about a user
-	action on any of the buttons of the ScorePlayerCtrl, so that the user application can
-	perform the expected actions associated to these buttons. If your application is oriented
-	to process scores in MusicXML format or regular LDP files without embedded controls
-	you will never receive these event types.
+	This event is generated only from LMD documents with embedded controls (buttons,
+    links, etc.). In particular, these events are generated by the ScorePlayerCtrl
+    object associated to an ImoScorePlayer object embedded in the Document. These events
+    inform about a user action on any of the buttons of the ScorePlayerCtrl, so that the
+    user application can perform the expected actions associated to these buttons. If
+    your application is oriented to process scores in MusicXML format or regular LDP
+    files without embedded controls you will never receive these event types.
 
     <b>Example</b>
 
-	For instance, in an application oriented to process LDP documents with embedded
+	For instance, in an application oriented to process LMD documents with embedded
 	controls, written using the wxWidgets framework, you
 	could handle these events as follows:
 
@@ -845,7 +837,7 @@ typedef SharedPtr<EventMouse>  SpEventMouse;
 		{
 		    spInteractor->set_operating_mode(Interactor::k_mode_playback);
 
-		    SpEventPlayScore pEv = static_pointer_cast<EventPlayScore>(pEvent);
+		    SpEventPlayCtrl pEv = static_pointer_cast<EventPlayCtrl>(pEvent);
 		    ImoScore* pScore = pEv->get_score();
 		    ScorePlayer* pPlayer  = m_appScope.get_score_player();
 		    PlayerGui* pPlayerGui = pEv->get_player();
@@ -879,19 +871,20 @@ typedef SharedPtr<EventMouse>  SpEventMouse;
 	}
 	@endcode
 */
-class EventPlayScore : public EventView
+class EventPlayCtrl : public EventAction
 {
 protected:
     ImoScore* m_pScore;
     PlayerGui* m_pPlayer;
 
-    EventPlayScore(EEventType evType) : EventView(evType, WpInteractor()) {}    //for unit tests
+    //for unit tests
+    EventPlayCtrl(EEventType evType) : EventAction(evType, WpInteractor(), WpDocument()) {}
 
 public:
     /// Constructor
-    EventPlayScore(EEventType evType, WpInteractor wpInteractor, ImoScore* pScore,
-                   PlayerGui* pPlayer)
-        : EventView(evType, wpInteractor)
+    EventPlayCtrl(EEventType evType, WpInteractor wpInteractor, WpDocument wpDoc,
+                  ImoScore* pScore, PlayerGui* pPlayer)
+        : EventAction(evType, wpInteractor, wpDoc)
         , m_pScore(pScore)
         , m_pPlayer(pPlayer)
     {
@@ -904,11 +897,94 @@ public:
     inline PlayerGui* get_player() const { return m_pPlayer; }
 };
 
-/** A shared pointer for an EventPlayScore.
+/** A shared pointer for an EventPlayCtrl.
     @ingroup typedefs
     @#include <lomse_events.h>
 */
-typedef SharedPtr<EventPlayScore>  SpEventPlayScore;
+typedef SharedPtr<EventPlayCtrl>  SpEventPlayCtrl;
+
+
+//---------------------------------------------------------------------------------------
+// EventEndOfPlayback
+/** An event generated by the ScorePlayer object to inform about the end of playback,
+    just in case your application would like to do any action, such as enabling or
+    disabling GUI buttons related to playback or to enable document edition.
+
+	Events of type <tt>k_end_of_playback_event</tt> must be handled by
+	by converting them into application events, placing them in the application events
+	loop and returning control to Lomse:
+
+	@code
+	void MainFrame::on_lomse_event(SpEventInfo pEvent)
+	{
+		DocumentWindow* pCanvas = get_active_document_window();
+
+		switch (pEvent->get_event_type())
+		{
+			...
+			case k_end_of_playback_event:
+			{
+			    if (pCanvas)
+			    {
+					//generate end of playback event
+			        SpEventEndOfPlayback pEv( static_pointer_cast<EventEndOfPlayback>(pEvent) );
+			        MyEndOfPlaybackEvent event(pEv);
+			        ::wxPostEvent(pCanvas, event);
+			    }
+			    break;
+			}
+		...
+	@endcode
+
+	Later, your application will process the application event. When doing it, it must
+	inform the Interactor, and then your application should do whatever it needs to
+	do, i.e.: enabling document edition:
+
+	@code
+	void DocumentWindow::on_end_of_playback(MyEndOfPlaybackEvent& event)
+	{
+		SpEventEndOfPlayback pEv = event.get_lomse_event();
+		WpInteractor wpInteractor = pEv->get_interactor();
+		if (SpInteractor spInteractor = wpInteractor.lock())
+		{
+		    spInteractor->on_end_of_play_event(pEv->get_score(), pEv->get_player());
+		    spInteractor->set_operating_mode(is_edition_enabled() ? Interactor::k_mode_edition
+		                                                          : Interactor::k_mode_read_only);
+		}
+	}
+	@endcode
+*/
+class EventEndOfPlayback : public EventPlayback
+{
+protected:
+    ImoScore* m_pScore;
+    PlayerGui* m_pPlayer;
+
+    EventEndOfPlayback(EEventType evType) : EventPlayback(evType, WpInteractor()) {}    //for unit tests
+
+public:
+    /// Constructor
+    EventEndOfPlayback(EEventType evType, WpInteractor wpInteractor, ImoScore* pScore,
+                   PlayerGui* pPlayer)
+        : EventPlayback(evType, wpInteractor)
+        , m_pScore(pScore)
+        , m_pPlayer(pPlayer)
+    {
+    }
+
+    // accessors
+    /// Returns a ptr. to the score affected by the event
+    inline ImoScore* get_score() const { return m_pScore; }
+	/// Returns a ptr. to the PlayerGui object associated with this score playback
+    inline PlayerGui* get_player() const { return m_pPlayer; }
+};
+
+/** A shared pointer for an EventEndOfPlayback.
+    @ingroup typedefs
+    @#include <lomse_events.h>
+*/
+typedef SharedPtr<EventEndOfPlayback>  SpEventEndOfPlayback;
+
 
 
 //---------------------------------------------------------------------------------------
@@ -921,13 +997,14 @@ typedef SharedPtr<EventPlayScore>  SpEventPlayScore;
 			 For processing it, do not retain control: generate an application
 			 event, place it on the application events loop, and return control to Lomse.
 
-	The EventScoreHighlight event, derived from EventView, signals the need to do
+	The %EventScoreHighlight event, derived from EventPlayback, signals the need to do
 	several actions related to highlighting / unhighlighting notes and to moving
 	the tempo line while the score is being played back. It contains a list of
 	sub-events and affected objects:
-	- <b>k_highlight_on_event</b>. Add highlight to a note/rest.
-	- <b>k_highlight_off_event</b>. Remove highlight from a note/rest.
-	- <b>k_end_of_higlight_event</b>. End of score play back. Remove all highlight.
+	- <b>k_highlight_on</b>. Add highlight to a note/rest.
+	- <b>k_highlight_off</b>. Remove highlight from a note/rest.
+	- <b>k_end_of_higlight</b>. End of score play back. Remove all highlight.
+	- <b>k_advance_tempo_line</b>. Advance visual tempo line to next beat.
 
 	For handling all events related to score playback it is **very important** to
 	return control to Lomse as soon
@@ -981,7 +1058,7 @@ typedef SharedPtr<EventPlayScore>  SpEventPlayScore;
 	}
 	@endcode
 */
-class EventScoreHighlight : public EventView
+class EventScoreHighlight : public EventPlayback
 {
 protected:
     ImoId m_nID;             //ID of the target score for the event
@@ -990,26 +1067,37 @@ protected:
 public:
     /// Constructor
     EventScoreHighlight(WpInteractor wpInteractor, ImoId nScoreID)
-        : EventView(k_highlight_event, wpInteractor)
+        : EventPlayback(k_highlight_event, wpInteractor)
         , m_nID(nScoreID)
     {
     }
 
     /// Copy constructor
     EventScoreHighlight(const EventScoreHighlight& event)
-        : EventView(event.m_type, event.m_wpInteractor)
+        : EventPlayback(event.m_type, event.m_wpInteractor)
         , m_nID(event.m_nID)
         , m_items(event.m_items)
     {
     }
 
+    ///Values for sub-events
+    enum EHighlightType
+    {
+        k_highlight_on,           ///< add highlight to a note/rest
+        k_highlight_off,          ///< remove highlight from a note/rest
+        k_end_of_higlight,        ///< end of score play back. Remove all highlight.
+        k_advance_tempo_line,     ///< advance visual tempo line to next beat
+    };
+
     /// Returns ID of the score affected by the event
     inline ImoId get_score_id() { return m_nID; }
+
 	/// Returns the number of sub-events
     inline int get_num_items() { return int( m_items.size() ); }
+
 	/** Returns the list of notes & rests affected by the event. Each list item is a pair
-		of two values: the event type, and the ID of the object (note / rest) to
-		highlight or un-highlight. */
+		of two values: the sub-event type (from enum #EHighlightType), and the ID of
+		the object (note / rest) to highlight or un-highlight. */
     inline std::list< pair<int, ImoId> >&  get_items() { return m_items; }
 
 ///@cond INTERNAL
@@ -1029,61 +1117,17 @@ typedef SharedPtr<EventScoreHighlight>  SpEventScoreHighlight;
 
 
 //---------------------------------------------------------------------------------------
-/** Base class for all events representing a user action (keyboard or mouse) that
-    has been interpreted by Lomse as a command to change the View or to modify
-	the Document.
-*/
-class EventCommand : public EventView
-{
-protected:
-    WpDocument m_wpDoc;
-    ImoId m_imoId;
-
-    EventCommand(EEventType type) : EventView(type, WpInteractor()) {}    //for unit tests
-
-    EventCommand(EEventType type, WpInteractor wpInteractor, ImoId id, WpDocument wpDoc)
-        : EventView(type, wpInteractor)
-        , m_wpDoc(wpDoc)
-        , m_imoId(id)
-    {
-    }
-
-public:
-
-    // accessors
-
-    /// Returns a pointer to the Document object (ImoObj) affected by the event.
-    ImoObj* get_imo_object();
-
-    /// Returns the ID of the Document object (ImoObj) affected by the event.
-    inline ImoId get_imo_id() { return m_imoId; }
-
-    ///Returns @true if the event is still valid and can be processed.
-    bool is_still_valid() {
-        return !m_wpDoc.expired() && !m_wpInteractor.expired();
-    }
-
-};
-
-
-/** A shared pointer for an EventCommand.
-    @ingroup typedefs
-    @#include <lomse_events.h>
-*/
-typedef SharedPtr<EventCommand>  SpEventCommand;
-
-
-//---------------------------------------------------------------------------------------
-/** EventControlPointMoved event is generated when a mouse action has been
+// EventControlPointMoved
+/** %EventControlPointMoved event is generated when a mouse action has been
 	interpreted by Lomse as a command for moving an object control point (handler).
 
-    Operating system raw mouse events should be passed to Lomse to be processed by
+    Operating system raw mouse events can be passed to Lomse to be processed by
     the currently selected Task object (see @ref tasks-overview). Once done, Lomse will
-    generate relevant events of different type (normally EventMouse,
+    generate relevant events of different types (normally EventMouse,
     EventControlPointMoved and EventUpdateUI events) with relevant information about
     affected Document objects or other.
 
-	In particular, an EventControlPointMoved event is generated when TaskMoveHandler
+	In particular, an %EventControlPointMoved event is generated when TaskMoveHandler
 	is selected and the user releases the mouse button. For having a full view of the
 	event generation process, imagine that your application has selected TaskSelection
 	behavior; this is the default task when no specific task is assigned. This task is
@@ -1094,7 +1138,7 @@ typedef SharedPtr<EventCommand>  SpEventCommand;
 	receives this event and having determined that the pointed object is a handle,
 	decides to select the clicked object and switch to TaskMoveObject. Now, Lomse
 	will take care of moving the handle while the mouse moves, and when the mouse button
-	is released, Lomse will generate the EventControlPointMoved to inform your
+	is released, Lomse will generate the %EventControlPointMoved to inform your
 	application about the event and the final destination point of the handle.
 
 	For processing this event, probably your application will issue an edition command
@@ -1120,18 +1164,18 @@ typedef SharedPtr<EventCommand>  SpEventCommand;
 		    spInteractor->set_rendering_buffer(&m_rbuf_window);
 
 		    //register to receive desired events
-		    spInteractor->add_event_handler(k_control_point_moved_event, this, wrapper_on_command_event);
+		    spInteractor->add_event_handler(k_control_point_moved_event, this, wrapper_on_action_event);
 		...
 	}
 
-	void DocumentWindow::wrapper_on_command_event(void* pThis, SpEventInfo pEvent)
+	void DocumentWindow::wrapper_on_action_event(void* pThis, SpEventInfo pEvent)
 	{
-		static_cast<DocumentWindow*>(pThis)->on_command_event(pEvent);
+		static_cast<DocumentWindow*>(pThis)->on_action_event(pEvent);
 	}
 
-	void DocumentWindow::on_command_event(SpEventInfo pEvent)
+	void DocumentWindow::on_action_event(SpEventInfo pEvent)
 	{
-		SpEventCommand pEv( static_pointer_cast<EventCommand>(pEvent) );
+		SpEventAction pEv( static_pointer_cast<EventAction>(pEvent) );
 		if (!pEv->is_still_valid())
 		    return;
 
@@ -1140,11 +1184,11 @@ typedef SharedPtr<EventCommand>  SpEventCommand;
 		    SelectionSet* selection = spInteractor->get_selection_set();
 		    DocCursor* cursor = spInteractor->get_cursor();
 		    CommandEventHandler handler(m_appScope, this, m_toolsInfo, selection, cursor);
-		    handler.process_command_event(pEv);
+		    handler.process_action_event(pEv);
 		}
 	}
 
-	void CommandEventHandler::process_command_event(SpEventCommand event)
+    void CommandEventHandler::process_action_event(SpEventAction event)
 	{
 		m_fEventProcessed = false;
 		if (m_pController->is_edition_enabled())
@@ -1185,9 +1229,10 @@ typedef SharedPtr<EventCommand>  SpEventCommand;
 	}
 	@endcode
 */
-class EventControlPointMoved : public EventCommand
+class EventControlPointMoved : public EventAction
 {
 protected:
+    ImoId m_imoId;
     int m_iHandler;     //modified point index
     UPoint m_uShift;    //shift to apply to object
     int m_gmoType;
@@ -1277,7 +1322,7 @@ public:
     RequestDynamic::set_object() passing as argument a pointer to the ImoObj
     that must be inserted in the Document.
 
-    See @ref dynamic-content.
+    See @ref page-dynamic-content.
 */
 class RequestDynamic : public Request
 {
@@ -1581,32 +1626,90 @@ public:
     /// Returns the EventNotifier object associated to this %Observable object.
 	virtual EventNotifier* get_event_notifier() = 0;
 
-    ///@{
-    /// Register a notification handler for an %Observer.
+    //register to observe the whole object
+    /** Register a notification handler (EventHandler object) for all events generated by
+        this %Observable object.
+        @param eventType    The type of event to be notified. It must be a value from
+            enmu #EEventType.
+        @param pHandler     The object, derived from EventHandler, that will receive
+            the notifications (by invoking its EventHandler::handle_event() method.    */
     virtual void add_event_handler(int eventType, EventHandler* pHandler);
+
+    /** Register a notification handler (c++ method) for all events generated by this
+        %Observable object.
+        @param eventType    The type of event to be notified. It must be a value from
+            enmu #EEventType.
+        @param pThis    Pointer to the object that will receive the notifications.
+        @param pt2Func  The method in previous object that will be invoked to
+            notify events.
+
+        See @ref handling-events
+    */
     virtual void add_event_handler(int eventType, void* pThis,
                                    void (*pt2Func)(void* pObj, SpEventInfo event) );
+
+    /** Register a notification handler (c function) for all events generated by this
+        %Observable object.
+        @param eventType    The type of event to be notified. It must be a value from
+            enmu #EEventType.
+        @param pt2Func  The function that will be invoked to notify events.
+
+        See @ref handling-events
+    */
     virtual void add_event_handler(int eventType, void (*pt2Func)(SpEventInfo event) );
-    ///@}
 
     /// This enum describes the valid observable targets.
     enum EObservedChild
-    {   k_root=0,       ///< The Document (in fact its root node)
+    {   k_root=0,       ///< The whole Document
         k_control,      ///< A control (an ImoControl) object
-        k_gmo,          ///< A Graphic Model object (GmoObj)
         k_imo,          ///< A child of the Document (an ImoObj) except ImoControl objs.
     };
 
-    ///@{
-    /** Register an event handler for an %Observer. Parameter childType must be a
-        value from enum #EImoObjType.     */
+    //register to observe just a child
+    /** Register an event handler (EventHandler object) for some events generated by
+        children of this %Observable object. Parameters <i>childType</i> and
+        <i>childId</i> allows to filter the desired events.
+        @param childType    It must be value <i>k_control</i> or <i>k_imo</i> from
+            enum #EObservedChild, and selects the source of the events to be notified.
+        @param childId      It is the ID of the ImoObj to observe.
+        @param eventType    The type of event to be notified. It must be a value from
+            enmu #EEventType.
+        @param pHandler     The object, derived from EventHandler, that will receive
+            the notifications (by invoking its EventHandler::handle_event() method.
+    */
     void add_event_handler(int childType, ImoId childId, int eventType,
                            EventHandler* pHandler);
+
+    /** Register an event handler (c++ method) for some events generated by children of
+        this %Observable object. Parameters <i>childType</i> and <i>childId</i> allows
+        to filter the desired events.
+        @param childType    It must be value <i>k_control</i> or <i>k_imo</i> from
+            enum #EObservedChild, and selects the source of the events to be notified.
+        @param childId      It is the ID of the ImoObj to observe.
+        @param eventType    The type of event to be notified. It must be a value from
+            enmu #EEventType.
+        @param pThis    Pointer to the object that will be notified.
+        @param pt2Func  The method in previous object that will be invoked to
+            notify events.
+
+        See @ref handling-events
+    */
     void add_event_handler(int childType, ImoId childId, int eventType, void* pThis,
                            void (*pt2Func)(void* pObj, SpEventInfo event) );
+
+    /** Register an event handler (c function) for some events generated by children
+        of this %Observable object. Parameters <i>childType</i> and <i>childId</i> allows
+        to filter the desired events.
+        @param childType    It must be value <i>k_control</i> or <i>k_imo</i> from
+            enum #EObservedChild, and selects the source of the events to be notified.
+        @param childId      It is the ID of the ImoObj to observe.
+        @param eventType    The type of event to be notified. It must be a value from
+            enmu #EEventType.
+        @param pt2Func  The method in previous object that will be invoked to
+            notify events.
+    */
     void add_event_handler(int childType, ImoId childId, int eventType,
                            void (*pt2Func)(SpEventInfo event) );
-    ///@}
 
     /// Returns a pointer to the observable child.    */
     virtual Observable* get_observable_child(int UNUSED(childType),

--- a/include/lomse_interactor.h
+++ b/include/lomse_interactor.h
@@ -104,7 +104,7 @@ enum EEventFlag
     and the Document (see @ref mvc-overview). It is responsible for translating your
     application requests into commands that manipulate the associated View and/or
     the Document, coordinating all the necessary actions. It also provides support for
-    managing the user interaction with your application GUI (see @ref tasks-page).
+    managing the user interaction with your application GUI (see @ref page-tasks).
 
 	The %Interactor plays the role of the Controller in the MVC model. Each View has an
 	associated %Interactor (in fact the View is owned by the %Interactor). The
@@ -134,7 +134,7 @@ enum EEventFlag
 
 	See:
 	- @ref mvc-overview.
-	- @ref tasks-page.
+	- @ref page-tasks.
 
 */
 class Interactor : public EventHandler
@@ -217,7 +217,7 @@ public:
             {
                 spInteractor->set_operating_mode(Interactor::k_mode_playback);
 
-                SpEventPlayScore pEv = boost::static_pointer_cast<EventPlayScore>(pEvent);
+                SpEventPlayCtrl pEv = boost::static_pointer_cast<EventPlayCtrl>(pEvent);
                 ImoScore* pScore = pEv->get_score();
                 ScorePlayer* pPlayer  = m_appScope.get_score_player();
                 PlayerGui* pPlayerGui = pEv->get_player();
@@ -278,7 +278,7 @@ public:
         @remarks When the %Interactor is created it is initialized with an instace of
             TaskSelection class.
 
-        See @ref tasks-page.
+        See @ref page-tasks.
 
         Example:
 
@@ -320,7 +320,7 @@ public:
 
     /** Returns the selection set associated to the View of this %Interactor.
 
-        See @ref document-edition-overview
+        See @ref page-edit-overview
     */
     inline SelectionSet* get_selection_set() { return m_pSelections; }
 
@@ -371,11 +371,11 @@ public:
     /**
         @todo This method should be for internal use. Analyse and refactor or document.
 
-        This method should be invoked when processing a EventPlayScore of type
+        This method should be invoked when processing a EventPlayCtrl of type
         <tt>k_end_of_playback_event</tt>. But this method generates a
         k_end_of_playback_event, this will create a loop!!!!   ?????????
     */
-    virtual void send_end_of_play_event(ImoScore* pScore, PlayerGui* pPlayCtrl);
+    virtual void on_end_of_play_event(ImoScore* pScore, PlayerGui* pPlayCtrl);
 
 
     /** Invoking this method controls the behavior of method force_redraw(). If disabled,
@@ -803,14 +803,14 @@ public:
         In order to not interfere with screen display, a different
         rendering buffer is used for printing.
 
-        See @subpage print-api
+        See @subpage page-printing
     */
     virtual void set_print_buffer(RenderingBuffer* rbuf);
 
 
     /** Sets the resolution (in dots per inch, dpi) to use for printing.
 
-        See @subpage print-api
+        See @subpage page-printing
     */
     virtual void set_print_ppi(double ppi);
 
@@ -821,14 +821,14 @@ public:
             to this method your application can split the page in tiles, so that printing
             in large paper formats will not require huge buffer sizes.
 
-        See @subpage print-api
+        See @subpage page-printing
     */
     virtual void print_page(int page, VPoint viewport=VPoint(0, 0));
 
 
     /** Returns the number of pages in current document.
 
-        See @subpage print-api
+        See @subpage page-printing
     */
     virtual int get_num_pages();
 
@@ -842,7 +842,7 @@ public:
 
     /** Returns the cursor associated to the View of this %Interactor.
 
-        See @ref document-edition-overview
+        See @ref page-edit-overview
     */
     inline DocCursor* get_cursor() { return m_pCursor; }
 
@@ -850,7 +850,7 @@ public:
         it. Lomse caret does not blink and this method is oriented to implement a
         blinking caret in your application.
 
-        See @ref document-edition-overview
+        See @ref page-edit-overview
 
         @remarks
             - Caret is always shown when document edition is enabled.
@@ -881,7 +881,7 @@ public:
         when caret on a music score. If caret is not on a music score, the returned
         string is empty.
 
-        See @ref document-edition-overview
+        See @ref page-edit-overview
 
         This method can be useful for displaying the timecode of the caret. For example:
 
@@ -1083,7 +1083,7 @@ public:
             these flags are described by enum #EEventFlag.
 
         @see
-        - @ref tasks-page.
+        - @ref page-tasks.
         - switch_task().
     */
     virtual void on_mouse_move(Pixels x, Pixels y, unsigned flags);
@@ -1097,7 +1097,7 @@ public:
             Values for these flas are described by enum #EEventFlag.
 
         @see
-        - @ref tasks-page.
+        - @ref page-tasks.
         - switch_task().
     */
     virtual void on_mouse_button_down(Pixels x, Pixels y, unsigned flags);
@@ -1111,7 +1111,7 @@ public:
             Values for these flags are described by enum #EEventFlag.
 
         @see
-        - @ref tasks-page.
+        - @ref page-tasks.
         - switch_task().
     */
     virtual void on_mouse_button_up(Pixels x, Pixels y, unsigned flags);
@@ -1125,7 +1125,7 @@ public:
             for these flags are described by enum #EEventFlag.
 
         @see
-        - @ref tasks-page.
+        - @ref page-tasks.
         - switch_task().
     */
     virtual void on_mouse_enter_window(Pixels x, Pixels y, unsigned flags);
@@ -1139,7 +1139,7 @@ public:
             Values for these flags are described by enum #EEventFlag.
 
         @see
-        - @ref tasks-page.
+        - @ref page-tasks.
         - switch_task().
     */
     virtual void on_mouse_leave_window(Pixels x, Pixels y, unsigned flags);
@@ -1351,7 +1351,7 @@ protected:
     ImoObj* find_event_originator_imo(GmoObj* pGmo);
     GmoRef find_event_originator_gref(GmoObj* pGmo);
     bool discard_score_highlight_event_if_not_valid(SpEventScoreHighlight pEvent);
-    bool is_valid_play_score_event(SpEventPlayScore pEvent);
+    bool is_valid_play_score_event(SpEventPlayCtrl pEvent);
     void update_caret_and_view();
     void redraw_caret();
     void send_update_UI_event(EEventType type);

--- a/include/lomse_presenter.h
+++ b/include/lomse_presenter.h
@@ -104,7 +104,7 @@ public:
     The %Presenter, returned by previous methods, gives acess to the Document and to
     the Interactors associated to the existing View objects for the Document.
 
-    See @subpage render-overview.
+    See @subpage page-render-overview.
 */
 class Presenter
 {

--- a/src/graphic_model/lomse_gm_basic.cpp
+++ b/src/graphic_model/lomse_gm_basic.cpp
@@ -1049,6 +1049,8 @@ void GmoBoxLink::notify_event(SpEventInfo pEvent)
     else if (pEvent->is_on_click_event())
     {
         LOMSE_LOG_ERROR("is_on_click_event: TODO");
+        //AWARE: should not reach this point as click events on links
+        //will be dispatched to the global handler.
         //TODO: GmoBoxLink::notify_event, on_click_event
 //        m_visited = true;
 //        m_prevColor = m_visitedColor;

--- a/src/gui_controls/lomse_score_player_ctrl.cpp
+++ b/src/gui_controls/lomse_score_player_ctrl.cpp
@@ -138,8 +138,9 @@ void ScorePlayerCtrl::handle_event(SpEventInfo pEvent)
             if (SpInteractor p = wpIntor.lock())
             {
                 ImoScore* pScore = m_pOwnerImo->get_score();
-                SpEventPlayScore event(
-                        LOMSE_NEW EventPlayScore(evType, wpIntor, pScore, this) );
+                SpEventPlayCtrl event(
+                        LOMSE_NEW EventPlayCtrl(evType, wpIntor, pEv->get_document(),
+                                                pScore, this) );
 
                 //AWARE: we notify directly to user app. (to observers of Interactor)
                 p->notify_observers(event, p.get());

--- a/src/module/lomse_events.cpp
+++ b/src/module/lomse_events.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -415,19 +415,13 @@ Observable* EventMouse::get_source()
     return nullptr;
 }
 
-//---------------------------------------------------------------------------------------
-bool EventMouse::is_still_valid()
-{
-    return !m_wpDoc.expired() && !m_wpInteractor.expired();
-}
-
 
 //=======================================================================================
 // EventControlPointMoved implementation
 //=======================================================================================
 EventControlPointMoved::EventControlPointMoved(EEventType type, WpInteractor wpInteractor,
                     GmoObj* pGmo, int iHandler, UPoint uShift, WpDocument wpDoc)
-    : EventCommand(type, wpInteractor, 0, wpDoc)
+    : EventAction(type, wpInteractor, wpDoc)
     , m_iHandler(iHandler)
     , m_uShift(uShift)
 {

--- a/src/module/lomse_injectors.cpp
+++ b/src/module/lomse_injectors.cpp
@@ -207,6 +207,7 @@ int LibraryScope::get_pixel_format() const
 //---------------------------------------------------------------------------------------
 void LibraryScope::post_event(SpEventInfo pEvent)
 {
+    LOMSE_LOG_DEBUG(Logger::k_events, "");
     m_pDoorway->post_event(pEvent);
 }
 

--- a/src/sound/lomse_score_player.cpp
+++ b/src/sound/lomse_score_player.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2017. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -487,7 +487,7 @@ void ScorePlayer::do_play(int nEvStart, int nEvEnd, bool fVisualTracking,
         if (fVisualTracking)
         {
             if (events[i]->pSO)
-                pEvent->add_item(k_advance_tempo_line_event, events[i]->pSO->get_id());
+                pEvent->add_item(EventScoreHighlight::k_advance_tempo_line, events[i]->pSO->get_id());
             if (nMtrEvDeltaTime < events[i]->DeltaTime)
             {
                 //last metronome click is previous to first event from table.
@@ -571,7 +571,7 @@ void ScorePlayer::do_play(int nEvStart, int nEvEnd, bool fVisualTracking,
                         m_pMidi->note_on(m_MtrChannel, m_MtrTone2, 127);
                 }
                 if (fVisualTracking && events[i]->pSO != nullptr)
-                    pEvent->add_item(k_advance_tempo_line_event, events[i]->pSO->get_id());
+                    pEvent->add_item(EventScoreHighlight::k_advance_tempo_line, events[i]->pSO->get_id());
 
                 fMtrOn = true;
                 nMtrEvDeltaTime += nMtrIntvalOff;
@@ -665,7 +665,7 @@ void ScorePlayer::do_play(int nEvStart, int nEvEnd, bool fVisualTracking,
                 {
                     ImoId id = events[i]->pSO->get_id();
                     m_pInteractor->change_viewport_if_necessary(id);
-                    pEvent->add_item(k_highlight_on_event, id);
+                    pEvent->add_item(EventScoreHighlight::k_highlight_on, id);
                 }
 
             }
@@ -690,7 +690,7 @@ void ScorePlayer::do_play(int nEvStart, int nEvEnd, bool fVisualTracking,
 
                 //generate implicit visual off event
                 if (fVisualTracking && events[i]->pSO->is_visible())
-                    pEvent->add_item(k_highlight_off_event, events[i]->pSO->get_id());
+                    pEvent->add_item(EventScoreHighlight::k_highlight_off, events[i]->pSO->get_id());
             }
             else if (events[i]->EventType == SoundEvent::k_visual_on)
             {
@@ -699,14 +699,14 @@ void ScorePlayer::do_play(int nEvStart, int nEvEnd, bool fVisualTracking,
                 {
                     ImoId id = events[i]->pSO->get_id();
                     m_pInteractor->change_viewport_if_necessary(id);
-                    pEvent->add_item(k_highlight_on_event, id);
+                    pEvent->add_item(EventScoreHighlight::k_highlight_on, id);
                 }
             }
             else if (events[i]->EventType == SoundEvent::k_visual_off)
             {
                 //remove visual highlight
                 if (fVisualTracking)
-                    pEvent->add_item(k_highlight_off_event, events[i]->pSO->get_id());
+                    pEvent->add_item(EventScoreHighlight::k_highlight_off, events[i]->pSO->get_id());
 
             }
             else if (events[i]->EventType == SoundEvent::k_end_of_score)
@@ -789,7 +789,7 @@ void ScorePlayer::do_play(int nEvStart, int nEvEnd, bool fVisualTracking,
         m_fFinalEventSent = true;
         SpEventScoreHighlight pEvent(
             LOMSE_NEW EventScoreHighlight(wpInteractor, m_pScore->get_id()) );
-        pEvent->add_item(k_end_of_higlight_event, k_no_imoid);
+        pEvent->add_item(EventScoreHighlight::k_end_of_higlight, k_no_imoid);
         if (m_fPostEvents)
             m_libScope.post_event(pEvent);
         else if (pInteractor)
@@ -818,7 +818,7 @@ void ScorePlayer::end_of_playback_housekeeping(bool fVisualTracking,
             wpInteractor = WpInteractor();
         SpEventScoreHighlight pEvent(
             LOMSE_NEW EventScoreHighlight(wpInteractor, m_pScore->get_id()) );
-        pEvent->add_item(k_end_of_higlight_event, k_no_imoid);
+        pEvent->add_item(EventScoreHighlight::k_end_of_higlight, k_no_imoid);
         if (m_fPostEvents)
             m_libScope.post_event(pEvent);
         else if (pInteractor)
@@ -846,7 +846,7 @@ void ScorePlayer::end_of_playback_housekeeping(bool fVisualTracking,
     if (pInteractor)
         pInteractor->enable_forced_view_updates(true);
 
-    //update player gui
+    //create event for updating player gui
     if (m_pPlayerGui)
     {
         //prepare weak_ptr to interactor
@@ -859,9 +859,9 @@ void ScorePlayer::end_of_playback_housekeeping(bool fVisualTracking,
         else
             wpInteractor = WpInteractor();
 
-        SpEventPlayScore event(
-            LOMSE_NEW EventPlayScore(k_end_of_playback_event, wpInteractor,
-                                     m_pScore, m_pPlayerGui) );
+        SpEventEndOfPlayback event(
+            LOMSE_NEW EventEndOfPlayback(k_end_of_playback_event, wpInteractor,
+                                         m_pScore, m_pPlayerGui) );
         if (m_fPostEvents)
             m_libScope.post_event(event);
         else if (pInteractor)

--- a/src/tests/lomse_test_score_player.cpp
+++ b/src/tests/lomse_test_score_player.cpp
@@ -341,7 +341,7 @@ SUITE(ScorePlayerTest)
         CHECK( pEv->get_num_items() == 1);
         std::list< pair<int, ImoId> >& items = pEv->get_items();
         std::list< pair<int, ImoId> >::iterator itItem = items.begin();
-        CHECK( (*itItem).first == k_advance_tempo_line_event );
+        CHECK( (*itItem).first == EventScoreHighlight::k_advance_tempo_line );
         //cout << "item type: " << (*itItem).first << endl;
         ++itN;
 
@@ -353,10 +353,10 @@ SUITE(ScorePlayerTest)
         CHECK( pEv->get_num_items() == 2);
         items = pEv->get_items();
         itItem = items.begin();
-        CHECK( (*itItem).first == k_advance_tempo_line_event );
+        CHECK( (*itItem).first == EventScoreHighlight::k_advance_tempo_line );
         //cout << "item type: " << (*itItem).first << endl;
         ++itItem;
-        CHECK( (*itItem).first == k_highlight_on_event );
+        CHECK( (*itItem).first == EventScoreHighlight::k_highlight_on );
         //cout << "item type: " << (*itItem).first << endl;
         ++itN;
 
@@ -367,7 +367,7 @@ SUITE(ScorePlayerTest)
         CHECK( pEv->get_num_items() == 1);
         items = pEv->get_items();
         itItem = items.begin();
-        CHECK( (*itItem).first == k_end_of_higlight_event );
+        CHECK( (*itItem).first == EventScoreHighlight::k_end_of_higlight );
         //cout << "item type: " << (*itItem).first << endl;
     }
 
@@ -414,7 +414,7 @@ SUITE(ScorePlayerTest)
         CHECK( pEv->get_num_items() == 1);
         std::list< pair<int, ImoId> >& items = pEv->get_items();
         std::list< pair<int, ImoId> >::iterator itItem = items.begin();
-        CHECK( (*itItem).first == k_advance_tempo_line_event );
+        CHECK( (*itItem).first == EventScoreHighlight::k_advance_tempo_line );
 //        cout << "item type: " << (*itItem).first << endl;
         ++itN;
 
@@ -425,16 +425,16 @@ SUITE(ScorePlayerTest)
         CHECK( pEv->get_num_items() == 4);
         items = pEv->get_items();
         itItem = items.begin();
-        CHECK( (*itItem).first == k_advance_tempo_line_event );
+        CHECK( (*itItem).first == EventScoreHighlight::k_advance_tempo_line );
 //        cout << "item type: " << (*itItem).first << endl;
         ++itItem;
-        CHECK( (*itItem).first == k_highlight_on_event );
+        CHECK( (*itItem).first == EventScoreHighlight::k_highlight_on );
 //        cout << "item type: " << (*itItem).first << endl;
         ++itItem;
-        CHECK( (*itItem).first == k_highlight_on_event );
+        CHECK( (*itItem).first == EventScoreHighlight::k_highlight_on );
 //        cout << "item type: " << (*itItem).first << endl;
         ++itItem;
-        CHECK( (*itItem).first == k_highlight_on_event );
+        CHECK( (*itItem).first == EventScoreHighlight::k_highlight_on );
 //        cout << "item type: " << (*itItem).first << endl;
         ++itN;
 
@@ -445,7 +445,7 @@ SUITE(ScorePlayerTest)
         CHECK( pEv->get_num_items() == 1);
         items = pEv->get_items();
         itItem = items.begin();
-        CHECK( (*itItem).first == k_end_of_higlight_event );
+        CHECK( (*itItem).first == EventScoreHighlight::k_end_of_higlight );
 //        cout << "item type: " << (*itItem).first << endl;
     }
 
@@ -501,7 +501,7 @@ SUITE(ScorePlayerTest)
 //        std::list<int>::iterator itN = m_notifications.begin();
 ////        cout << "notif.type = " << *itN << endl;
 //        CHECK( *(itN++) == k_prepare_for_highlight_event );
-//        CHECK( *(itN++) == k_highlight_on_event );
+//        CHECK( *(itN++) == EventScoreHighlight::k_highlight_on );
 //        CHECK( *(itN++) == k_highlight_off_event );
 //        CHECK( *(itN++) == k_end_of_higlight_event );
 //    }


### PR DESCRIPTION
This PR closes #111.

The documentation about events has been reviewed and improved.

Due to refactoring events code, some names have been changed and this results in backwards incompatible API changes. Due to this, library version number has been changed.