### PR TITLE
Fixed compilation errors on Windows

### DIFF
--- a/include/lomse_events_dispatcher.h
+++ b/include/lomse_events_dispatcher.h
@@ -42,7 +42,6 @@
 #if (LOMSE_USE_BOOST_ASIO == 1)
     #include <boost/asio.hpp>
 #endif
-using namespace boost;
 
 #include <queue>
 using namespace std;

--- a/include/lomse_internal_model.h
+++ b/include/lomse_internal_model.h
@@ -49,7 +49,6 @@ typedef int TIntAttribute;
 using namespace std;
 
 #include <boost/variant.hpp>
-using namespace boost;
 
 ///@cond INTERNALS
 namespace lomse

--- a/include/lomse_score_player.h
+++ b/include/lomse_score_player.h
@@ -37,7 +37,6 @@
 
 #include <boost/thread/thread.hpp>
 #include <boost/thread/condition_variable.hpp>
-using namespace boost;
 
 namespace lomse
 {

--- a/include/lomse_spacing_algorithm_gourlay.h
+++ b/include/lomse_spacing_algorithm_gourlay.h
@@ -39,7 +39,6 @@
 //For performance measurements (timing)
 #include <ctime>   //clock
 #include <boost/date_time/posix_time/posix_time.hpp>
-using namespace boost::posix_time;
 
 
 namespace lomse

--- a/include/lomse_system_layouter.h
+++ b/include/lomse_system_layouter.h
@@ -44,7 +44,6 @@ using namespace std;
 //For performance measurements (timing)
 #include <ctime>   //clock
 #include <boost/date_time/posix_time/posix_time.hpp>
-using namespace boost::posix_time;
 
 
 namespace lomse

--- a/include/lomse_tasks.h
+++ b/include/lomse_tasks.h
@@ -36,7 +36,6 @@
 #include <iostream>
 #include <boost/date_time/posix_time/posix_time.hpp>
 using namespace std;
-using namespace boost::posix_time;
 
 namespace lomse
 {

--- a/packages/minizip/ioapi.c
+++ b/packages/minizip/ioapi.c
@@ -220,8 +220,10 @@ static int ZCALLBACK ferror_file_func (voidpf opaque, voidpf stream)
     return ret;
 }
 
+// Changed function declaration for better compatibility with C++ compilers:
+//void fill_fopen_filefunc (pzlib_filefunc_def)
+//    zlib_filefunc_def* pzlib_filefunc_def;
 void fill_fopen_filefunc (zlib_filefunc_def* pzlib_filefunc_def)
-
 {
     pzlib_filefunc_def->zopen_file = fopen_file_func;
     pzlib_filefunc_def->zread_file = fread_file_func;

--- a/packages/minizip/ioapi.c
+++ b/packages/minizip/ioapi.c
@@ -220,8 +220,8 @@ static int ZCALLBACK ferror_file_func (voidpf opaque, voidpf stream)
     return ret;
 }
 
-void fill_fopen_filefunc (pzlib_filefunc_def)
-  zlib_filefunc_def* pzlib_filefunc_def;
+void fill_fopen_filefunc (zlib_filefunc_def* pzlib_filefunc_def)
+
 {
     pzlib_filefunc_def->zopen_file = fopen_file_func;
     pzlib_filefunc_def->zread_file = fread_file_func;

--- a/src/document/lomse_command.cpp
+++ b/src/document/lomse_command.cpp
@@ -55,9 +55,6 @@ using namespace std;
 #include "boost/date_time/local_time/local_time.hpp"
 
 using namespace std;
-using namespace boost::gregorian;
-using namespace boost::posix_time;
-using namespace boost::local_time;
 
 
 namespace lomse

--- a/src/exporters/lomse_ldp_exporter.cpp
+++ b/src/exporters/lomse_ldp_exporter.cpp
@@ -44,9 +44,6 @@ using namespace std;
 #include "boost/date_time/local_time/local_time.hpp"
 
 using namespace std;
-using namespace boost::gregorian;
-using namespace boost::posix_time;
-using namespace boost::local_time;
 
 
 

--- a/src/exporters/lomse_lmd_exporter.cpp
+++ b/src/exporters/lomse_lmd_exporter.cpp
@@ -44,9 +44,6 @@
 #include "boost/date_time/local_time/local_time.hpp"
 
 using namespace std;
-using namespace boost::gregorian;
-using namespace boost::posix_time;
-using namespace boost::local_time;
 
 namespace lomse
 {

--- a/src/exporters/lomse_mnx_exporter.cpp
+++ b/src/exporters/lomse_mnx_exporter.cpp
@@ -43,9 +43,6 @@
 #include "boost/date_time/local_time/local_time.hpp"
 
 using namespace std;
-using namespace boost::gregorian;
-using namespace boost::posix_time;
-using namespace boost::local_time;
 
 namespace lomse
 {

--- a/src/graphic_model/layouters/lomse_spacing_algorithm_gourlay.cpp
+++ b/src/graphic_model/layouters/lomse_spacing_algorithm_gourlay.cpp
@@ -376,7 +376,7 @@ void SpAlgGourlay::do_spacing(int iCol, bool fTrace)
 
     if (fTrace || m_libraryScope.dump_column_tables())
     {
-        dbgLogger << endl << to_simple_string( microsec_clock::local_time() )
+        dbgLogger << endl << boost::posix_time::to_simple_string( boost::posix_time::microsec_clock::local_time() )
                   << " ******************* Before spacing" << endl;
         m_columns[iCol]->dump(dbgLogger);
     }


### PR DESCRIPTION
This fixes compilation errors on Windows. I'm using Visual Studio 2015 but the changes are not specific to that compiler version.

## 1. Name conflicts
The following error occurs for many compilation units:
```
C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\thr/xtimec.h(24): error C2872: 'xtime': ambiguous symbol (compiling source file src\graphic_model\lomse_caret.cpp)
```
It happens due to simultaneous `using boost` and `using std`.
The fix was to not `using boost`. That was easy because the boost symbols are used with full qualifiers throughout the lomse code, except one place where I added boost names prefixes.

## 2. minizip/ioapi.c
Compilation fails at:
```C
void fill_fopen_filefunc (pzlib_filefunc_def)
  zlib_filefunc_def* pzlib_filefunc_def;
{
...
```
with
```
>packages\minizip\ioapi.c(223): error C2065: 'pzlib_filefunc_def': undeclared identifier
1>packages\minizip\ioapi.c(223): error C2182: 'fill_fopen_filefunc': illegal use of type 'void'
1>packages\minizip\ioapi.c(223): error C2365: 'fill_fopen_filefunc': redefinition; previous definition was 'function'
```
The error can be fixed by changing compiler options for individual file `ioapi.c` and setting option "Compile as" to "Compile as C Code" (instead of default "Compile as C++ Code". It wasn't obvious to find that option. A better more universal fix is to change that code line to be C++ compatible:
```C++
void fill_fopen_filefunc (zlib_filefunc_def* pzlib_filefunc_def)
{
```

That's it. Thanks for consdering this PR.