### PR TITLE
Allow negative stride and fix Windows example

### DIFF
--- a/examples/example_1_win32.cpp
+++ b/examples/example_1_win32.cpp
@@ -135,7 +135,7 @@ void create_bitmap_for_the_rendering_buffer(unsigned width, unsigned height)
     m_rbuf_window.attach(m_bitmap.buf(), 
                          m_bitmap.width(),
                          m_bitmap.height(),
-                         -m_bitmap.stride()
+                         m_bitmap.stride()
                         );
     m_view_needs_redraw = true;
 }
@@ -582,6 +582,8 @@ void Bitmap::draw(HDC h_dc, const RECT *device_rect, const RECT *bmp_rect) const
         dvc_width  = device_rect->right  - device_rect->left;
         dvc_height = device_rect->bottom - device_rect->top;
     }
+
+	m_bmp->bmiHeader.biHeight = -abs(m_bmp->bmiHeader.biHeight);
 
     if(dvc_width != bmp_width || dvc_height != bmp_height)
     {

--- a/src/graphic_model/lomse_overlays_generator.cpp
+++ b/src/graphic_model/lomse_overlays_generator.cpp
@@ -145,7 +145,7 @@ void OverlaysGenerator::save_rendering_buffer()
     unsigned w = m_pCanvasBuffer->width();
     unsigned h = m_pCanvasBuffer->height();
     int stride = m_pCanvasBuffer->stride();
-    size_t bytes = h * stride;
+    size_t bytes = h * abs(stride);
     if (m_pSaveBytes == nullptr || bytes != m_savedBuffer.height() * m_savedBuffer.stride())
     {
         delete m_pSaveBytes;


### PR DESCRIPTION
This is a follow up to #97. The PR consists of two commits:
1. one to allow negative stride;
2. a fix by @jellyr to windows example to use positive stride.

Any one of these commits fixes the issue with Windows example. Applied together they work too as well.

Tested on Windows 10 and XP.