### PR TITLE
#125: Fixed vector resizing

### DIFF
--- a/src/exporters/lomse_ldp_exporter.cpp
+++ b/src/exporters/lomse_ldp_exporter.cpp
@@ -1477,7 +1477,6 @@ protected:
     {
         m_fNewMeasure = true;
         m_curMeasure = 0;
-        m_rCurTime.reserve(k_max_voices);
         m_rCurTime.assign(k_max_voices, 0.0);
     }
 

--- a/src/graphic_model/engravers/lomse_instrument_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_instrument_engraver.cpp
@@ -87,10 +87,10 @@ void PartsEngraver::create_group_engravers()
                 LOMSE_NEW GroupEngraver(m_libraryScope, m_pMeter, pGroup, m_pScore, this) );
         }
 
-        m_iGrpName.reserve(numGrps);
-        m_iGrpBracketFirst.reserve(numGrps);
-        m_iGrpAbbrev.reserve(numGrps);
-        m_iGrpBracketOther.reserve(numGrps);
+        m_iGrpName.resize(numGrps);
+        m_iGrpBracketFirst.resize(numGrps);
+        m_iGrpAbbrev.resize(numGrps);
+        m_iGrpBracketOther.resize(numGrps);
     }
 }
 
@@ -121,10 +121,10 @@ void PartsEngraver::create_instrument_engravers()
         pPrevEngrv = pEngrv;
     }
 
-    m_iInstrName.reserve(numInstr);
-    m_iInstrBracketFirst.reserve(numInstr);
-    m_iInstrAbbrev.reserve(numInstr);
-    m_iInstrBracketOther.reserve(numInstr);
+    m_iInstrName.resize(numInstr);
+    m_iInstrBracketFirst.resize(numInstr);
+    m_iInstrAbbrev.resize(numInstr);
+    m_iInstrBracketOther.resize(numInstr);
 }
 
 //---------------------------------------------------------------------------------------
@@ -551,9 +551,9 @@ InstrumentEngraver::InstrumentEngraver(LibraryScope& libraryScope,
     , m_pNextInstrEngr(nullptr)
 {
     int numStaves = m_pInstr->get_num_staves();
-    m_staffTop.reserve(numStaves);
-    m_staffTopLine.reserve(numStaves);
-    m_lineThickness.reserve(numStaves);
+    m_staffTop.resize(numStaves);
+    m_staffTopLine.resize(numStaves);
+    m_lineThickness.resize(numStaves);
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -762,11 +762,8 @@ ColumnBreaker::ColumnBreaker(int numInstruments, StaffObjsCursor* pSysCursor)
     , m_lastBreakTime(0.0f)
 {
     m_numLines = pSysCursor->get_num_lines();
-    m_measures.reserve(numInstruments);
     m_measures.assign(numInstruments, 0.0f);
-    m_beamed.reserve(m_numLines);
     m_beamed.assign(m_numLines, false);
-    m_tied.reserve(m_numLines);
     m_tied.assign(m_numLines, false);
 
     determine_measure_mean_time(pSysCursor);
@@ -1571,7 +1568,6 @@ void LinesBreakerOptimal::retrieve_breaks_sequence()
     }
 
     int numBreaks = m_entries[i].system;
-    m_breaks.reserve(numBreaks);
     m_breaks.assign(numBreaks, 0);
 
     while (m_entries[i].predecessor > 0)

--- a/src/graphic_model/layouters/lomse_score_meter.cpp
+++ b/src/graphic_model/layouters/lomse_score_meter.cpp
@@ -72,7 +72,7 @@ ScoreMeter::ScoreMeter(ImoScore* pScore, int numInstruments, int numStaves,
     , m_maxLineSpace(0.0f)
     , m_pScore(pScore)
 {
-    m_staffIndex.reserve(numInstruments);
+    m_staffIndex.resize(numInstruments);
     int staves = 0;
     for (int iInstr=0; iInstr < numInstruments; ++iInstr)
     {
@@ -127,7 +127,7 @@ void ScoreMeter::get_options(ImoScore* pScore)
 void ScoreMeter::get_staff_spacing(ImoScore* pScore)
 {
     int instruments = pScore->get_num_instruments();
-    m_staffIndex.reserve(instruments);
+    m_staffIndex.resize(instruments);
     int staves = 0;
     for (int iInstr=0; iInstr < instruments; ++iInstr)
     {

--- a/src/graphic_model/layouters/lomse_spacing_algorithm.cpp
+++ b/src/graphic_model/layouters/lomse_spacing_algorithm.cpp
@@ -479,7 +479,7 @@ void ColumnsBuilder::determine_staves_vertical_position()
 {
     int numInstrs = m_pScore->get_num_instruments();
 
-    m_SliceInstrHeights.reserve(numInstrs);
+    m_SliceInstrHeights.resize(numInstrs);
 
     LUnits yPos = 0.0f;
     for (int iInstr = 0; iInstr < numInstrs; iInstr++)
@@ -607,12 +607,8 @@ ColumnData::~ColumnData()
 //---------------------------------------------------------------------------------------
 void ColumnData::reserve_space_for_prolog_clefs_keys(int numStaves)
 {
-    m_prologClefs.clear();
-    m_prologClefs.reserve(numStaves);
     m_prologClefs.assign(numStaves, (ColStaffObjsEntry*)nullptr);     //GCC complains if nullptr not casted
 
-    m_prologKeys.clear();
-    m_prologKeys.reserve(numStaves);
     m_prologKeys.assign(numStaves, (ColStaffObjsEntry*)nullptr);
 }
 

--- a/src/graphic_model/layouters/lomse_spacing_algorithm_gourlay.cpp
+++ b/src/graphic_model/layouters/lomse_spacing_algorithm_gourlay.cpp
@@ -297,14 +297,8 @@ void SpAlgGourlay::new_slice(ColStaffObjsEntry* pEntry, int entryType, int iColu
     if (entryType == TimeSlice::k_prolog)
     {
         int numStaves = m_pScoreMeter->num_staves();
-        m_prologClefs.clear();
-        m_prologClefs.reserve(numStaves);
         m_prologClefs.assign(numStaves, false);
-        m_prologKeys.clear();
-        m_prologKeys.reserve(numStaves);
         m_prologKeys.assign(numStaves, false);
-        m_prologTimes.clear();
-        m_prologTimes.reserve(numStaves);
         m_prologTimes.assign(numStaves, false);
 
         m_lastPrologTime = pEntry->time();
@@ -1077,7 +1071,7 @@ int TimeSlice::collect_barlines_information(int numInstruments)
 
     //vector: one entry per instrument. Value = barline type or -1 if no barline
     vector<int> barlines;
-    barlines.reserve(numInstruments);
+    barlines.resize(numInstruments);
 
     ColStaffObjsEntry* pEntry = m_firstEntry;
     for (int i=0; i < m_numEntries; ++i, pEntry = pEntry->get_next())
@@ -1446,7 +1440,6 @@ void TimeSliceNonTimed::assign_spacing_values(vector<StaffObjData*>& data,
     //vector for widths
     int numStaves = pMeter->num_staves();
     m_numStaves = numStaves;
-    m_widths.reserve(numStaves);
     m_widths.assign(numStaves, 0.0f);
 
     //loop for computing widths
@@ -1554,7 +1547,6 @@ void TimeSliceNonTimed::move_shapes_to_final_positions(vector<StaffObjData*>& da
 {
     //vector for current position on each staff
     vector<LUnits> positions;
-    positions.reserve(m_numStaves);
     positions.assign(m_numStaves, 0.0f);
     for (int i=0; i < m_numStaves; ++i)
         positions[i] = xPos - m_widths[i] + m_xLeft;
@@ -1643,7 +1635,6 @@ void ColumnDataGourlay::dump(ostream& outStream, bool fOrdered)
 //---------------------------------------------------------------------------------------
 void ColumnDataGourlay::set_num_entries(int numSlices)
 {
-    m_orderedSlices.reserve(numSlices);
     m_orderedSlices.assign(numSlices, (TimeSlice*)nullptr);   //GCC 4.8.4 complains if nullptr not casted
 }
 

--- a/src/graphic_model/layouters/lomse_staffobjs_cursor.cpp
+++ b/src/graphic_model/layouters/lomse_staffobjs_cursor.cpp
@@ -57,7 +57,7 @@ StaffObjsCursor::~StaffObjsCursor()
 //---------------------------------------------------------------------------------------
 void StaffObjsCursor::initialize_clefs_keys_times(ImoScore* pScore)
 {
-    m_staffIndex.reserve(m_numInstruments);
+    m_staffIndex.resize(m_numInstruments);
     m_numStaves = 0;
     for (int i=0; i < m_numInstruments; ++i)
     {
@@ -65,13 +65,8 @@ void StaffObjsCursor::initialize_clefs_keys_times(ImoScore* pScore)
         m_numStaves += pScore->get_instrument(i)->get_num_staves();
     }
 
-    m_clefs.reserve(m_numStaves);
     m_clefs.assign(m_numStaves, (ColStaffObjsEntry*)nullptr);     //GCC complains if nullptr not casted
-
-    m_keys.reserve(m_numStaves);
     m_keys.assign(m_numStaves, (ColStaffObjsEntry*)nullptr);
-
-    m_times.reserve(m_numInstruments);
     m_times.assign(m_numInstruments, (ColStaffObjsEntry*)nullptr);
 }
 

--- a/src/graphic_model/layouters/lomse_table_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_table_layouter.cpp
@@ -204,7 +204,7 @@ void TableLayouter::determine_width_for_columns()
 {
     //TODO: For now width will be assigned based on column style.
 
-    m_columnsWidth.reserve(m_numCols);
+    m_columnsWidth.resize(m_numCols);
     m_tableWidth = 0.0f;
     std::list<ImoStyle*>& cols = m_pTable->get_column_styles();
     std::list<ImoStyle*>::iterator it;

--- a/src/parser/lomse_autoclef.cpp
+++ b/src/parser/lomse_autoclef.cpp
@@ -69,23 +69,13 @@ void AutoClef::find_staves_needing_clef()
     int staves = m_pCursor->get_num_staves();
     int stavesWithNotes = 0;
 
-    m_fNeedsClef.reserve(staves);
     m_fNeedsClef.assign(staves, false);
-
-    m_pAt.reserve(staves);
     m_pAt.assign(staves, (ImoStaffObj*)nullptr);
-
-    m_maxPitch.reserve(staves);
     m_maxPitch.assign(staves, k_undefined_fpitch);
-
-    m_minPitch.reserve(staves);
     m_minPitch.assign(staves, k_undefined_fpitch);
-
-    m_numNotes.reserve(staves);
     m_numNotes.assign(staves, 0);
 
     vector<bool> fHasNotes;         //true if staff i has pitched notes
-    fHasNotes.reserve(staves);
     fHasNotes.assign(staves, false);
 
     while(!m_pCursor->is_end())

--- a/src/sound/lomse_midi_table.cpp
+++ b/src/sound/lomse_midi_table.cpp
@@ -109,7 +109,7 @@ void SoundEventsTable::create_table()
 void SoundEventsTable::program_sounds_for_instruments()
 {
 	int numInstruments = m_pScore->get_num_instruments();
-    m_channels.reserve(numInstruments);
+    m_channels.resize(numInstruments);
 
     for (int iInstr = 0; iInstr < numInstruments; iInstr++)
     {


### PR DESCRIPTION
This is a fix to #125:
1) Using resize() instead of reserve() when need to access elements afterwards.
2) Removed unnecessary resize() before assign().