### PR TITLE
Always use std::shared_ptr

### DIFF
--- a/include/lomse_basic.h
+++ b/include/lomse_basic.h
@@ -34,6 +34,7 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 using namespace std;
 
 
@@ -49,30 +50,6 @@ using namespace std;
     #define UNUSED(x) /* x */
 #endif
 
-
-//---------------------------------------------------------------------------------------
-//if it is a C++11 compliant compiler use std shared_ptr, else use boost shared_ptr
-#if __cplusplus > 199711L
-    #include <memory>
-    namespace lomse
-    {
-        #define LOMSE_IS_USING_STD_SHARED_PTRS  1
-        #define SharedPtr std::shared_ptr
-        #define WeakPtr std::weak_ptr
-        #define EnableSharedFromThis  std::enable_shared_from_this
-    }
-#else
-    #include <boost/shared_ptr.hpp>
-    #include <boost/weak_ptr.hpp>
-    #include <boost/enable_shared_from_this.hpp>
-    namespace lomse
-    {
-        #define LOMSE_IS_USING_STD_SHARED_PTRS  0
-        #define SharedPtr boost::shared_ptr
-        #define WeakPtr boost::weak_ptr
-        #define EnableSharedFromThis  boost::enable_shared_from_this
-    }
-#endif
 
 namespace lomse
 {

--- a/include/lomse_document.h
+++ b/include/lomse_document.h
@@ -113,7 +113,7 @@ enum EDocLayoutOptions
 class LOMSE_EXPORT Document : public BlockLevelCreatorApi
                             , public EventNotifier
                             , public Observable
-                            , public EnableSharedFromThis<Document>
+                            , public std::enable_shared_from_this<Document>
 {
 protected:
     LibraryScope&   m_libraryScope;
@@ -528,7 +528,7 @@ public:
     inline LibraryScope& get_library_scope() { return m_libraryScope; }
 
     /** Returns a shared pointer for this %Document. */
-    inline SharedPtr<Document> get_shared_ptr_from_this() { return shared_from_this(); }
+    inline std::shared_ptr<Document> get_shared_ptr_from_this() { return shared_from_this(); }
 
     //properties
     /** Returns @true if the %Document is editable.
@@ -645,8 +645,8 @@ protected:
 
 };
 
-typedef SharedPtr<Document>  SpDocument;
-typedef WeakPtr<Document>  WpDocument;
+typedef std::shared_ptr<Document>  SpDocument;
+typedef std::weak_ptr<Document>  WpDocument;
 
 
 }   //namespace lomse

--- a/include/lomse_document_cursor.h
+++ b/include/lomse_document_cursor.h
@@ -137,7 +137,7 @@ public:
 
 };
 
-typedef SharedPtr<ElementCursorState>  SpElementCursorState;
+typedef std::shared_ptr<ElementCursorState>  SpElementCursorState;
 
 
 //---------------------------------------------------------------------------------------
@@ -234,7 +234,7 @@ public:
     }
 };
 
-typedef SharedPtr<ScoreCursorState>  SpScoreCursorState;
+typedef std::shared_ptr<ScoreCursorState>  SpScoreCursorState;
 
 
 //---------------------------------------------------------------------------------------

--- a/include/lomse_events.h
+++ b/include/lomse_events.h
@@ -55,10 +55,10 @@ class SelectionSet;
 class GmoObj;
 
 class Interactor;
-typedef WeakPtr<Interactor>     WpInteractor;
+typedef std::weak_ptr<Interactor>     WpInteractor;
 
 class Document;
-typedef WeakPtr<Document>       WpDocument;
+typedef std::weak_ptr<Document>       WpDocument;
 
 
 //observer pattern
@@ -167,7 +167,7 @@ protected:
     @ingroup typedefs
     @#include <lomse_events.h>
 */
-typedef SharedPtr<EventInfo>  SpEventInfo;
+typedef std::shared_ptr<EventInfo>  SpEventInfo;
 
 
 //---------------------------------------------------------------------------------------
@@ -212,7 +212,7 @@ public:
     @ingroup typedefs
     @#include <lomse_events.h>
 */
-typedef SharedPtr<EventDoc>  SpEventDoc;
+typedef std::shared_ptr<EventDoc>  SpEventDoc;
 
 
 //---------------------------------------------------------------------------------------
@@ -320,7 +320,7 @@ public:
     @ingroup typedefs
     @#include <lomse_events.h>
 */
-typedef SharedPtr<EventPaint>  SpEventPaint;
+typedef std::shared_ptr<EventPaint>  SpEventPaint;
 
 
 //---------------------------------------------------------------------------------------
@@ -362,7 +362,7 @@ public:
     @ingroup typedefs
     @#include <lomse_events.h>
 */
-typedef SharedPtr<EventAction>  SpEventAction;
+typedef std::shared_ptr<EventAction>  SpEventAction;
 
 
 //---------------------------------------------------------------------------------------
@@ -394,7 +394,7 @@ public:
     @ingroup typedefs
     @#include <lomse_events.h>
 */
-typedef SharedPtr<EventPlayback>  SpEventPlayback;
+typedef std::shared_ptr<EventPlayback>  SpEventPlayback;
 
 
 //---------------------------------------------------------------------------------------
@@ -504,7 +504,7 @@ public:
     @ingroup typedefs
     @#include <lomse_events.h>
 */
-typedef SharedPtr<EventUpdateViewport>  SpEventUpdateViewport;
+typedef std::shared_ptr<EventUpdateViewport>  SpEventUpdateViewport;
 
 
 //---------------------------------------------------------------------------------------
@@ -621,7 +621,7 @@ public:
     @ingroup typedefs
     @#include <lomse_events.h>
 */
-typedef SharedPtr<EventUpdateUI>  SpEventUpdateUI;
+typedef std::shared_ptr<EventUpdateUI>  SpEventUpdateUI;
 
 
 //---------------------------------------------------------------------------------------
@@ -768,7 +768,7 @@ public:
     @ingroup typedefs
     @#include <lomse_events.h>
 */
-typedef SharedPtr<EventMouse>  SpEventMouse;
+typedef std::shared_ptr<EventMouse>  SpEventMouse;
 
 
 //---------------------------------------------------------------------------------------
@@ -901,7 +901,7 @@ public:
     @ingroup typedefs
     @#include <lomse_events.h>
 */
-typedef SharedPtr<EventPlayCtrl>  SpEventPlayCtrl;
+typedef std::shared_ptr<EventPlayCtrl>  SpEventPlayCtrl;
 
 
 //---------------------------------------------------------------------------------------
@@ -983,7 +983,7 @@ public:
     @ingroup typedefs
     @#include <lomse_events.h>
 */
-typedef SharedPtr<EventEndOfPlayback>  SpEventEndOfPlayback;
+typedef std::shared_ptr<EventEndOfPlayback>  SpEventEndOfPlayback;
 
 
 
@@ -1113,7 +1113,7 @@ public:
     @ingroup typedefs
     @#include <lomse_events.h>
 */
-typedef SharedPtr<EventScoreHighlight>  SpEventScoreHighlight;
+typedef std::shared_ptr<EventScoreHighlight>  SpEventScoreHighlight;
 
 
 //---------------------------------------------------------------------------------------
@@ -1259,7 +1259,7 @@ public:
     @ingroup typedefs
     @#include <lomse_events.h>
 */
-typedef SharedPtr<EventControlPointMoved>  SpEventControlPointMoved;
+typedef std::shared_ptr<EventControlPointMoved>  SpEventControlPointMoved;
 
 
 //=======================================================================================

--- a/include/lomse_events_dispatcher.h
+++ b/include/lomse_events_dispatcher.h
@@ -36,7 +36,6 @@
 #include "lomse_injectors.h"
 #include "lomse_events.h"
 
-//#include <boost/shared_ptr.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/condition_variable.hpp>
 #if (LOMSE_USE_BOOST_ASIO == 1)

--- a/include/lomse_graphic_view.h
+++ b/include/lomse_graphic_view.h
@@ -69,7 +69,7 @@ class SelectionHighlight;
 class SelectionSet;
 class AreaInfo;
 
-typedef SharedPtr<GmoShape>  SpGmoShape;
+typedef std::shared_ptr<GmoShape>  SpGmoShape;
 
 
 ////---------------------------------------------------------------------------------------

--- a/include/lomse_image.h
+++ b/include/lomse_image.h
@@ -33,8 +33,6 @@
 #include "lomse_basic.h"
 #include "lomse_pixel_formats.h"
 
-#include <boost/shared_ptr.hpp>
-
 #include <string>
 using namespace std;
 
@@ -88,7 +86,7 @@ protected:
 
 };
 
-typedef SharedPtr<Image>     SpImage;
+typedef std::shared_ptr<Image>     SpImage;
 
 
 }   //namespace lomse

--- a/include/lomse_interactor.h
+++ b/include/lomse_interactor.h
@@ -64,11 +64,11 @@ class Task;
 class Handler;
 
 class Document;
-typedef SharedPtr<Document>     SpDocument;
-typedef WeakPtr<Document>       WpDocument;
+typedef std::shared_ptr<Document>     SpDocument;
+typedef std::weak_ptr<Document>       WpDocument;
 
 class GmoShape;
-typedef SharedPtr<GmoShape>  SpGmoShape;
+typedef std::shared_ptr<GmoShape>  SpGmoShape;
 
 //some constants for improving code legibillity
 #define k_no_redraw     false   //do not force view redraw
@@ -140,7 +140,7 @@ enum EEventFlag
 class Interactor : public EventHandler
                  , public EventNotifier
                  , public Observable
-                 , public EnableSharedFromThis<Interactor>
+                 , public std::enable_shared_from_this<Interactor>
 {
 protected:
     LibraryScope&   m_libScope;
@@ -1283,7 +1283,7 @@ public:
                DocCommandExecuter* pExec);
     virtual ~Interactor();
 
-    inline SharedPtr<Interactor> get_shared_ptr_from_this() { return shared_from_this(); }
+    inline std::shared_ptr<Interactor> get_shared_ptr_from_this() { return shared_from_this(); }
 
     //mandatory override required by EventHandler
 	void handle_event(SpEventInfo pEvent);
@@ -1377,8 +1377,8 @@ protected:
 
 };
 
-typedef SharedPtr<Interactor>   SpInteractor;
-typedef WeakPtr<Interactor>     WpInteractor;
+typedef std::shared_ptr<Interactor>   SpInteractor;
+typedef std::weak_ptr<Interactor>     WpInteractor;
 
 ////---------------------------------------------------------------------------------------
 ////A view to edit the document in full page

--- a/include/lomse_ldp_elements.h
+++ b/include/lomse_ldp_elements.h
@@ -31,13 +31,12 @@
 #define __LOMSE_LDP_ELEMENTS_H__
 
 #include <vector>
+#include <cassert>
 
 #include "lomse_build_options.h"
 #include "lomse_tree.h"
 #include "lomse_visitor.h"
 #include "lomse_basic.h"
-
-#include <boost/shared_ptr.hpp>
 
 
 namespace lomse
@@ -277,7 +276,7 @@ enum ELdpElement
 //forward declarations
 class LdpElement;
 class ImoObj;
-typedef SharedPtr<LdpElement>    SpLdpElement;
+typedef std::shared_ptr<LdpElement>    SpLdpElement;
 
 //---------------------------------------------------------------------------------------
 // A generic LDP element representation.
@@ -376,9 +375,9 @@ class LdpObject : public LdpElement
 
 // A tree of LdpElements
 typedef Tree<LdpElement>  LdpTree;
-typedef SharedPtr<LdpTree> SpLdpTree;
+typedef std::shared_ptr<LdpTree> SpLdpTree;
 typedef TreeNode<LdpElement> LdpNode;
-typedef SharedPtr<LdpNode> SpLdpNode;
+typedef std::shared_ptr<LdpNode> SpLdpNode;
 
 
 }   //namespace lomse

--- a/include/lomse_presenter.h
+++ b/include/lomse_presenter.h
@@ -50,21 +50,21 @@ class View;
 class LibraryScope;
 
 class Document;
-typedef SharedPtr<Document>     SpDocument;
-typedef WeakPtr<Document>       WpDocument;
+typedef std::shared_ptr<Document>     SpDocument;
+typedef std::weak_ptr<Document>       WpDocument;
 
 class Interactor;
 /** A shared pointer for an Interactor.
     @ingroup typedefs
     @#include <lomse_presenter.h>
 */
-typedef SharedPtr<Interactor>   SpInteractor;
+typedef std::shared_ptr<Interactor>   SpInteractor;
 
 /** A weak pointer for an Interactor.
     @ingroup typedefs
     @#include <lomse_presenter.h>
 */
-typedef WeakPtr<Interactor>     WpInteractor;
+typedef std::weak_ptr<Interactor>     WpInteractor;
 
 
 //---------------------------------------------------------------------------------------

--- a/include/lomse_selections.h
+++ b/include/lomse_selections.h
@@ -47,8 +47,8 @@ class ImoNoteRest;
 class ImoStaffObj;
 class SelectionSet;
 class Document;
-typedef SharedPtr<Document>     SpDocument;
-typedef WeakPtr<Document>       WpDocument;
+typedef std::shared_ptr<Document>     SpDocument;
+typedef std::weak_ptr<Document>       WpDocument;
 
 
 //---------------------------------------------------------------------------------------

--- a/include/lomse_visual_effect.h
+++ b/include/lomse_visual_effect.h
@@ -48,7 +48,7 @@ class GmoShape;
 class GmoObj;
 class SelectionSet;
 
-typedef SharedPtr<GmoShape>  SpGmoShape;
+typedef std::shared_ptr<GmoShape>  SpGmoShape;
 
 
 //---------------------------------------------------------------------------------------

--- a/src/document/lomse_document_cursor.cpp
+++ b/src/document/lomse_document_cursor.cpp
@@ -274,7 +274,7 @@ void DocContentCursor::to_end()
 SpElementCursorState DocContentCursor::get_state()
 {
     //TODO: Not needed. Perhaps DocContentCursor should not derive from ElementCursor?
-    return SharedPtr<ElementCursorState>();
+    return std::shared_ptr<ElementCursorState>();
 }
 
 //---------------------------------------------------------------------------------------
@@ -287,7 +287,7 @@ void DocContentCursor::restore_state(SpElementCursorState UNUSED(spState))
 SpElementCursorState DocContentCursor::find_previous_pos_state()
 {
     //TODO: Not needed. Perhaps DocContentCursor should not derive from ElementCursor?
-    return SharedPtr<ElementCursorState>();
+    return std::shared_ptr<ElementCursorState>();
 }
 
 
@@ -558,7 +558,7 @@ DocCursorState DocCursor::find_previous_pos_state()
 		return DocCursorState(id, m_pInnerCursor->find_previous_pos_state());
 	else
 		return DocCursorState(m_outerCursor.get_prev_id(),
-                              SharedPtr<ElementCursorState>());
+                              std::shared_ptr<ElementCursorState>());
 }
 
 //---------------------------------------------------------------------------------------
@@ -632,7 +632,7 @@ DocCursorState DocCursor::get_state()
     if (is_inside_terminal_node())
 		return DocCursorState(get_parent_id(), m_pInnerCursor->get_state());
 	else
-        return DocCursorState(get_pointee_id(), SharedPtr<ElementCursorState>());
+        return DocCursorState(get_pointee_id(), std::shared_ptr<ElementCursorState>());
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/layouters/lomse_right_aligner.cpp
+++ b/src/graphic_model/layouters/lomse_right_aligner.cpp
@@ -29,6 +29,8 @@
 
 #include "lomse_right_aligner.h"
 
+#include <algorithm>
+
 using namespace std;
 
 namespace lomse

--- a/src/graphic_model/lomse_caret_positioner.cpp
+++ b/src/graphic_model/lomse_caret_positioner.cpp
@@ -115,7 +115,7 @@ DocCursorState CaretPositioner::click_point_to_cursor_state(GraphicModel* pGMode
         return DocCursorState(topId, innerState);
     }
 	else
-        return DocCursorState(pTopImo->get_id(), SharedPtr<ElementCursorState>());
+        return DocCursorState(pTopImo->get_id(), std::shared_ptr<ElementCursorState>());
 }
 
 
@@ -528,7 +528,7 @@ SpElementCursorState ScoreCaretPositioner::click_point_to_cursor_state(int iPage
     }
 
     //other cases: ignore click
-    return SharedPtr<ElementCursorState>();
+    return std::shared_ptr<ElementCursorState>();
 }
 
 


### PR DESCRIPTION
This is a follow-up to #131.

`boost::shared_ptr` has been replaced with `std::shared_ptr`. For most systems this is rather a cosmetic change because `std::shared_ptr` was already used via `ifdef` in `lomse_basic.h`:

```C++
//if it is a C++11 compliant compiler use std shared_ptr, else use boost shared_ptr
#if __cplusplus > 199711L
    #include <memory>
    #define SharedPtr std::shared_ptr
#else
    #include <boost/shared_ptr.hpp>
    #define SharedPtr boost::shared_ptr
#endif
```

Visual C++ however was still using boost because Visual C++ defines `__cplusplus ` to `199711L` (although it supports most from C++11, C++14 and C++17).

With this PR Visual C++ starts using `std::shared_ptr` too, like other compilers.