### PR TITLE
Allow clang and other compilers

### DIFF
--- a/build-options.cmake
+++ b/build-options.cmake
@@ -114,10 +114,8 @@ endif()
 # compiler
 if(MSVC)
     set( LOMSE_COMPILER_MSVC  "1")
-    set( LOMSE_COMPILER_GCC   "0")
-elseif(CMAKE_COMPILER_IS_GNUCC)
+else()
     set( LOMSE_COMPILER_MSVC  "0")
-    set( LOMSE_COMPILER_GCC   "1")
 endif()
 
 

--- a/include/lomse_logger.h
+++ b/include/lomse_logger.h
@@ -59,7 +59,7 @@ extern ofstream dbgLogger;
         #define LOMSE_LOG_TRACE(area, msg)
     #endif
 
-#elif (LOMSE_COMPILER_GCC == 1)
+#else
     #define LOMSE_LOG_ERROR(msg)        logger.log_error(__FILE__,__LINE__,__PRETTY_FUNCTION__, msg);
     #define LOMSE_LOG_WARN(msg)         logger.log_warn(__FILE__,__LINE__,__PRETTY_FUNCTION__, msg);
     #define LOMSE_LOG_INFO(msg)         logger.log_info(__FILE__,__LINE__,__PRETTY_FUNCTION__, msg);

--- a/lomse_config.h.cmake
+++ b/lomse_config.h.cmake
@@ -49,7 +49,6 @@
 #define LOMSE_PLATFORM_WIN32      @LOMSE_PLATFORM_WIN32@
 #define LOMSE_PLATFORM_UNIX       @LOMSE_PLATFORM_UNIX@
 #define LOMSE_COMPILER_MSVC       @LOMSE_COMPILER_MSVC@
-#define LOMSE_COMPILER_GCC        @LOMSE_COMPILER_GCC@
 
 
 //---------------------------------------------------------------------------------------


### PR DESCRIPTION
Currently compilation fails on any compiler other than GCC and MSVC. The cmake config explicitly checks for GCC and MSVC and defines symbols accordingly.

Then `lomse_logger.h` defines macros for logging based on compiler detection made by make. This macros rely on compiler specific  features and exist in two versions: for MSVC and for GCC. For other compilers the log macros are not defined at all. This cause compilation errors on other compilers, in particular **clang**.

I propose to remove explicit check for GCC and retain only check for MSVC. Let the code which was previously active only for GCC to be active on all compilers other that MSVC. This change is sufficient to compile on clang successfully. I wouldn't introduce an extra check for clang (it greatly mimics GCC).

Hopefully other compilers will work too. In any case these three compilers (GCC, MSVC, clang) are the most important nowadays and they all work after the fix.