### PR TITLE
Fixed crash in chord engraver layout_accidentals

### DIFF
--- a/src/graphic_model/engravers/lomse_chord_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_chord_engraver.cpp
@@ -342,8 +342,8 @@ void ChordEngraver::layout_accidentals()
             {
                 GmoShapeNotehead* pHead = (*itCur)->pNoteShape->get_notehead_shape();
                 shift_acc_if_confict_with_shape(pCurAcc, pHead);
+                ++itCur;
             }
-            ++itCur;
             if (itCur != m_notes.rend())
             {
                 GmoShapeNotehead* pHead = (*itCur)->pNoteShape->get_notehead_shape();


### PR DESCRIPTION
During testing of example [musicxml-files](https://www.musicxml.com/music-in-musicxml/example-set/) encountered program crashes on most of the files.

The issue has been localized to an iterator incremented two times in a row without bounds check.

After the fix 17 from 18 files are read (and displayed) without crash. One file still causes a crash but I wasn't able to fix this. In a case you want to fix this yourself - this is file "ActorPreludeSample.musicxml", which is the biggest one (1 MB) in the set.