### PR TITLE
Fixed compilation error in minizip unit on macOS

### DIFF
--- a/packages/minizip/ioapi.c
+++ b/packages/minizip/ioapi.c
@@ -16,6 +16,7 @@
 
 #include "ioapi.h"
 
+//Lomse. Fix compilation on macOS, where ftello64, fseeko64 and fopen64 are not defined.
 #ifdef __APPLE__
     #define ftello64 ftello
     #define fseeko64 fseeko
@@ -88,7 +89,7 @@ static int     ZCALLBACK ferror_file_func OF((voidpf opaque, voidpf stream));
 
 static voidpf ZCALLBACK fopen_file_func (voidpf opaque, const char* filename, int mode)
 {
-    (void)opaque;     //CSG. Fix for warning due to unused param
+    (void)opaque;     //Lomse. Fix for warning due to unused param
     FILE* file = NULL;
     const char* mode_fopen = NULL;
     if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER)==ZLIB_FILEFUNC_MODE_READ)
@@ -107,7 +108,7 @@ static voidpf ZCALLBACK fopen_file_func (voidpf opaque, const char* filename, in
 
 static voidpf ZCALLBACK fopen64_file_func (voidpf opaque, const void* filename, int mode)
 {
-    (void)opaque;     //CSG. Fix for warning due to unused param
+    (void)opaque;     //Lomse. Fix for warning due to unused param
 
     FILE* file = NULL;
     const char* mode_fopen = NULL;
@@ -128,7 +129,7 @@ static voidpf ZCALLBACK fopen64_file_func (voidpf opaque, const void* filename, 
 
 static uLong ZCALLBACK fread_file_func (voidpf opaque, voidpf stream, void* buf, uLong size)
 {
-    (void)opaque;     //CSG. Fix for warning due to unused param
+    (void)opaque;     //Lomse. Fix for warning due to unused param
     uLong ret;
     ret = (uLong)fread(buf, 1, (size_t)size, (FILE *)stream);
     return ret;
@@ -136,7 +137,7 @@ static uLong ZCALLBACK fread_file_func (voidpf opaque, voidpf stream, void* buf,
 
 static uLong ZCALLBACK fwrite_file_func (voidpf opaque, voidpf stream, const void* buf, uLong size)
 {
-    (void)opaque;     //CSG. Fix for warning due to unused param
+    (void)opaque;     //Lomse. Fix for warning due to unused param
     uLong ret;
     ret = (uLong)fwrite(buf, 1, (size_t)size, (FILE *)stream);
     return ret;
@@ -144,7 +145,7 @@ static uLong ZCALLBACK fwrite_file_func (voidpf opaque, voidpf stream, const voi
 
 static long ZCALLBACK ftell_file_func (voidpf opaque, voidpf stream)
 {
-    (void)opaque;     //CSG. Fix for warning due to unused param
+    (void)opaque;     //Lomse. Fix for warning due to unused param
     long ret;
     ret = ftell((FILE *)stream);
     return ret;
@@ -153,7 +154,7 @@ static long ZCALLBACK ftell_file_func (voidpf opaque, voidpf stream)
 
 static ZPOS64_T ZCALLBACK ftell64_file_func (voidpf opaque, voidpf stream)
 {
-    (void)opaque;     //CSG. Fix for warning due to unused param
+    (void)opaque;     //Lomse. Fix for warning due to unused param
     ZPOS64_T ret;
     ret = ftello64((FILE *)stream);
     return ret;
@@ -161,7 +162,7 @@ static ZPOS64_T ZCALLBACK ftell64_file_func (voidpf opaque, voidpf stream)
 
 static long ZCALLBACK fseek_file_func (voidpf  opaque, voidpf stream, uLong offset, int origin)
 {
-    (void)opaque;     //CSG. Fix for warning due to unused param
+    (void)opaque;     //Lomse. Fix for warning due to unused param
     int fseek_origin=0;
     long ret;
     switch (origin)
@@ -185,7 +186,7 @@ static long ZCALLBACK fseek_file_func (voidpf  opaque, voidpf stream, uLong offs
 
 static long ZCALLBACK fseek64_file_func (voidpf  opaque, voidpf stream, ZPOS64_T offset, int origin)
 {
-    (void)opaque;     //CSG. Fix for warning due to unused param
+    (void)opaque;     //Lomse. Fix for warning due to unused param
     int fseek_origin=0;
     long ret;
     switch (origin)
@@ -212,7 +213,7 @@ static long ZCALLBACK fseek64_file_func (voidpf  opaque, voidpf stream, ZPOS64_T
 
 static int ZCALLBACK fclose_file_func (voidpf opaque, voidpf stream)
 {
-    (void)opaque;     //CSG. Fix for warning due to unused param
+    (void)opaque;     //Lomse. Fix for warning due to unused param
     int ret;
     ret = fclose((FILE *)stream);
     return ret;
@@ -220,13 +221,13 @@ static int ZCALLBACK fclose_file_func (voidpf opaque, voidpf stream)
 
 static int ZCALLBACK ferror_file_func (voidpf opaque, voidpf stream)
 {
-    (void)opaque;     //CSG. Fix for warning due to unused param
+    (void)opaque;     //Lomse. Fix for warning due to unused param
     int ret;
     ret = ferror((FILE *)stream);
     return ret;
 }
 
-// Changed function declaration for better compatibility with C++ compilers:
+//Lomse. Changed function declaration for better compatibility with C++ compilers:
 //void fill_fopen_filefunc (pzlib_filefunc_def)
 //    zlib_filefunc_def* pzlib_filefunc_def;
 void fill_fopen_filefunc (zlib_filefunc_def* pzlib_filefunc_def)

--- a/packages/minizip/ioapi.c
+++ b/packages/minizip/ioapi.c
@@ -16,6 +16,12 @@
 
 #include "ioapi.h"
 
+#ifdef __APPLE__
+    #define ftello64 ftello
+    #define fseeko64 fseeko
+    #define fopen64 fopen
+#endif
+
 voidpf call_zopen64 (const zlib_filefunc64_32_def* pfilefunc,const void*filename,int mode)
 {
     if (pfilefunc->zfile_func64.zopen64_file != NULL)


### PR DESCRIPTION
Minizip code uses `ftello64`, `fseeko64`, `fopen64`. MacOS doesn't have them and compilation fails.

Clang produces warnings during compilation:
```
Implicit declaration of function 'fopen64' is invalid in C99
Implicit declaration of function 'ftello64' is invalid in C99
Implicit declaration of function 'fseeko64' is invalid in C99
```
and errors during linking:
```
Undefined symbols for architecture x86_64:
  "_fopen64", referenced from:
      _fopen64_file_func in ioapi.o
  "_fseeko64", referenced from:
      _fseek64_file_func in ioapi.o
  "_ftello64", referenced from:
      _ftell64_file_func in ioapi.o
```

As suggested on stackoverflow (also related to minizip) a solution is to define the symbols as:
```C++
#ifdef __APPLE__
    #define ftello64 ftello
    #define fseeko64 fseeko
    #define fopen64 fopen
#endif
```

That indeed helps. The question is only what is the best place for that code snippet? I've put it into minizip's file `ioapi.c` because this is the only unit needing them. If you think there is a better place for the snippet please let me know and I'll move it there (or you can do that yourself of course).

Thanks.