### PR TITLE
Fixed test failures for invalid font size

### DIFF
--- a/src/parser/ldp/lomse_ldp_analyser.cpp
+++ b/src/parser/ldp/lomse_ldp_analyser.cpp
@@ -363,13 +363,12 @@ protected:
         const string& value = m_pParamToAnalyse->get_value();
         int size = static_cast<int>(value.size()) - 2;
         string points = value.substr(0, size);
-        string number = m_pParamToAnalyse->get_value();
         float rNumber;
-        std::istringstream iss(number);
+        std::istringstream iss(points);
         if ((iss >> std::dec >> rNumber).fail())
         {
             report_msg(m_pParamToAnalyse->get_line_number(),
-                "Invalid size '" + number + "'. Replaced by '12'.");
+                "Invalid size '" + value + "'. Replaced by '12'.");
             return 12.0f;
         }
         else

--- a/src/parser/lmd/lomse_lmd_analyser.cpp
+++ b/src/parser/lmd/lomse_lmd_analyser.cpp
@@ -475,13 +475,12 @@ protected:
         const string value = m_childToAnalyse.value();
         int size = static_cast<int>(value.size()) - 2;
         string points = value.substr(0, size);
-        string number = m_childToAnalyse.value();
         float rNumber;
-        std::istringstream iss(number);
+        std::istringstream iss(points);
         if ((iss >> std::dec >> rNumber).fail())
         {
             report_msg(m_pAnalyser->get_line_number(&m_childToAnalyse),
-                "Invalid size '" + number + "'. Replaced by '12'.");
+                "Invalid size '" + value + "'. Replaced by '12'.");
             return 12.0f;
         }
         else

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -825,13 +825,12 @@ protected:
 //        const string value = m_childToAnalyse.value();
 //        int size = static_cast<int>(value.size()) - 2;
 //        string points = value.substr(0, size);
-//        string number = m_childToAnalyse.value();
 //        float rNumber;
-//        std::istringstream iss(number);
+//        std::istringstream iss(points);
 //        if ((iss >> std::dec >> rNumber).fail())
 //        {
 //            report_msg(m_pAnalyser->get_line_number(&m_analysedNode),
-//                "Invalid size '" + number + "'. Replaced by '12'.");
+//                "Invalid size '" + value + "'. Replaced by '12'.");
 //            return 12.0f;
 //        }
 //        else


### PR DESCRIPTION
This PR fixes:

>All unit tests error messages such as "Line 0. Invalid size '10pt'. Replaced by '12'." are originated in lomse_ldp_analyser.cpp, line 361, method float get_font_size_value(). I do not understand why. Received parameter should be something as "10pt".

It attempts to read from `istream` a text such as "10pt" whereas the intention was to read the text with stripped suffix such as "10".

It seems libstdc++ (used on Linux) reads until the first non-digit character and succeed (and therefore the bug went unnoticed). With libc++ (clang) any non-digit character causes reading failure. From my understanding of description of `operator >>` the clang's behaviour is the correct one.