### PR TITLE
Travis build should fail on test failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,9 @@ addons:
       - gcc-4.9
       - g++-4.9
 
-before_script:
+script:
   - mkdir build
   - cd build
   - cmake -G "Unix Makefiles"  ..
-
-script:
   - make
-
-after_success:
   - ./bin/testlib
-


### PR DESCRIPTION
Currently test failures do not cause Travis builds to fail.

Take a look at [this Travis build execution](https://travis-ci.org/hugbug/lomse/builds/366269445#L1186). The build is marked as **passed** although one test has failed:
```
$ ./bin/testlib
Lomse version 0.23.0+aa5b271. Library tests runner.
Lomse build date: 13-Apr-2018 19:41:10
Path for tests scores: '/home/travis/build/hugbug/lomse/test-scores/'
Running all tests
/home/travis/build/hugbug/lomse/src/tests/lomse_test_ldp_analyser.cpp:8182: error: Failure in Analyser_Font_SizeError: errormsg.str() == expected.str()
FAILURE: 1 out of 1577 tests failed (1 failures).
Test time: 9.75 seconds.
Done. Your build exited with 0.
```

Tests failed yet the build exited with 0. This is because the tests are executed in `after_script` section, whose exit code is [ignored](https://docs.travis-ci.com/user/customizing-the-build#Breaking-the-Build):

>The exit code of after_success, after_failure, after_script and subsequent stages do not affect the build result. 