### PR TITLE
Match whole string in regex'es

### DIFF
--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -2806,7 +2806,7 @@ bool mxl_is_valid_ending_number(const string& num)
 
     //XSD regex is  "([ ]*)|([1-9][0-9]*(, ?[1-9][0-9]*)*)"
     //but Lomse will be permissive with blank space errors such as :  "1,2", "1, 2 "
-    std::regex regexValid("([ ]*)|([1-9][0-9]*(, *[1-9][0-9]*)* *)");
+    std::regex regexValid("^([ ]*)$|^([1-9][0-9]*(, *[1-9][0-9]*)* *)$");
     return std::regex_match(num, regexValid);
 }
 
@@ -6647,14 +6647,14 @@ int mxl_type_of_repetion_mark(const string& value)
     //by default, regex uses modified ECMAScript syntax
     //See:  http://www.cplusplus.com/reference/regex/ECMAScript/
     //See:  http://en.cppreference.com/w/cpp/regex/ecmascript
-    std::regex regexDaCapo(" *(d|d\\.) *(c|c\\.) *| *da *capo *");    //d\\.? *c\\.? Fails!
-    std::regex regexDaCapoAlFine(" *(d|d\\.) *(c|c\\.) *al *fine *| *da *capo *al *fine *");
-    std::regex regexDaCapoAlCoda(" *(d|d\\.) *(c|c\\.) *al *coda *| *da *capo *al *coda *");
-    std::regex regexDalSegno(" *(d|d\\.) *(s|s\\.) *| *d(a|e)l *segno *");
-    std::regex regexDalSegnoAlFine(" *(d|d\\.) *(s|s\\.) *al *fine *| *d(a|e)l *segno *al *fine *");
-    std::regex regexDalSegnoAlCoda(" *(d|d\\.) *(s|s\\.) *al *coda *| *d(a|e)l *segno *al *coda *");
-    std::regex regexFine(" *fine *");
-    std::regex regexToCoda(" *to *coda *");
+    std::regex regexDaCapo("^ *(d|d\\.) *(c|c\\.) *$|^ *da *capo *$");    //d\\.? *c\\.? Fails!
+    std::regex regexDaCapoAlFine("^ *(d|d\\.) *(c|c\\.) *al *fine *$|^ *da *capo *al *fine *$");
+    std::regex regexDaCapoAlCoda("^ *(d|d\\.) *(c|c\\.) *al *coda *$|^ *da *capo *al *coda *$");
+    std::regex regexDalSegno("^ *(d|d\\.) *(s|s\\.) *$|^ *d(a|e)l *segno *$");
+    std::regex regexDalSegnoAlFine("^ *(d|d\\.) *(s|s\\.) *al *fine *$|^ *d(a|e)l *segno *al *fine *$");
+    std::regex regexDalSegnoAlCoda("^ *(d|d\\.) *(s|s\\.) *al *coda *$|^ *d(a|e)l *segno *al *coda *$");
+    std::regex regexFine("^ *fine *$");
+    std::regex regexToCoda("^ *to *coda *$");
 
     if (std::regex_match(text, regexDaCapo))
         return k_repeat_da_capo;


### PR DESCRIPTION
This PR fixes the following issues from #138:

>All unit tests error messages such as "Line 112. Invalid ending number '1, 2'. ignored." are originated in lomse_mxl_analyser.cpp, line 2804, method bool mxl_is_valid_ending_number(const string& num). Looks like a problem with std::regex
>
>Also all failures in tests such as MxlAnalyser_direction_words_04 are due to std::regex behaviour in mac
>
>Also all problems related to volta_bracket seem to have its origin in method bool mxl_is_valid_ending_number(const string& num) in lomse_mxl_analyser.cpp and related to sdt::regex.

## Explanation
In `mxl_is_valid_ending_number` you use regex from XSD `([ ]*)|([1-9][0-9]*(, ?[1-9][0-9]*)*)` (in a modified form but that doesn't matter. I tested that regex on https://regexr.com and it reported a problem in the regex:
>The expression can match 0 characters, and therefore matches infinitely.

Because of the error the online check tool didn't allow to test any input string but https://regex101.com did and reported **matching** for any input. That's not what we want obviously.

I did know that there are many kinds of regex syntaxes. The great site [regular-expressions.info](https://www.regular-expressions.info/xml.html) calls them **flavors**. `std::regex` supports many flavors. What I wanted to know which flavor is used in XSD. regular-expressions.info has info about that too - [XML Schema Regular Expressions](https://www.regular-expressions.info/xml.html) explaining peculiar properties of XSD regex flavor. The interesting part:

> Particularly noteworthy is the complete absence of anchors like the caret and dollar, word boundaries, and lookaround. XML schema always implicitly anchors the entire regular expression. The regex must match the whole element for the element to be considered valid. If you have the pattern `regexp`, the XML schema validator will apply it in the same way as say Perl, Java or .NET would do with the pattern `^regexp$`.

That means that we can't use XSD regexes **as is** in `std::regex`. Although `std::regex` doesn't support XSD flavor we can use ECMAScript flavor but we need to add `^` and `$` to XSD regex.

Then instead of `([ ]*)|([1-9][0-9]*(, *[1-9][0-9]*)* *)` we have `^([ ]*)$|^([1-9][0-9]*(, *[1-9][0-9]*)* *)$`. That fixed test failures in `mxl_is_valid_ending_number`. Online regex testers accepted the new regex and reported expected results on all inputs. 

## Part II
It seems regexes in `mxl_type_of_repetion_mark` must match whole string too. Those regexes come not from XSD but if I understand the intention of the code correctly the whole input string must match here as well.

I applied the same modification to regexes here. That have fixed a bunch of other test failures.