### PR TITLE
Replacing boost::format with std::stringstream

### DIFF
--- a/include/lomse_logger.h
+++ b/include/lomse_logger.h
@@ -37,10 +37,8 @@
 #include <iomanip>
 #include <fstream>
 #include <string>
+#include <sstream>
 using namespace std;
-
-//other
-#include <boost/format.hpp>
 
 namespace lomse
 {

--- a/src/file_system/lomse_zip_stream.cpp
+++ b/src/file_system/lomse_zip_stream.cpp
@@ -35,6 +35,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <cstring>
+#include <algorithm>  //min()
 using namespace std;
 
 namespace lomse

--- a/src/graphic_model/engravers/lomse_engrouters.cpp
+++ b/src/graphic_model/engravers/lomse_engrouters.cpp
@@ -40,7 +40,6 @@
 #include "lomse_logger.h"
 
 //other
-#include <boost/format.hpp>
 #include "utf8.h"
 
 namespace lomse
@@ -88,17 +87,19 @@ Engrouter* EngroutersCreator::create_next_engrouter(LUnits maxSpace, bool fFirst
     if (!is_there_a_pending_engrouter())
     {
         ImoInlineLevelObj* pImo = static_cast<ImoInlineLevelObj*>( *m_itCurContent );
-        LOMSE_LOG_TRACE(Logger::k_layout, str(boost::format(
-            "Trying to create the EngroutersCreator for Imo id %d %s")
-            % pImo->get_id() % pImo->get_name() ));
+        stringstream ss;
+        ss << "Trying to create the EngroutersCreator for Imo id " <<
+            pImo->get_id() << " " << pImo->get_name();
+        LOMSE_LOG_TRACE(Logger::k_layout, ss.str());
 
         //composite content objects
         if (pImo->is_text_item())
         {
             ImoTextItem* pText = static_cast<ImoTextItem*>(pImo);
             pEngr = create_next_text_engrouter_for(pText, maxSpace, fFirstOfLine);
-            LOMSE_LOG_TRACE(Logger::k_layout, str(boost::format(
-                "Text item [%s]") % pText->get_text() ));
+            stringstream ss;
+            ss << "Text item [" << pText->get_text() << "]";
+            LOMSE_LOG_TRACE(Logger::k_layout, ss.str());
         }
         else if (pImo->is_box_inline())
         {
@@ -130,9 +131,11 @@ Engrouter* EngroutersCreator::create_next_engrouter(LUnits maxSpace, bool fFirst
             return pEngr;
         else
         {
-            LOMSE_LOG_TRACE(Logger::k_layout, str(boost::format(
-                "Not enough space for engrouter. Needed=%.02f, available=%.02f")
-                % width % maxSpace ));
+            stringstream ss;
+            ss.precision(2);
+            ss << "Not enough space for engrouter. Needed=" << fixed <<
+                width << ", available=" << maxSpace;
+            LOMSE_LOG_TRACE(Logger::k_layout, ss.str());
             save_engrouter_for_next_call(pEngr);
             return nullptr;
         }
@@ -163,12 +166,11 @@ Engrouter* EngroutersCreator::create_engrouter_for(ImoInlineLevelObj* pImo)
     }
     else
     {
-        string msg = str( boost::format(
-                            "[EngroutersCreator::create_engrouter_for] invalid object %d")
-                            % pImo->get_obj_type() );
-        cout << "Throw: " << msg << endl;
-        LOMSE_LOG_ERROR(msg);
-        throw std::runtime_error(msg);
+		stringstream ss;
+        ss << "[EngroutersCreator::create_engrouter_for] invalid object " << pImo->get_obj_type();
+        cout << "Throw: " << ss.str() << endl;
+        LOMSE_LOG_ERROR(ss.str());
+        throw std::runtime_error(ss.str());
     }
 }
 

--- a/src/graphic_model/engravers/lomse_metronome_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_metronome_engraver.cpp
@@ -37,9 +37,6 @@
 #include "lomse_shape_text.h"
 #include "lomse_logger.h"
 
-//other
-#include <boost/format.hpp>
-
 using namespace std;
 
 namespace lomse
@@ -78,11 +75,10 @@ GmoShape* MetronomeMarkEngraver::create_shape(ImoMetronomeMark* pImo, UPoint uPo
             return create_shape_mm_value();
         default:
         {
-            string msg = str( boost::format(
-                            "[MetronomeMarkEngraver::create_shape] invalid mark type %d")
-                            % markType );
-            LOMSE_LOG_ERROR(msg);
-            throw runtime_error(msg);
+			stringstream ss;
+            ss << "[MetronomeMarkEngraver::create_shape] invalid mark type " << markType;
+            LOMSE_LOG_ERROR(ss.str());
+            throw runtime_error(ss.str());
         }
     }
 }
@@ -94,9 +90,9 @@ GmoShape* MetronomeMarkEngraver::create_shape_mm_value()
     int ticksPerMinute = m_pCreatorImo->get_ticks_per_minute();
     bool fParenthesis = m_pCreatorImo->has_parenthesis();
 
-    string msg = str( fParenthesis ? boost::format("(M.M. = %d)") % ticksPerMinute
-                                   : boost::format("M.M. = %d") % ticksPerMinute );
-    create_text_shape(msg);
+	stringstream ss;
+	ss << (fParenthesis ? "(" : "") << "M.M. = " << ticksPerMinute << (fParenthesis ? ")" : "");
+    create_text_shape(ss.str());
     return m_pMainShape;
 }
 
@@ -132,9 +128,9 @@ GmoShape* MetronomeMarkEngraver::create_shape_note_value()
     if (fParenthesis)
         create_text_shape("(");
     create_symbol_shape(leftNoteType, leftDots);
-    string msg = str( fParenthesis ? boost::format(" = %d)") % ticksPerMinute
-                                   : boost::format(" = %d") % ticksPerMinute );
-    create_text_shape(msg);
+	stringstream ss;
+	ss << " = " << ticksPerMinute << (fParenthesis ? ")" : "");
+    create_text_shape(ss.str());
     return m_pMainShape;
 }
 
@@ -211,11 +207,10 @@ int MetronomeMarkEngraver::select_glyph(int noteType)
             return k_glyph_small_256th_note;
         default:
         {
-            string msg = str( boost::format(
-                            "[MetronomeMarkEngraver::select_glyph] invalid note type %d")
-                            % noteType );
-            LOMSE_LOG_ERROR(msg);
-            throw runtime_error(msg);
+			stringstream ss;
+			ss << "[MetronomeMarkEngraver::select_glyph] invalid note type " << noteType;
+            LOMSE_LOG_ERROR(ss.str());
+            throw runtime_error(ss.str());
         }
     }
 }

--- a/src/graphic_model/engravers/lomse_time_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_time_engraver.cpp
@@ -76,12 +76,12 @@ GmoShape* TimeEngraver::create_shape(ImoTimeSignature* pCreatorImo, UPoint uPos,
     }
     else
     {
-        string msg = str( boost::format(
-                        "[TimeEngraver::create_shape] unsupported time signature type %d")
-                        % pCreatorImo->get_type() );
-        LOMSE_LOG_ERROR(msg);
-        throw runtime_error(msg);
-    }
+		std::stringstream ss;
+		ss << "[TimeEngraver::create_shape] unsupported time signature type " <<
+                        pCreatorImo->get_type();
+        LOMSE_LOG_ERROR(ss.str());
+        throw runtime_error(ss.str());
+	}
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/layouters/lomse_inlines_container_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_inlines_container_layouter.cpp
@@ -39,9 +39,6 @@
 #include "lomse_blocks_container_layouter.h"
 #include "lomse_logger.h"
 
-//other
-#include <boost/format.hpp>
-
 namespace lomse
 {
 
@@ -144,8 +141,10 @@ void InlinesContainerLayouter::prepare_line()
 
     bool fBreak = false;
 
-    LOMSE_LOG_TRACE(Logger::k_layout, str(boost::format("available space=%.02f")
-                                          % m_availableSpace ));
+    stringstream ss;
+    ss.precision(2);
+    ss << "available space=" << fixed << m_availableSpace;
+    LOMSE_LOG_TRACE(Logger::k_layout, ss.str());
 
     bool fSomethingAdded = false;
     bool fFirstEngrouterOfLine = true;

--- a/src/graphic_model/layouters/lomse_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_layouter.cpp
@@ -90,8 +90,9 @@ GmoBox* Layouter::start_new_page()
 //---------------------------------------------------------------------------------------
 void Layouter::layout_item(ImoContentObj* pItem, GmoBox* pParentBox, int constrains)
 {
-    LOMSE_LOG_DEBUG(Logger::k_layout, str(boost::format(
-        "Laying out id %d %s") % pItem->get_id() % pItem->get_name() ));
+    stringstream ss;
+    ss << "Laying out id " << pItem->get_id() << " " << pItem->get_name();
+    LOMSE_LOG_DEBUG(Logger::k_layout, ss.str());
 
     m_pCurLayouter = create_layouter(pItem);
     m_pCurLayouter->set_constrains(constrains);
@@ -132,9 +133,11 @@ void Layouter::set_cursor_and_available_space()
     m_availableWidth = m_pItemMainBox->get_content_width();
     m_availableHeight = m_pItemMainBox->get_content_height();
 
-    LOMSE_LOG_DEBUG(Logger::k_layout, str(boost::format(
-        "cursor at(%.2f, %.2f), available space(%.2f, %.2f)")
-        % m_pageCursor.x % m_pageCursor.y % m_availableWidth % m_availableHeight ));
+    stringstream ss;
+    ss.precision(2);
+    ss << fixed << "cursor at(" << m_pageCursor.x << ", " << m_pageCursor.y <<
+        "), available space(" << m_availableWidth << ", " << m_availableHeight << ")";
+    LOMSE_LOG_DEBUG(Logger::k_layout, ss.str());
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/lomse_graphical_model.cpp
+++ b/src/graphic_model/lomse_graphical_model.cpp
@@ -175,9 +175,10 @@ void GraphicModel::add_to_map_imo_to_box(GmoBox* pBox)
         map<ImoId, GmoBox*>::const_iterator it = m_imoToBox.find(id);
         if (it != m_imoToBox.end())
         {
-            LOMSE_LOG_ERROR( str( boost::format(
-                "Duplicated Imo id %d. Existing Gmo: %s. Adding Gmo: %s")
-                % id % (it->second)->get_name() % pBox->get_name()) );
+			stringstream ss;
+			ss << "Duplicated Imo id " << id << ". Existing Gmo: " <<
+				(it->second)->get_name() << ". Adding Gmo: " << pBox->get_name();
+            LOMSE_LOG_ERROR(ss.str());
             //TO_INVESTIGATE: This is nor an error. An Imo can create two
             //boxes (currently DocPage and DocPageContent boxes). Maybe the
             //error is in the implications if this is accepted.
@@ -193,8 +194,9 @@ void GraphicModel::add_to_map_ref_to_box(GmoBox* pBox)
     GmoRef gref = pBox->get_ref();
     if (gref != k_no_gmo_ref)
     {
-        LOMSE_LOG_TRACE(Logger::k_gmodel, str(boost::format("Added (%d, %d) %s")
-            % gref.first % gref.second % pBox->get_name() ));
+        stringstream ss;
+        ss << "Added (" << gref.first << ", " << gref.second << ") " << pBox->get_name();
+        LOMSE_LOG_TRACE(Logger::k_gmodel, ss.str());
         m_ctrolToPtr[gref] = pBox;
     }
 }
@@ -223,8 +225,9 @@ GmoShape* GraphicModel::get_main_shape_for_imo(ImoId id)
         return it->second;
     else
     {
-        LOMSE_LOG_DEBUG(Logger::k_score_player, str(boost::format(
-            "No shape found for Imo id: %d") % id) );
+        stringstream ss;
+        ss << "No shape found for Imo id: " << id;
+        LOMSE_LOG_DEBUG(Logger::k_score_player, ss.str());
         return nullptr;
     }
 }

--- a/src/gui_controls/lomse_hyperlink_ctrl.cpp
+++ b/src/gui_controls/lomse_hyperlink_ctrl.cpp
@@ -104,7 +104,9 @@ GmoBoxControl* HyperlinkCtrl::layout(LibraryScope& UNUSED(libraryScope), UPoint 
 //---------------------------------------------------------------------------------------
 void HyperlinkCtrl::handle_event(SpEventInfo pEvent)
 {
-    LOMSE_LOG_DEBUG(Logger::k_events, str(boost::format("label: %s") % m_label));
+    stringstream ss;
+    ss << "label: " << m_label;
+    LOMSE_LOG_DEBUG(Logger::k_events, ss.str());
 
     if (m_fEnabled)
     {

--- a/src/gui_controls/lomse_progress_bar_ctrl.cpp
+++ b/src/gui_controls/lomse_progress_bar_ctrl.cpp
@@ -37,8 +37,6 @@
 #include "lomse_calligrapher.h"
 #include "lomse_events.h"
 
-#include <boost/format.hpp>
-
 namespace lomse
 {
 
@@ -114,12 +112,17 @@ void ProgressBarCtrl::set_value(float value)
     else
         m_percent = 0.0f;
 
-    if (m_fDisplayPercentage)
-        m_label = str( boost::format("%.01f%%") % (m_percent * 100.0f));
-    else
-        m_label = str( boost::format("%.0f") % value);
+	stringstream ss;
+	if (m_fDisplayPercentage)
+	{
+		ss.precision(1);
+		ss << fixed << (m_percent * 100.0f) << "%";
+	}
+	else
+        ss << fixed << value;
+	m_label = ss.str();
 
-    if (m_pMainBox)
+	if (m_pMainBox)
         m_pMainBox->set_dirty(true);
 }
 

--- a/src/gui_controls/lomse_score_player_ctrl.cpp
+++ b/src/gui_controls/lomse_score_player_ctrl.cpp
@@ -148,8 +148,9 @@ void ScorePlayerCtrl::handle_event(SpEventInfo pEvent)
         }
         else
         {
-            LOMSE_LOG_WARN(str(boost::format("Unknown event received. Type=%d")
-                            % pEvent->get_event_type()) );
+			stringstream ss;
+			ss << "Unknown event received. Type=" << pEvent->get_event_type();
+			LOMSE_LOG_WARN(ss.str());
         }
     }
 }

--- a/src/internal_model/lomse_score_utilities.cpp
+++ b/src/internal_model/lomse_score_utilities.cpp
@@ -33,8 +33,6 @@
 #include "lomse_im_note.h"
 #include "lomse_logger.h"
 
-//other
-#include <boost/format.hpp>
 #include <cmath>                //for fabs
 
 using namespace std;
@@ -68,11 +66,11 @@ int get_beat_position(TimeUnits timePos, ImoTimeSignature* pTS)
         case 16: beatDuration = int( to_duration(k_eighth, 0) ); break;
         default:
         {
-            string msg = str( boost::format("[get_beat_position] BeatType %d unknown.")
-                              % beatType );
-            LOMSE_LOG_ERROR(msg);
-            throw runtime_error(msg);
-        }
+			stringstream ss;
+			ss << "[get_beat_position] BeatType " << beatType << " unknown.";
+            LOMSE_LOG_ERROR(ss.str());
+            throw runtime_error(ss.str());
+		}
     }
 
     // compute relative position of this note/rest with reference to the beat
@@ -110,12 +108,11 @@ TimeUnits get_duration_for_ref_note(int bottomNumber)
             return pow(2.0, (10 - k_64th));
         default:
         {
-            string msg = str( boost::format(
-                                "[get_duration_for_ref_note] Invalid bottom number %d")
-                                % bottomNumber );
-            LOMSE_LOG_ERROR(msg);
-            throw runtime_error(msg);
-        }
+			stringstream ss;
+			ss << "[get_duration_for_ref_note] Invalid bottom number " << bottomNumber;
+            LOMSE_LOG_ERROR(ss.str());
+            throw runtime_error(ss.str());
+		}
     }
 }
 
@@ -249,11 +246,10 @@ void get_accidentals_for_key(int keyType, int nAccidentals[])
             break;
         default:
         {
-            string msg = str( boost::format(
-                                "[get_accidentals_for_key] Invalid key signature %d")
-                                % keyType );
-            LOMSE_LOG_ERROR(msg);
-            throw runtime_error(msg);
+			stringstream ss;
+			ss << "[get_accidentals_for_key] Invalid key signature " << keyType;
+            LOMSE_LOG_ERROR(ss.str());
+            throw runtime_error(ss.str());
         }
     }
 
@@ -315,11 +311,10 @@ int get_step_for_root_note(EKeySignature keyType)
 
         default:
         {
-            string msg = str( boost::format(
-                                "[get_step_for_root_note] Invalid key signature %d")
-                                % keyType );
-            LOMSE_LOG_ERROR(msg);
-            throw runtime_error(msg);
+			stringstream ss;
+			ss << "[get_step_for_root_note] Invalid key signature " << keyType;
+            LOMSE_LOG_ERROR(ss.str());
+            throw runtime_error(ss.str());
         }
     }
 }
@@ -410,11 +405,10 @@ int key_signature_to_num_fifths(int keyType)
             break;
         default:
         {
-            string msg = str( boost::format(
-                                "[key_signature_to_num_fifths] Invalid key signature %d")
-                                % keyType );
-            LOMSE_LOG_ERROR(msg);
-            throw runtime_error(msg);
+			stringstream ss;
+			ss << "[key_signature_to_num_fifths] Invalid key signature " << keyType;
+            LOMSE_LOG_ERROR(ss.str());
+            throw runtime_error(ss.str());
         }
     }
     return nFifths;
@@ -456,11 +450,10 @@ EKeySignature get_relative_minor_key(EKeySignature nMajorKey)
             return k_key_af;
         default:
         {
-            string msg = str( boost::format(
-                                "[get_relative_minor_key] Invalid key signature %d")
-                                % nMajorKey );
-            LOMSE_LOG_ERROR(msg);
-            throw runtime_error(msg);
+			stringstream ss;
+			ss << "[get_relative_minor_key] Invalid key signature " << nMajorKey;
+            LOMSE_LOG_ERROR(ss.str());
+            throw runtime_error(ss.str());
         }
     }
 
@@ -502,11 +495,10 @@ EKeySignature get_relative_major_key(EKeySignature nMinorKey)
             return k_key_Cf;
         default:
         {
-            string msg = str( boost::format(
-                                "[get_relative_major_key] Invalid key signature %d")
-                                % nMinorKey );
-            LOMSE_LOG_ERROR(msg);
-            //throw runtime_error(msg);
+			stringstream ss;
+			ss << "[get_relative_major_key] Invalid key signature " << nMinorKey;
+            LOMSE_LOG_ERROR(ss.str());
+            //throw runtime_error(ss.str());
             return k_key_c;
         }
     }
@@ -547,11 +539,10 @@ DiatonicPitch get_diatonic_pitch_for_first_line(EClef nClef)
         case k_clef_percussion:   return NO_DPITCH;
         default:
         {
-            string msg = str( boost::format(
-                                "[get_diatonic_pitch_for_first_line] Invalid clef %d")
-                                % nClef );
-            LOMSE_LOG_ERROR(msg);
-            throw runtime_error(msg);
+			stringstream ss;
+			ss << "[get_diatonic_pitch_for_first_line] Invalid clef " << nClef;
+            LOMSE_LOG_ERROR(ss.str());
+            throw runtime_error(ss.str());
         }
     }
     return NO_DPITCH;

--- a/src/module/lomse_logger.cpp
+++ b/src/module/lomse_logger.cpp
@@ -27,6 +27,7 @@
 // the project at cecilios@users.sourceforge.net
 //---------------------------------------------------------------------------------------
 
+#include <algorithm>
 #include "lomse_logger.h"
 
 using namespace std;

--- a/src/mvc/lomse_graphic_view.cpp
+++ b/src/mvc/lomse_graphic_view.cpp
@@ -693,16 +693,20 @@ void GraphicView::highlight_object(ImoStaffObj* pSO)
     GmoShape* pShape = pGModel->get_main_shape_for_imo(pSO->get_id());
     if (!pShape)
     {
-        LOMSE_LOG_ERROR(str(boost::format("No shape found for Imo id: %d")
-                            % pSO->get_id()) );
+		stringstream ss;
+		ss << "No shape found for Imo id: " << pSO->get_id();
+		LOMSE_LOG_ERROR(ss.str());
         return;
     }
     if (! (pShape->is_shape_notehead()
            || pShape->is_shape_note()
            || pShape->is_shape_rest()) )
-        LOMSE_LOG_ERROR(str(boost::format("Shape is neither note nor rest. Shape type: %s, Imo id=%d")
-                            % pShape->get_name()
-                            % pSO->get_id() ));
+	{
+		stringstream ss;
+		ss << "Shape is neither note nor rest. Shape type: " << pShape->get_name() <<
+			", Imo id=" << pSO->get_id();
+		LOMSE_LOG_ERROR(ss.str());
+	}
 
     m_pHighlighted->add_highlight( pShape );
 }

--- a/src/mvc/lomse_interactor.cpp
+++ b/src/mvc/lomse_interactor.cpp
@@ -54,9 +54,6 @@
 #include <sstream>
 using namespace std;
 
-//other
-#include <boost/format.hpp>
-
 namespace lomse
 {
 
@@ -471,25 +468,26 @@ void Interactor::task_action_mouse_in_out(Pixels x, Pixels y,
 
     GmoRef gref = find_event_originator_gref(pGmo);
 
-    LOMSE_LOG_DEBUG(Logger::k_events, str(boost::format(
-        "Gmo %d, %s / gref(%d, %d) -------------------")
-         % pGmo->get_gmobj_type() % pGmo->get_name()
-         % gref.first % gref.second ));
+    stringstream ss1;
+    ss1 << "Gmo " << pGmo->get_gmobj_type() << ", " << pGmo->get_name() <<
+        " / gref(" << gref.first << ", " << gref.second << ") -------------------";
+    LOMSE_LOG_DEBUG(Logger::k_events, ss1.str());
 
     if (m_grefLastMouseOver != k_no_gmo_ref && m_grefLastMouseOver != gref)
     {
-        LOMSE_LOG_DEBUG(Logger::k_events, str(boost::format(
-            "Mouse out. gref(%d %d)")
-            % m_grefLastMouseOver.first % m_grefLastMouseOver.second ));
+        stringstream ss2;
+        ss2 << "Mouse out. gref(" << m_grefLastMouseOver.first <<
+            " " << m_grefLastMouseOver.second << ")";
+        LOMSE_LOG_DEBUG(Logger::k_events, ss2.str());
         send_mouse_out_event(m_grefLastMouseOver, x, y);
         m_grefLastMouseOver = k_no_gmo_ref;
     }
 
     if (m_grefLastMouseOver == k_no_gmo_ref && gref != k_no_gmo_ref)
     {
-        LOMSE_LOG_DEBUG(Logger::k_events, str(boost::format(
-            "Mouse in. gref(%d %d)")
-            % gref.first % gref.second ));
+        stringstream ss2;
+        ss2 << "Mouse in. gref(" << gref.first << " " << gref.second << ")";
+        LOMSE_LOG_DEBUG(Logger::k_events, ss2.str());
         send_mouse_in_event(gref, x, y);
         m_grefLastMouseOver = gref;
     }
@@ -1356,10 +1354,10 @@ bool Interactor::discard_score_highlight_event_if_not_valid(SpEventScoreHighligh
 
     if (!pScore || !pScore->is_score())
     {
-        LOMSE_LOG_DEBUG(Logger::k_events, str(boost::format(
-            "Highlight discarded: score id: %d, pScore? %s")
-             % pEvent->get_score_id()
-             % (pScore ? "not null" : "null") ));
+        stringstream ss;
+        ss << "Highlight discarded: score id: " << pEvent->get_score_id() <<
+            ", pScore? " << (pScore ? "not null" : "null");
+        LOMSE_LOG_DEBUG(Logger::k_events, ss.str());
 
         discard_all_highlight();
         return true;
@@ -1424,10 +1422,10 @@ void Interactor::on_visual_highlight(SpEventScoreHighlight pEvent)
 
                 default:
                 {
-                    string msg = str( boost::format("Unknown event type %d.")
-                                    % (*it).first );
-                    LOMSE_LOG_ERROR(msg);
-                    throw runtime_error(msg);
+					stringstream ss;
+					ss << "Unknown event type " << (*it).first << ".";
+                    LOMSE_LOG_ERROR(ss.str());
+                    throw runtime_error(ss.str());
                 }
             }
         }
@@ -1596,8 +1594,9 @@ void Interactor::find_parent_link_box_and_notify_event(SpEventInfo pEvent, GmoOb
 {
     while(pGmo && !pGmo->is_box_link())
     {
-        LOMSE_LOG_DEBUG(Logger::k_events, str( boost::format("Gmo type: %d, %s")
-                    % pGmo->get_gmobj_type() % pGmo->get_name() ) );
+        stringstream ss;
+        ss << "Gmo type: " << pGmo->get_gmobj_type() << ", " << pGmo->get_name();
+        LOMSE_LOG_DEBUG(Logger::k_events, ss.str());
         pGmo = pGmo->get_owner_box();
     }
 

--- a/src/parser/mnx/lomse_mnx_analyser.cpp
+++ b/src/parser/mnx/lomse_mnx_analyser.cpp
@@ -2225,12 +2225,11 @@ protected:
 
                 default:
                 {
-                    string msg = str( boost::format(
-                                        "Invalid number of fifths %d")
-                                        % fifths );
-                    error_msg(msg);
-    //                LOMSE_LOG_ERROR(msg);
-    //                throw runtime_error(msg);
+					stringstream ss;
+					ss << "Invalid number of fifths " << fifths;
+                    error_msg(ss.str());
+    //                LOMSE_LOG_ERROR(ss.str());
+    //                throw runtime_error(ss.str());
                     return k_key_C;
                 }
             }
@@ -2276,12 +2275,11 @@ protected:
 
                 default:
                 {
-                    string msg = str( boost::format(
-                                        "Invalid number of fifths %d")
-                                        % fifths );
-                    error_msg(msg);
-    //                LOMSE_LOG_ERROR(msg);
-    //                throw runtime_error(msg);
+					stringstream ss;
+					ss << "Invalid number of fifths " << fifths;
+                    error_msg(ss.str());
+    //                LOMSE_LOG_ERROR(ss.str());
+    //                throw runtime_error(ss.str());
                     return k_key_a;
                 }
             }

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -3160,12 +3160,11 @@ protected:
 
                 default:
                 {
-                    string msg = str( boost::format(
-                                        "Invalid number of fifths %d")
-                                        % fifths );
-                    error_msg(msg);
-    //                LOMSE_LOG_ERROR(msg);
-    //                throw runtime_error(msg);
+					stringstream ss;
+					ss << "Invalid number of fifths " << fifths;
+                    error_msg(ss.str());
+    //                LOMSE_LOG_ERROR(ss.str());
+    //                throw runtime_error(ss.str());
                     return k_key_C;
                 }
             }
@@ -3211,12 +3210,11 @@ protected:
 
                 default:
                 {
-                    string msg = str( boost::format(
-                                        "Invalid number of fifths %d")
-                                        % fifths );
-                    error_msg(msg);
-    //                LOMSE_LOG_ERROR(msg);
-    //                throw runtime_error(msg);
+					stringstream ss;
+					ss << "Invalid number of fifths " << fifths;
+                    error_msg(ss.str());
+    //                LOMSE_LOG_ERROR(ss.str());
+    //                throw runtime_error(ss.str());
                     return k_key_a;
                 }
             }

--- a/src/sound/lomse_midi_table.cpp
+++ b/src/sound/lomse_midi_table.cpp
@@ -39,8 +39,6 @@
 #include "lomse_score_utilities.h"
 #include "lomse_im_attributes.h"
 
-#include <boost/format.hpp>
-
 using namespace std;
 
 namespace lomse
@@ -527,58 +525,57 @@ string SoundEventsTable::dump_events_table()
         return "Midi events table is empty";
 
     //headers
-    string msg = "Num.\tTime\t\tCh.\tMeas.\tEvent\t\tPitch\tStep\tVolume\n";
+	stringstream msg;
+    msg << "Num.\tTime\t\tCh.\tMeas.\tEvent\t\tPitch\tStep\tVolume\n";
 
         for(int i=0; i < int(m_events.size()); i++)
         {
             //division line every four entries
             if (i % 4 == 0) {
-                msg += "-------------------------------------------------------------\n";
+                msg << "-------------------------------------------------------------\n";
             }
 
             //list current entry
             SoundEvent* pSE = m_events[i];
-            msg += str( boost::format("%4d:\t%d\t\t%d\t%d\t") %
-                        i % pSE->DeltaTime % pSE->Channel % pSE->Measure );
+			msg << i << ":\t" << pSE->DeltaTime << "\t\t" << pSE->Channel << "\t" << pSE->Measure << "\t";
 
             bool fAddData = true;
             switch (pSE->EventType)
             {
                 case SoundEvent::k_note_on:
-                    msg += "ON        ";
+                    msg << "ON        ";
                     break;
                 case SoundEvent::k_note_off:
-                    msg += "OFF       ";
+                    msg << "OFF       ";
                     break;
                 case SoundEvent::k_visual_on:
-                    msg += "VISUAL ON ";
+                    msg << "VISUAL ON ";
                     break;
                 case SoundEvent::k_visual_off:
-                    msg += "VISUAL OFF";
+                    msg << "VISUAL OFF";
                     break;
                 case SoundEvent::k_end_of_score:
-                    msg += "END TABLE ";
+                    msg << "END TABLE ";
                     break;
                 case SoundEvent::k_rhythm_change:
-                    msg += "RITHM CHG ";
+                    msg << "RITHM CHG ";
                     break;
                 case SoundEvent::k_prog_instr:
-                    msg += "PRG INSTR ";
+                    msg << "PRG INSTR ";
                     break;
                 case SoundEvent::k_jump:
-                    msg += "JUMP      ";
-                    msg += pSE->pJump->dump_entry();
+                    msg << "JUMP      ";
+                    msg << pSE->pJump->dump_entry();
                     fAddData = false;
                     break;
                 default:
-                    msg += str( boost::format("?? %d") % pSE->EventType );
+                    msg << "?? " << pSE->EventType;
             }
-            if (fAddData)
-                msg += str( boost::format("\t%d\t%d\t%d\n") %
-                            pSE->NotePitch % pSE->NoteStep % pSE->Volume );
+			if (fAddData)
+				msg << "\t" << pSE->NotePitch << "\t" << pSE->NoteStep << "\t" << pSE->Volume << "\n";
         }
 
-    return msg;
+    return msg.str();
 }
 
 //---------------------------------------------------------------------------------------
@@ -587,29 +584,29 @@ string SoundEventsTable::dump_measures_table()
     if (m_measures.size() == 0)
         return "Measures table is empty";
 
+	stringstream msg;
+
     // measures start time table and first event for each measure
     int num = int(m_measures.size()) - 2;
-    string msg =
-        str( boost::format("\n\nMeasures start times and first event (%d measures)\n\n")
-                           % num );
-    msg += "Num.\tTime\tEvent\n";
+	msg << "\n\nMeasures start times and first event (" << num << " measures)\n\n";
+    msg << "Num.\tTime\tEvent\n";
     for(int i=1; i < int(m_measures.size()); i++)
     {
         //division line every four entries
         if (i % 4 == 0)
-            msg += "-------------------------------------------------------------\n";
+            msg << "-------------------------------------------------------------\n";
 
         int nEntry = m_measures[i];
         if (nEntry >= 0)
         {
             SoundEvent* pSE = m_events[nEntry];
-            msg += str( boost::format("%4d:\t%d\t%d\n") % i % pSE->DeltaTime % nEntry );
+            msg << i << ":\t" << pSE->DeltaTime << "\t" << nEntry << "\n";
         }
         else
-            msg += str( boost::format("%4d:\tEmpty entry\n") % i );
+            msg << i << ":\tEmpty entry\n";
     }
 
-    return msg;
+	return msg.str();
 }
 
 //---------------------------------------------------------------------------------------


### PR DESCRIPTION
As part of eliminating dependency from `boost` we replace `boost::format` with an alternative solution which relies on standard library only.

I've made two variants of the replacement:
- the one which uses `std::stringstream`;
- and another one with an own `printf`-like function;

I'm posting both variants as separate PRs and let you choose which one you like more.

In this PR we use `std::stringstream`.

The replacement looks like this:
#### was:
```C++
    LOMSE_LOG_TRACE(Logger::k_layout, str(boost::format(
        "Trying to create the EngroutersCreator for Imo id %d %s")
        % pImo->get_id() % pImo->get_name() ));
```

#### became:
```C++
    stringstream ss;
    ss << "Trying to create the EngroutersCreator for Imo id " <<
        pImo->get_id() << " " << pImo->get_name();
    LOMSE_LOG_TRACE(Logger::k_layout, ss.str());
```

It's a little bit more verbose but manageable. However there is one issue. `LOMSE_LOG_DEBUG` and `LOMSE_LOG_TRACE` are macros which in debug builds expand to calls `logger.log_debug()` and `logger.log_trace()`. In release builds these macros expand to empty code.

Therefore in release mode:
- variant with `boost::format` produces no code.
- variant with `stringstream` instantiates a stringstream object and writes into it, the result isn't used. I doubt compilers can eliminate instantiation and writing into stream here.

To avoid this unnecessary runtime overhead in release builds we should write:
```C++
#if (LOMSE_ENABLE_DEBUG_LOGS == 1)
    stringstream ss;
    ss << "Trying to create the EngroutersCreator for Imo id " <<
        pImo->get_id() << " " << pImo->get_name();
    LOMSE_LOG_TRACE(Logger::k_layout, ss.str());
#endif
```

This is considerably more verbose than the original boost-version.

These additional `#if (LOMSE_ENABLE_DEBUG_LOGS == 1)` are not included in this PR but they probably should be added if you choose that alternative.

The second approach (own printf-like function, for which I'll post another PR) works similar to `boost::format` version and doesn't produce code in release builds.