### PR TITLE
Replacing boost::format with own format function

### DIFF
--- a/include/lomse_logger.h
+++ b/include/lomse_logger.h
@@ -39,9 +39,6 @@
 #include <string>
 using namespace std;
 
-//other
-#include <boost/format.hpp>
-
 namespace lomse
 {
 
@@ -71,6 +68,14 @@ extern ofstream dbgLogger;
         #define LOMSE_LOG_TRACE(area, msg)
     #endif
 
+#endif
+
+#ifdef __GNUC__
+// GCC and Clang support error detection of format arguments in compile time
+std::string format(const char* fmtstr, ...) __attribute__((format(printf, 1, 2)));
+#else
+// This compiler does not support error detection of format arguments in compile time
+std::string format(const char* fmtstr, ...);
 #endif
 
 

--- a/src/file_system/lomse_zip_stream.cpp
+++ b/src/file_system/lomse_zip_stream.cpp
@@ -35,6 +35,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <cstring>
+#include <algorithm> // min()
 using namespace std;
 
 namespace lomse

--- a/src/graphic_model/engravers/lomse_engrouters.cpp
+++ b/src/graphic_model/engravers/lomse_engrouters.cpp
@@ -40,7 +40,6 @@
 #include "lomse_logger.h"
 
 //other
-#include <boost/format.hpp>
 #include "utf8.h"
 
 namespace lomse
@@ -88,17 +87,17 @@ Engrouter* EngroutersCreator::create_next_engrouter(LUnits maxSpace, bool fFirst
     if (!is_there_a_pending_engrouter())
     {
         ImoInlineLevelObj* pImo = static_cast<ImoInlineLevelObj*>( *m_itCurContent );
-        LOMSE_LOG_TRACE(Logger::k_layout, str(boost::format(
-            "Trying to create the EngroutersCreator for Imo id %d %s")
-            % pImo->get_id() % pImo->get_name() ));
+        LOMSE_LOG_TRACE(Logger::k_layout, format(
+            "Trying to create the EngroutersCreator for Imo id %d %s",
+            pImo->get_id(), pImo->get_name().c_str() ));
 
         //composite content objects
         if (pImo->is_text_item())
         {
             ImoTextItem* pText = static_cast<ImoTextItem*>(pImo);
             pEngr = create_next_text_engrouter_for(pText, maxSpace, fFirstOfLine);
-            LOMSE_LOG_TRACE(Logger::k_layout, str(boost::format(
-                "Text item [%s]") % pText->get_text() ));
+            LOMSE_LOG_TRACE(Logger::k_layout, format(
+                "Text item [%s]", pText->get_text().c_str() ));
         }
         else if (pImo->is_box_inline())
         {
@@ -130,9 +129,9 @@ Engrouter* EngroutersCreator::create_next_engrouter(LUnits maxSpace, bool fFirst
             return pEngr;
         else
         {
-            LOMSE_LOG_TRACE(Logger::k_layout, str(boost::format(
-                "Not enough space for engrouter. Needed=%.02f, available=%.02f")
-                % width % maxSpace ));
+            LOMSE_LOG_TRACE(Logger::k_layout, format(
+                "Not enough space for engrouter. Needed=%.02f, available=%.02f",
+                width, maxSpace ));
             save_engrouter_for_next_call(pEngr);
             return nullptr;
         }
@@ -163,9 +162,9 @@ Engrouter* EngroutersCreator::create_engrouter_for(ImoInlineLevelObj* pImo)
     }
     else
     {
-        string msg = str( boost::format(
-                            "[EngroutersCreator::create_engrouter_for] invalid object %d")
-                            % pImo->get_obj_type() );
+        string msg = format(
+                         "[EngroutersCreator::create_engrouter_for] invalid object %d",
+                         pImo->get_obj_type() );
         cout << "Throw: " << msg << endl;
         LOMSE_LOG_ERROR(msg);
         throw std::runtime_error(msg);

--- a/src/graphic_model/engravers/lomse_metronome_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_metronome_engraver.cpp
@@ -37,9 +37,6 @@
 #include "lomse_shape_text.h"
 #include "lomse_logger.h"
 
-//other
-#include <boost/format.hpp>
-
 using namespace std;
 
 namespace lomse
@@ -78,9 +75,9 @@ GmoShape* MetronomeMarkEngraver::create_shape(ImoMetronomeMark* pImo, UPoint uPo
             return create_shape_mm_value();
         default:
         {
-            string msg = str( boost::format(
-                            "[MetronomeMarkEngraver::create_shape] invalid mark type %d")
-                            % markType );
+            string msg = format(
+                             "[MetronomeMarkEngraver::create_shape] invalid mark type %d",
+                             markType );
             LOMSE_LOG_ERROR(msg);
             throw runtime_error(msg);
         }
@@ -94,8 +91,8 @@ GmoShape* MetronomeMarkEngraver::create_shape_mm_value()
     int ticksPerMinute = m_pCreatorImo->get_ticks_per_minute();
     bool fParenthesis = m_pCreatorImo->has_parenthesis();
 
-    string msg = str( fParenthesis ? boost::format("(M.M. = %d)") % ticksPerMinute
-                                   : boost::format("M.M. = %d") % ticksPerMinute );
+    string msg = fParenthesis ? format("(M.M. = %d)", ticksPerMinute)
+                              : format("M.M. = %d", ticksPerMinute);
     create_text_shape(msg);
     return m_pMainShape;
 }
@@ -132,8 +129,8 @@ GmoShape* MetronomeMarkEngraver::create_shape_note_value()
     if (fParenthesis)
         create_text_shape("(");
     create_symbol_shape(leftNoteType, leftDots);
-    string msg = str( fParenthesis ? boost::format(" = %d)") % ticksPerMinute
-                                   : boost::format(" = %d") % ticksPerMinute );
+    string msg = fParenthesis ? format(" = %d)", ticksPerMinute)
+                              : format(" = %d", ticksPerMinute);
     create_text_shape(msg);
     return m_pMainShape;
 }
@@ -211,9 +208,9 @@ int MetronomeMarkEngraver::select_glyph(int noteType)
             return k_glyph_small_256th_note;
         default:
         {
-            string msg = str( boost::format(
-                            "[MetronomeMarkEngraver::select_glyph] invalid note type %d")
-                            % noteType );
+            string msg = format(
+                             "[MetronomeMarkEngraver::select_glyph] invalid note type %d",
+                             noteType );
             LOMSE_LOG_ERROR(msg);
             throw runtime_error(msg);
         }

--- a/src/graphic_model/engravers/lomse_time_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_time_engraver.cpp
@@ -76,9 +76,9 @@ GmoShape* TimeEngraver::create_shape(ImoTimeSignature* pCreatorImo, UPoint uPos,
     }
     else
     {
-        string msg = str( boost::format(
-                        "[TimeEngraver::create_shape] unsupported time signature type %d")
-                        % pCreatorImo->get_type() );
+        string msg = format(
+                        "[TimeEngraver::create_shape] unsupported time signature type %d",
+                        pCreatorImo->get_type() );
         LOMSE_LOG_ERROR(msg);
         throw runtime_error(msg);
     }

--- a/src/graphic_model/layouters/lomse_inlines_container_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_inlines_container_layouter.cpp
@@ -39,9 +39,6 @@
 #include "lomse_blocks_container_layouter.h"
 #include "lomse_logger.h"
 
-//other
-#include <boost/format.hpp>
-
 namespace lomse
 {
 
@@ -144,8 +141,8 @@ void InlinesContainerLayouter::prepare_line()
 
     bool fBreak = false;
 
-    LOMSE_LOG_TRACE(Logger::k_layout, str(boost::format("available space=%.02f")
-                                          % m_availableSpace ));
+    LOMSE_LOG_TRACE(Logger::k_layout, format("available space=%.02f",
+                                          m_availableSpace ));
 
     bool fSomethingAdded = false;
     bool fFirstEngrouterOfLine = true;

--- a/src/graphic_model/layouters/lomse_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_layouter.cpp
@@ -90,8 +90,8 @@ GmoBox* Layouter::start_new_page()
 //---------------------------------------------------------------------------------------
 void Layouter::layout_item(ImoContentObj* pItem, GmoBox* pParentBox, int constrains)
 {
-    LOMSE_LOG_DEBUG(Logger::k_layout, str(boost::format(
-        "Laying out id %d %s") % pItem->get_id() % pItem->get_name() ));
+    LOMSE_LOG_DEBUG(Logger::k_layout, format(
+        "Laying out id %d %s", pItem->get_id(), pItem->get_name().c_str()));
 
     m_pCurLayouter = create_layouter(pItem);
     m_pCurLayouter->set_constrains(constrains);
@@ -132,9 +132,9 @@ void Layouter::set_cursor_and_available_space()
     m_availableWidth = m_pItemMainBox->get_content_width();
     m_availableHeight = m_pItemMainBox->get_content_height();
 
-    LOMSE_LOG_DEBUG(Logger::k_layout, str(boost::format(
-        "cursor at(%.2f, %.2f), available space(%.2f, %.2f)")
-        % m_pageCursor.x % m_pageCursor.y % m_availableWidth % m_availableHeight ));
+    LOMSE_LOG_DEBUG(Logger::k_layout, format(
+        "cursor at(%.2f, %.2f), available space(%.2f, %.2f)",
+        m_pageCursor.x, m_pageCursor.y, m_availableWidth, m_availableHeight ));
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/lomse_graphical_model.cpp
+++ b/src/graphic_model/lomse_graphical_model.cpp
@@ -175,9 +175,9 @@ void GraphicModel::add_to_map_imo_to_box(GmoBox* pBox)
         map<ImoId, GmoBox*>::const_iterator it = m_imoToBox.find(id);
         if (it != m_imoToBox.end())
         {
-            LOMSE_LOG_ERROR( str( boost::format(
-                "Duplicated Imo id %d. Existing Gmo: %s. Adding Gmo: %s")
-                % id % (it->second)->get_name() % pBox->get_name()) );
+            LOMSE_LOG_ERROR(format(
+                "Duplicated Imo id %d. Existing Gmo: %s. Adding Gmo: %s",
+                id, (it->second)->get_name().c_str(), pBox->get_name().c_str() ));
             //TO_INVESTIGATE: This is nor an error. An Imo can create two
             //boxes (currently DocPage and DocPageContent boxes). Maybe the
             //error is in the implications if this is accepted.
@@ -193,8 +193,8 @@ void GraphicModel::add_to_map_ref_to_box(GmoBox* pBox)
     GmoRef gref = pBox->get_ref();
     if (gref != k_no_gmo_ref)
     {
-        LOMSE_LOG_TRACE(Logger::k_gmodel, str(boost::format("Added (%d, %d) %s")
-            % gref.first % gref.second % pBox->get_name() ));
+        LOMSE_LOG_TRACE(Logger::k_gmodel, format("Added (%d, %d) %s",
+            gref.first, gref.second, pBox->get_name().c_str() ));
         m_ctrolToPtr[gref] = pBox;
     }
 }
@@ -223,8 +223,8 @@ GmoShape* GraphicModel::get_main_shape_for_imo(ImoId id)
         return it->second;
     else
     {
-        LOMSE_LOG_DEBUG(Logger::k_score_player, str(boost::format(
-            "No shape found for Imo id: %d") % id) );
+        LOMSE_LOG_DEBUG(Logger::k_score_player, format(
+            "No shape found for Imo id: %d", id ));
         return nullptr;
     }
 }

--- a/src/gui_controls/lomse_hyperlink_ctrl.cpp
+++ b/src/gui_controls/lomse_hyperlink_ctrl.cpp
@@ -104,7 +104,7 @@ GmoBoxControl* HyperlinkCtrl::layout(LibraryScope& UNUSED(libraryScope), UPoint 
 //---------------------------------------------------------------------------------------
 void HyperlinkCtrl::handle_event(SpEventInfo pEvent)
 {
-    LOMSE_LOG_DEBUG(Logger::k_events, str(boost::format("label: %s") % m_label));
+    LOMSE_LOG_DEBUG(Logger::k_events, format("label: %s", m_label.c_str()));
 
     if (m_fEnabled)
     {

--- a/src/gui_controls/lomse_progress_bar_ctrl.cpp
+++ b/src/gui_controls/lomse_progress_bar_ctrl.cpp
@@ -37,8 +37,6 @@
 #include "lomse_calligrapher.h"
 #include "lomse_events.h"
 
-#include <boost/format.hpp>
-
 namespace lomse
 {
 
@@ -115,9 +113,9 @@ void ProgressBarCtrl::set_value(float value)
         m_percent = 0.0f;
 
     if (m_fDisplayPercentage)
-        m_label = str( boost::format("%.01f%%") % (m_percent * 100.0f));
+        m_label = format("%.01f%%", (m_percent * 100.0f));
     else
-        m_label = str( boost::format("%.0f") % value);
+        m_label = format("%.0f", value);
 
     if (m_pMainBox)
         m_pMainBox->set_dirty(true);

--- a/src/gui_controls/lomse_score_player_ctrl.cpp
+++ b/src/gui_controls/lomse_score_player_ctrl.cpp
@@ -148,8 +148,8 @@ void ScorePlayerCtrl::handle_event(SpEventInfo pEvent)
         }
         else
         {
-            LOMSE_LOG_WARN(str(boost::format("Unknown event received. Type=%d")
-                            % pEvent->get_event_type()) );
+            LOMSE_LOG_WARN(format("Unknown event received. Type=%d",
+                               pEvent->get_event_type() ));
         }
     }
 }

--- a/src/internal_model/lomse_score_utilities.cpp
+++ b/src/internal_model/lomse_score_utilities.cpp
@@ -34,7 +34,6 @@
 #include "lomse_logger.h"
 
 //other
-#include <boost/format.hpp>
 #include <cmath>                //for fabs
 
 using namespace std;
@@ -68,8 +67,8 @@ int get_beat_position(TimeUnits timePos, ImoTimeSignature* pTS)
         case 16: beatDuration = int( to_duration(k_eighth, 0) ); break;
         default:
         {
-            string msg = str( boost::format("[get_beat_position] BeatType %d unknown.")
-                              % beatType );
+            string msg = format("[get_beat_position] BeatType %d unknown.",
+                              beatType );
             LOMSE_LOG_ERROR(msg);
             throw runtime_error(msg);
         }
@@ -110,9 +109,9 @@ TimeUnits get_duration_for_ref_note(int bottomNumber)
             return pow(2.0, (10 - k_64th));
         default:
         {
-            string msg = str( boost::format(
-                                "[get_duration_for_ref_note] Invalid bottom number %d")
-                                % bottomNumber );
+            string msg = format(
+                             "[get_duration_for_ref_note] Invalid bottom number %d",
+                             bottomNumber );
             LOMSE_LOG_ERROR(msg);
             throw runtime_error(msg);
         }
@@ -249,9 +248,9 @@ void get_accidentals_for_key(int keyType, int nAccidentals[])
             break;
         default:
         {
-            string msg = str( boost::format(
-                                "[get_accidentals_for_key] Invalid key signature %d")
-                                % keyType );
+            string msg = format(
+                             "[get_accidentals_for_key] Invalid key signature %d",
+                             keyType );
             LOMSE_LOG_ERROR(msg);
             throw runtime_error(msg);
         }
@@ -315,9 +314,9 @@ int get_step_for_root_note(EKeySignature keyType)
 
         default:
         {
-            string msg = str( boost::format(
-                                "[get_step_for_root_note] Invalid key signature %d")
-                                % keyType );
+            string msg = format(
+                             "[get_step_for_root_note] Invalid key signature %d",
+                             keyType );
             LOMSE_LOG_ERROR(msg);
             throw runtime_error(msg);
         }
@@ -410,9 +409,9 @@ int key_signature_to_num_fifths(int keyType)
             break;
         default:
         {
-            string msg = str( boost::format(
-                                "[key_signature_to_num_fifths] Invalid key signature %d")
-                                % keyType );
+            string msg = format(
+                             "[key_signature_to_num_fifths] Invalid key signature %d",
+                             keyType );
             LOMSE_LOG_ERROR(msg);
             throw runtime_error(msg);
         }
@@ -456,9 +455,9 @@ EKeySignature get_relative_minor_key(EKeySignature nMajorKey)
             return k_key_af;
         default:
         {
-            string msg = str( boost::format(
-                                "[get_relative_minor_key] Invalid key signature %d")
-                                % nMajorKey );
+            string msg = format(
+                             "[get_relative_minor_key] Invalid key signature %d",
+                             nMajorKey );
             LOMSE_LOG_ERROR(msg);
             throw runtime_error(msg);
         }
@@ -502,9 +501,9 @@ EKeySignature get_relative_major_key(EKeySignature nMinorKey)
             return k_key_Cf;
         default:
         {
-            string msg = str( boost::format(
-                                "[get_relative_major_key] Invalid key signature %d")
-                                % nMinorKey );
+            string msg = format(
+                             "[get_relative_major_key] Invalid key signature %d",
+                             nMinorKey );
             LOMSE_LOG_ERROR(msg);
             //throw runtime_error(msg);
             return k_key_c;
@@ -547,9 +546,9 @@ DiatonicPitch get_diatonic_pitch_for_first_line(EClef nClef)
         case k_clef_percussion:   return NO_DPITCH;
         default:
         {
-            string msg = str( boost::format(
-                                "[get_diatonic_pitch_for_first_line] Invalid clef %d")
-                                % nClef );
+            string msg = format(
+                             "[get_diatonic_pitch_for_first_line] Invalid clef %d",
+                             nClef );
             LOMSE_LOG_ERROR(msg);
             throw runtime_error(msg);
         }

--- a/src/module/lomse_logger.cpp
+++ b/src/module/lomse_logger.cpp
@@ -29,6 +29,8 @@
 
 #include "lomse_logger.h"
 
+#include <algorithm> // min
+#include <stdarg.h> // va_start, va_end
 using namespace std;
 
 
@@ -107,5 +109,27 @@ void Logger::log_trace(const string& file, int line, const string& prettyFunctio
         log_message(file, line, prettyFunction, "TRACE: ", msg);
 }
 
+std::string format(const char* fmtstr, ...)
+{
+    va_list ap;
+    va_start(ap, fmtstr);
+
+    va_list ap2;
+    va_copy(ap2, ap);
+
+    int newLen = vsnprintf(nullptr, 0, fmtstr, ap);
+    if (newLen < 0)
+    {
+        throw std::invalid_argument("Invalid argument to format-function");
+    }
+
+    vector<char> data(newLen + 1);
+    vsnprintf(data.data(), newLen + 1, fmtstr, ap2);
+
+    va_end(ap2);
+    va_end(ap);
+
+    return string(data.data());
+}
 
 }   //namespace lomse

--- a/src/mvc/lomse_graphic_view.cpp
+++ b/src/mvc/lomse_graphic_view.cpp
@@ -693,16 +693,16 @@ void GraphicView::highlight_object(ImoStaffObj* pSO)
     GmoShape* pShape = pGModel->get_main_shape_for_imo(pSO->get_id());
     if (!pShape)
     {
-        LOMSE_LOG_ERROR(str(boost::format("No shape found for Imo id: %d")
-                            % pSO->get_id()) );
+        LOMSE_LOG_ERROR(format("No shape found for Imo id: %d",
+                            pSO->get_id() ));
         return;
     }
     if (! (pShape->is_shape_notehead()
            || pShape->is_shape_note()
            || pShape->is_shape_rest()) )
-        LOMSE_LOG_ERROR(str(boost::format("Shape is neither note nor rest. Shape type: %s, Imo id=%d")
-                            % pShape->get_name()
-                            % pSO->get_id() ));
+        LOMSE_LOG_ERROR(format("Shape is neither note nor rest. Shape type: %s, Imo id=%d",
+                            pShape->get_name().c_str(),
+                            pSO->get_id() ));
 
     m_pHighlighted->add_highlight( pShape );
 }

--- a/src/mvc/lomse_interactor.cpp
+++ b/src/mvc/lomse_interactor.cpp
@@ -54,9 +54,6 @@
 #include <sstream>
 using namespace std;
 
-//other
-#include <boost/format.hpp>
-
 namespace lomse
 {
 
@@ -471,25 +468,25 @@ void Interactor::task_action_mouse_in_out(Pixels x, Pixels y,
 
     GmoRef gref = find_event_originator_gref(pGmo);
 
-    LOMSE_LOG_DEBUG(Logger::k_events, str(boost::format(
-        "Gmo %d, %s / gref(%d, %d) -------------------")
-         % pGmo->get_gmobj_type() % pGmo->get_name()
-         % gref.first % gref.second ));
+    LOMSE_LOG_DEBUG(Logger::k_events, format(
+        "Gmo %d, %s / gref(%d, %d) -------------------",
+         pGmo->get_gmobj_type(), pGmo->get_name().c_str(),
+         gref.first, gref.second ));
 
     if (m_grefLastMouseOver != k_no_gmo_ref && m_grefLastMouseOver != gref)
     {
-        LOMSE_LOG_DEBUG(Logger::k_events, str(boost::format(
-            "Mouse out. gref(%d %d)")
-            % m_grefLastMouseOver.first % m_grefLastMouseOver.second ));
+        LOMSE_LOG_DEBUG(Logger::k_events, format(
+            "Mouse out. gref(%d %d)",
+            m_grefLastMouseOver.first, m_grefLastMouseOver.second ));
         send_mouse_out_event(m_grefLastMouseOver, x, y);
         m_grefLastMouseOver = k_no_gmo_ref;
     }
 
     if (m_grefLastMouseOver == k_no_gmo_ref && gref != k_no_gmo_ref)
     {
-        LOMSE_LOG_DEBUG(Logger::k_events, str(boost::format(
-            "Mouse in. gref(%d %d)")
-            % gref.first % gref.second ));
+        LOMSE_LOG_DEBUG(Logger::k_events, format(
+            "Mouse in. gref(%d %d)",
+            gref.first, gref.second ));
         send_mouse_in_event(gref, x, y);
         m_grefLastMouseOver = gref;
     }
@@ -1356,10 +1353,10 @@ bool Interactor::discard_score_highlight_event_if_not_valid(SpEventScoreHighligh
 
     if (!pScore || !pScore->is_score())
     {
-        LOMSE_LOG_DEBUG(Logger::k_events, str(boost::format(
-            "Highlight discarded: score id: %d, pScore? %s")
-             % pEvent->get_score_id()
-             % (pScore ? "not null" : "null") ));
+        LOMSE_LOG_DEBUG(Logger::k_events, format(
+            "Highlight discarded: score id: %d, pScore? %s",
+            pEvent->get_score_id(),
+            (pScore ? "not null" : "null") ));
 
         discard_all_highlight();
         return true;
@@ -1424,8 +1421,8 @@ void Interactor::on_visual_highlight(SpEventScoreHighlight pEvent)
 
                 default:
                 {
-                    string msg = str( boost::format("Unknown event type %d.")
-                                    % (*it).first );
+                    string msg = format("Unknown event type %d.",
+                                     (*it).first );
                     LOMSE_LOG_ERROR(msg);
                     throw runtime_error(msg);
                 }
@@ -1596,8 +1593,8 @@ void Interactor::find_parent_link_box_and_notify_event(SpEventInfo pEvent, GmoOb
 {
     while(pGmo && !pGmo->is_box_link())
     {
-        LOMSE_LOG_DEBUG(Logger::k_events, str( boost::format("Gmo type: %d, %s")
-                    % pGmo->get_gmobj_type() % pGmo->get_name() ) );
+        LOMSE_LOG_DEBUG(Logger::k_events, format("Gmo type: %d, %s",
+                    pGmo->get_gmobj_type(), pGmo->get_name().c_str() ));
         pGmo = pGmo->get_owner_box();
     }
 

--- a/src/parser/mnx/lomse_mnx_analyser.cpp
+++ b/src/parser/mnx/lomse_mnx_analyser.cpp
@@ -2225,9 +2225,9 @@ protected:
 
                 default:
                 {
-                    string msg = str( boost::format(
-                                        "Invalid number of fifths %d")
-                                        % fifths );
+                    string msg = format(
+                                     "Invalid number of fifths %d",
+                                     fifths );
                     error_msg(msg);
     //                LOMSE_LOG_ERROR(msg);
     //                throw runtime_error(msg);
@@ -2276,9 +2276,9 @@ protected:
 
                 default:
                 {
-                    string msg = str( boost::format(
-                                        "Invalid number of fifths %d")
-                                        % fifths );
+                    string msg = format(
+                                     "Invalid number of fifths %d",
+                                     fifths );
                     error_msg(msg);
     //                LOMSE_LOG_ERROR(msg);
     //                throw runtime_error(msg);

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -3160,9 +3160,9 @@ protected:
 
                 default:
                 {
-                    string msg = str( boost::format(
-                                        "Invalid number of fifths %d")
-                                        % fifths );
+                    string msg = format(
+                                     "Invalid number of fifths %d",
+                                     fifths );
                     error_msg(msg);
     //                LOMSE_LOG_ERROR(msg);
     //                throw runtime_error(msg);
@@ -3211,9 +3211,9 @@ protected:
 
                 default:
                 {
-                    string msg = str( boost::format(
-                                        "Invalid number of fifths %d")
-                                        % fifths );
+                    string msg = format(
+                                     "Invalid number of fifths %d",
+                                     fifths );
                     error_msg(msg);
     //                LOMSE_LOG_ERROR(msg);
     //                throw runtime_error(msg);

--- a/src/sound/lomse_midi_table.cpp
+++ b/src/sound/lomse_midi_table.cpp
@@ -39,8 +39,6 @@
 #include "lomse_score_utilities.h"
 #include "lomse_im_attributes.h"
 
-#include <boost/format.hpp>
-
 using namespace std;
 
 namespace lomse
@@ -538,8 +536,8 @@ string SoundEventsTable::dump_events_table()
 
             //list current entry
             SoundEvent* pSE = m_events[i];
-            msg += str( boost::format("%4d:\t%d\t\t%d\t%d\t") %
-                        i % pSE->DeltaTime % pSE->Channel % pSE->Measure );
+            msg += format("%4d:\t%ld\t\t%d\t%d\t",
+                       i, pSE->DeltaTime, pSE->Channel, pSE->Measure );
 
             bool fAddData = true;
             switch (pSE->EventType)
@@ -571,11 +569,11 @@ string SoundEventsTable::dump_events_table()
                     fAddData = false;
                     break;
                 default:
-                    msg += str( boost::format("?? %d") % pSE->EventType );
+                    msg += format("?? %d", pSE->EventType );
             }
             if (fAddData)
-                msg += str( boost::format("\t%d\t%d\t%d\n") %
-                            pSE->NotePitch % pSE->NoteStep % pSE->Volume );
+                msg += format("\t%d\t%d\t%d\n",
+                           pSE->NotePitch, pSE->NoteStep, pSE->Volume );
         }
 
     return msg;
@@ -589,9 +587,8 @@ string SoundEventsTable::dump_measures_table()
 
     // measures start time table and first event for each measure
     int num = int(m_measures.size()) - 2;
-    string msg =
-        str( boost::format("\n\nMeasures start times and first event (%d measures)\n\n")
-                           % num );
+    string msg = format("\n\nMeasures start times and first event (%d measures)\n\n",
+                     num );
     msg += "Num.\tTime\tEvent\n";
     for(int i=1; i < int(m_measures.size()); i++)
     {
@@ -603,10 +600,10 @@ string SoundEventsTable::dump_measures_table()
         if (nEntry >= 0)
         {
             SoundEvent* pSE = m_events[nEntry];
-            msg += str( boost::format("%4d:\t%d\t%d\n") % i % pSE->DeltaTime % nEntry );
+            msg += format("%4d:\t%ld\t%d\n", i, pSE->DeltaTime, nEntry );
         }
         else
-            msg += str( boost::format("%4d:\tEmpty entry\n") % i );
+            msg += format("%4d:\tEmpty entry\n", i );
     }
 
     return msg;


### PR DESCRIPTION
This is an alternative solution for replacing `boost::format`.
Related issue: #142.

Our own format function:
```C++
    std::string format(const char* fmtstr, ...);
```

I've placed it into `lomse_logger.h/.cpp`. Is that a proper place?

Usage:

#### was:
```C++
    LOMSE_LOG_TRACE(Logger::k_layout, str(boost::format(
        "Trying to create the EngroutersCreator for Imo id %d %s")
        % pImo->get_id() % pImo->get_name() ));
```

#### became:
```C++
    LOMSE_LOG_TRACE(Logger::k_layout, format(
        "Trying to create the EngroutersCreator for Imo id %d %s",
        pImo->get_id(), pImo->get_name().c_str() ));
```

Function `printf` is traditionally considered unsafe because passing parameters of incorrect types (as expected in format string) can cause crashes. However GCC and clang check parameters of printf-family functions and print warnings like this:
```
src/graphic_model/engravers/lomse_engrouters.cpp:92:13: Format specifies type 'int' but the argument has type 'const char *'
       LOMSE_LOG_TRACE(Logger::k_layout, format(
            "Trying to create the EngroutersCreator for Imo id %d %s",
            "test error", pImo->get_name().c_str() ));
            ^~~~~~~~~~~~~~
```

Even better these compilers expand the checks to user defined functions by marking functions with a special attribute:
```C++
    std::string format(const char* fmtstr, ...) __attribute__((format(printf, 1, 2)));
```

All potential issues with formatting arguments are catched at compile time.

