### PR TITLE
Replaced boost::format with standard functions

### DIFF
--- a/src/file_system/lomse_zip_stream.cpp
+++ b/src/file_system/lomse_zip_stream.cpp
@@ -35,6 +35,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <cstring>
+#include <algorithm> // min()
 using namespace std;
 
 namespace lomse

--- a/src/graphic_model/engravers/lomse_engrouters.cpp
+++ b/src/graphic_model/engravers/lomse_engrouters.cpp
@@ -40,7 +40,6 @@
 #include "lomse_logger.h"
 
 //other
-#include <boost/format.hpp>
 #include "utf8.h"
 
 namespace lomse
@@ -88,17 +87,17 @@ Engrouter* EngroutersCreator::create_next_engrouter(LUnits maxSpace, bool fFirst
     if (!is_there_a_pending_engrouter())
     {
         ImoInlineLevelObj* pImo = static_cast<ImoInlineLevelObj*>( *m_itCurContent );
-        LOMSE_LOG_TRACE(Logger::k_layout, str(boost::format(
-            "Trying to create the EngroutersCreator for Imo id %d %s")
-            % pImo->get_id() % pImo->get_name() ));
+        LOMSE_LOG_TRACE(Logger::k_layout,
+            "Trying to create the EngroutersCreator for Imo id %d %s",
+            pImo->get_id(), pImo->get_name().c_str() );
 
         //composite content objects
         if (pImo->is_text_item())
         {
             ImoTextItem* pText = static_cast<ImoTextItem*>(pImo);
             pEngr = create_next_text_engrouter_for(pText, maxSpace, fFirstOfLine);
-            LOMSE_LOG_TRACE(Logger::k_layout, str(boost::format(
-                "Text item [%s]") % pText->get_text() ));
+            LOMSE_LOG_TRACE(Logger::k_layout,
+                "Text item [%s]", pText->get_text().c_str() );
         }
         else if (pImo->is_box_inline())
         {
@@ -130,9 +129,9 @@ Engrouter* EngroutersCreator::create_next_engrouter(LUnits maxSpace, bool fFirst
             return pEngr;
         else
         {
-            LOMSE_LOG_TRACE(Logger::k_layout, str(boost::format(
-                "Not enough space for engrouter. Needed=%.02f, available=%.02f")
-                % width % maxSpace ));
+            LOMSE_LOG_TRACE(Logger::k_layout,
+                "Not enough space for engrouter. Needed=%.02f, available=%.02f",
+                width, maxSpace );
             save_engrouter_for_next_call(pEngr);
             return nullptr;
         }
@@ -163,12 +162,12 @@ Engrouter* EngroutersCreator::create_engrouter_for(ImoInlineLevelObj* pImo)
     }
     else
     {
-        string msg = str( boost::format(
-                            "[EngroutersCreator::create_engrouter_for] invalid object %d")
-                            % pImo->get_obj_type() );
-        cout << "Throw: " << msg << endl;
-        LOMSE_LOG_ERROR(msg);
-        throw std::runtime_error(msg);
+        stringstream msg;
+        msg << "[EngroutersCreator::create_engrouter_for] invalid object " <<
+               pImo->get_obj_type();
+        cout << "Throw: " << msg.str() << endl;
+        LOMSE_LOG_ERROR(msg.str());
+        throw std::runtime_error(msg.str());
     }
 }
 

--- a/src/graphic_model/engravers/lomse_metronome_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_metronome_engraver.cpp
@@ -37,9 +37,6 @@
 #include "lomse_shape_text.h"
 #include "lomse_logger.h"
 
-//other
-#include <boost/format.hpp>
-
 using namespace std;
 
 namespace lomse
@@ -78,11 +75,11 @@ GmoShape* MetronomeMarkEngraver::create_shape(ImoMetronomeMark* pImo, UPoint uPo
             return create_shape_mm_value();
         default:
         {
-            string msg = str( boost::format(
-                            "[MetronomeMarkEngraver::create_shape] invalid mark type %d")
-                            % markType );
-            LOMSE_LOG_ERROR(msg);
-            throw runtime_error(msg);
+            stringstream msg;
+            msg << "[MetronomeMarkEngraver::create_shape] invalid mark type " <<
+                   markType ;
+            LOMSE_LOG_ERROR(msg.str());
+            throw runtime_error(msg.str());
         }
     }
 }
@@ -94,9 +91,9 @@ GmoShape* MetronomeMarkEngraver::create_shape_mm_value()
     int ticksPerMinute = m_pCreatorImo->get_ticks_per_minute();
     bool fParenthesis = m_pCreatorImo->has_parenthesis();
 
-    string msg = str( fParenthesis ? boost::format("(M.M. = %d)") % ticksPerMinute
-                                   : boost::format("M.M. = %d") % ticksPerMinute );
-    create_text_shape(msg);
+    stringstream msg;
+    msg << (fParenthesis ? "(" : "") << "M.M. = " << ticksPerMinute << (fParenthesis ? ")" : "");
+    create_text_shape(msg.str());
     return m_pMainShape;
 }
 
@@ -132,9 +129,9 @@ GmoShape* MetronomeMarkEngraver::create_shape_note_value()
     if (fParenthesis)
         create_text_shape("(");
     create_symbol_shape(leftNoteType, leftDots);
-    string msg = str( fParenthesis ? boost::format(" = %d)") % ticksPerMinute
-                                   : boost::format(" = %d") % ticksPerMinute );
-    create_text_shape(msg);
+    stringstream msg;
+    msg << " = " << ticksPerMinute << (fParenthesis ? ")" : "");
+    create_text_shape(msg.str());
     return m_pMainShape;
 }
 
@@ -211,11 +208,10 @@ int MetronomeMarkEngraver::select_glyph(int noteType)
             return k_glyph_small_256th_note;
         default:
         {
-            string msg = str( boost::format(
-                            "[MetronomeMarkEngraver::select_glyph] invalid note type %d")
-                            % noteType );
-            LOMSE_LOG_ERROR(msg);
-            throw runtime_error(msg);
+            stringstream msg;
+            msg << "[MetronomeMarkEngraver::select_glyph] invalid note type " << noteType;
+            LOMSE_LOG_ERROR(msg.str());
+            throw runtime_error(msg.str());
         }
     }
 }

--- a/src/graphic_model/engravers/lomse_time_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_time_engraver.cpp
@@ -76,11 +76,11 @@ GmoShape* TimeEngraver::create_shape(ImoTimeSignature* pCreatorImo, UPoint uPos,
     }
     else
     {
-        string msg = str( boost::format(
-                        "[TimeEngraver::create_shape] unsupported time signature type %d")
-                        % pCreatorImo->get_type() );
-        LOMSE_LOG_ERROR(msg);
-        throw runtime_error(msg);
+        stringstream msg;
+        msg << "[TimeEngraver::create_shape] unsupported time signature type " <<
+               pCreatorImo->get_type() ;
+        LOMSE_LOG_ERROR(msg.str());
+        throw runtime_error(msg.str());
     }
 }
 

--- a/src/graphic_model/layouters/lomse_inlines_container_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_inlines_container_layouter.cpp
@@ -39,9 +39,6 @@
 #include "lomse_blocks_container_layouter.h"
 #include "lomse_logger.h"
 
-//other
-#include <boost/format.hpp>
-
 namespace lomse
 {
 
@@ -144,8 +141,7 @@ void InlinesContainerLayouter::prepare_line()
 
     bool fBreak = false;
 
-    LOMSE_LOG_TRACE(Logger::k_layout, str(boost::format("available space=%.02f")
-                                          % m_availableSpace ));
+    LOMSE_LOG_TRACE(Logger::k_layout, "available space=%.02f", m_availableSpace);
 
     bool fSomethingAdded = false;
     bool fFirstEngrouterOfLine = true;

--- a/src/graphic_model/layouters/lomse_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_layouter.cpp
@@ -90,8 +90,8 @@ GmoBox* Layouter::start_new_page()
 //---------------------------------------------------------------------------------------
 void Layouter::layout_item(ImoContentObj* pItem, GmoBox* pParentBox, int constrains)
 {
-    LOMSE_LOG_DEBUG(Logger::k_layout, str(boost::format(
-        "Laying out id %d %s") % pItem->get_id() % pItem->get_name() ));
+    LOMSE_LOG_DEBUG(Logger::k_layout,
+        "Laying out id %d %s", pItem->get_id(), pItem->get_name().c_str());
 
     m_pCurLayouter = create_layouter(pItem);
     m_pCurLayouter->set_constrains(constrains);
@@ -132,9 +132,9 @@ void Layouter::set_cursor_and_available_space()
     m_availableWidth = m_pItemMainBox->get_content_width();
     m_availableHeight = m_pItemMainBox->get_content_height();
 
-    LOMSE_LOG_DEBUG(Logger::k_layout, str(boost::format(
-        "cursor at(%.2f, %.2f), available space(%.2f, %.2f)")
-        % m_pageCursor.x % m_pageCursor.y % m_availableWidth % m_availableHeight ));
+    LOMSE_LOG_DEBUG(Logger::k_layout,
+        "cursor at(%.2f, %.2f), available space(%.2f, %.2f)",
+        m_pageCursor.x, m_pageCursor.y, m_availableWidth, m_availableHeight);
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/lomse_graphical_model.cpp
+++ b/src/graphic_model/lomse_graphical_model.cpp
@@ -175,9 +175,9 @@ void GraphicModel::add_to_map_imo_to_box(GmoBox* pBox)
         map<ImoId, GmoBox*>::const_iterator it = m_imoToBox.find(id);
         if (it != m_imoToBox.end())
         {
-            LOMSE_LOG_ERROR( str( boost::format(
-                "Duplicated Imo id %d. Existing Gmo: %s. Adding Gmo: %s")
-                % id % (it->second)->get_name() % pBox->get_name()) );
+            LOMSE_LOG_ERROR(
+                "Duplicated Imo id %d. Existing Gmo: %s. Adding Gmo: %s",
+                id, (it->second)->get_name().c_str(), pBox->get_name().c_str() );
             //TO_INVESTIGATE: This is nor an error. An Imo can create two
             //boxes (currently DocPage and DocPageContent boxes). Maybe the
             //error is in the implications if this is accepted.
@@ -193,8 +193,8 @@ void GraphicModel::add_to_map_ref_to_box(GmoBox* pBox)
     GmoRef gref = pBox->get_ref();
     if (gref != k_no_gmo_ref)
     {
-        LOMSE_LOG_TRACE(Logger::k_gmodel, str(boost::format("Added (%d, %d) %s")
-            % gref.first % gref.second % pBox->get_name() ));
+        LOMSE_LOG_TRACE(Logger::k_gmodel, "Added (%d, %d) %s",
+            gref.first, gref.second, pBox->get_name().c_str() );
         m_ctrolToPtr[gref] = pBox;
     }
 }
@@ -223,8 +223,8 @@ GmoShape* GraphicModel::get_main_shape_for_imo(ImoId id)
         return it->second;
     else
     {
-        LOMSE_LOG_DEBUG(Logger::k_score_player, str(boost::format(
-            "No shape found for Imo id: %d") % id) );
+        LOMSE_LOG_DEBUG(Logger::k_score_player,
+            "No shape found for Imo id: %d", id );
         return nullptr;
     }
 }

--- a/src/gui_controls/lomse_hyperlink_ctrl.cpp
+++ b/src/gui_controls/lomse_hyperlink_ctrl.cpp
@@ -104,7 +104,7 @@ GmoBoxControl* HyperlinkCtrl::layout(LibraryScope& UNUSED(libraryScope), UPoint 
 //---------------------------------------------------------------------------------------
 void HyperlinkCtrl::handle_event(SpEventInfo pEvent)
 {
-    LOMSE_LOG_DEBUG(Logger::k_events, str(boost::format("label: %s") % m_label));
+    LOMSE_LOG_DEBUG(Logger::k_events, "label: %s", m_label.c_str());
 
     if (m_fEnabled)
     {

--- a/src/gui_controls/lomse_progress_bar_ctrl.cpp
+++ b/src/gui_controls/lomse_progress_bar_ctrl.cpp
@@ -37,8 +37,6 @@
 #include "lomse_calligrapher.h"
 #include "lomse_events.h"
 
-#include <boost/format.hpp>
-
 namespace lomse
 {
 
@@ -114,10 +112,12 @@ void ProgressBarCtrl::set_value(float value)
     else
         m_percent = 0.0f;
 
+    stringstream ss;
     if (m_fDisplayPercentage)
-        m_label = str( boost::format("%.01f%%") % (m_percent * 100.0f));
+        ss << fixed << setprecision(1) << (m_percent * 100.0f) << "%";
     else
-        m_label = str( boost::format("%.0f") % value);
+        ss << fixed << setprecision(0) << value;
+    m_label = ss.str();
 
     if (m_pMainBox)
         m_pMainBox->set_dirty(true);

--- a/src/gui_controls/lomse_score_player_ctrl.cpp
+++ b/src/gui_controls/lomse_score_player_ctrl.cpp
@@ -148,8 +148,8 @@ void ScorePlayerCtrl::handle_event(SpEventInfo pEvent)
         }
         else
         {
-            LOMSE_LOG_WARN(str(boost::format("Unknown event received. Type=%d")
-                            % pEvent->get_event_type()) );
+            LOMSE_LOG_WARN("Unknown event received. Type=%d",
+                           pEvent->get_event_type() );
         }
     }
 }

--- a/src/internal_model/lomse_score_utilities.cpp
+++ b/src/internal_model/lomse_score_utilities.cpp
@@ -33,8 +33,6 @@
 #include "lomse_im_note.h"
 #include "lomse_logger.h"
 
-//other
-#include <boost/format.hpp>
 #include <cmath>                //for fabs
 
 using namespace std;
@@ -68,10 +66,10 @@ int get_beat_position(TimeUnits timePos, ImoTimeSignature* pTS)
         case 16: beatDuration = int( to_duration(k_eighth, 0) ); break;
         default:
         {
-            string msg = str( boost::format("[get_beat_position] BeatType %d unknown.")
-                              % beatType );
-            LOMSE_LOG_ERROR(msg);
-            throw runtime_error(msg);
+            stringstream ss;
+            ss << "[get_beat_position] BeatType " << beatType << " unknown.";
+            LOMSE_LOG_ERROR(ss.str());
+            throw runtime_error(ss.str());
         }
     }
 
@@ -110,11 +108,10 @@ TimeUnits get_duration_for_ref_note(int bottomNumber)
             return pow(2.0, (10 - k_64th));
         default:
         {
-            string msg = str( boost::format(
-                                "[get_duration_for_ref_note] Invalid bottom number %d")
-                                % bottomNumber );
-            LOMSE_LOG_ERROR(msg);
-            throw runtime_error(msg);
+            stringstream ss;
+            ss << "[get_duration_for_ref_note] Invalid bottom number " << bottomNumber;
+            LOMSE_LOG_ERROR(ss.str());
+            throw runtime_error(ss.str());
         }
     }
 }
@@ -249,11 +246,10 @@ void get_accidentals_for_key(int keyType, int nAccidentals[])
             break;
         default:
         {
-            string msg = str( boost::format(
-                                "[get_accidentals_for_key] Invalid key signature %d")
-                                % keyType );
-            LOMSE_LOG_ERROR(msg);
-            throw runtime_error(msg);
+            stringstream ss;
+            ss << "[get_accidentals_for_key] Invalid key signature " << keyType;
+            LOMSE_LOG_ERROR(ss.str());
+            throw runtime_error(ss.str());
         }
     }
 
@@ -315,11 +311,10 @@ int get_step_for_root_note(EKeySignature keyType)
 
         default:
         {
-            string msg = str( boost::format(
-                                "[get_step_for_root_note] Invalid key signature %d")
-                                % keyType );
-            LOMSE_LOG_ERROR(msg);
-            throw runtime_error(msg);
+            stringstream ss;
+            ss << "[get_step_for_root_note] Invalid key signature " << keyType;
+            LOMSE_LOG_ERROR(ss.str());
+            throw runtime_error(ss.str());
         }
     }
 }
@@ -410,11 +405,10 @@ int key_signature_to_num_fifths(int keyType)
             break;
         default:
         {
-            string msg = str( boost::format(
-                                "[key_signature_to_num_fifths] Invalid key signature %d")
-                                % keyType );
-            LOMSE_LOG_ERROR(msg);
-            throw runtime_error(msg);
+            stringstream ss;
+            ss << "[key_signature_to_num_fifths] Invalid key signature " << keyType;
+            LOMSE_LOG_ERROR(ss.str());
+            throw runtime_error(ss.str());
         }
     }
     return nFifths;
@@ -456,11 +450,10 @@ EKeySignature get_relative_minor_key(EKeySignature nMajorKey)
             return k_key_af;
         default:
         {
-            string msg = str( boost::format(
-                                "[get_relative_minor_key] Invalid key signature %d")
-                                % nMajorKey );
-            LOMSE_LOG_ERROR(msg);
-            throw runtime_error(msg);
+            stringstream ss;
+            ss << "[get_relative_minor_key] Invalid key signature " << nMajorKey;
+            LOMSE_LOG_ERROR(ss.str());
+            throw runtime_error(ss.str());
         }
     }
 
@@ -502,11 +495,10 @@ EKeySignature get_relative_major_key(EKeySignature nMinorKey)
             return k_key_Cf;
         default:
         {
-            string msg = str( boost::format(
-                                "[get_relative_major_key] Invalid key signature %d")
-                                % nMinorKey );
-            LOMSE_LOG_ERROR(msg);
-            //throw runtime_error(msg);
+            stringstream ss;
+            ss << "[get_relative_major_key] Invalid key signature " << nMinorKey;
+            LOMSE_LOG_ERROR(ss.str());
+            //throw runtime_error(ss.str());
             return k_key_c;
         }
     }
@@ -547,11 +539,10 @@ DiatonicPitch get_diatonic_pitch_for_first_line(EClef nClef)
         case k_clef_percussion:   return NO_DPITCH;
         default:
         {
-            string msg = str( boost::format(
-                                "[get_diatonic_pitch_for_first_line] Invalid clef %d")
-                                % nClef );
-            LOMSE_LOG_ERROR(msg);
-            throw runtime_error(msg);
+            stringstream ss;
+            ss << "[get_diatonic_pitch_for_first_line] Invalid clef " << nClef;
+            LOMSE_LOG_ERROR(ss.str());
+            throw runtime_error(ss.str());
         }
     }
     return NO_DPITCH;

--- a/src/mvc/lomse_graphic_view.cpp
+++ b/src/mvc/lomse_graphic_view.cpp
@@ -693,16 +693,16 @@ void GraphicView::highlight_object(ImoStaffObj* pSO)
     GmoShape* pShape = pGModel->get_main_shape_for_imo(pSO->get_id());
     if (!pShape)
     {
-        LOMSE_LOG_ERROR(str(boost::format("No shape found for Imo id: %d")
-                            % pSO->get_id()) );
+        LOMSE_LOG_ERROR("No shape found for Imo id: %d",
+                        pSO->get_id() );
         return;
     }
     if (! (pShape->is_shape_notehead()
            || pShape->is_shape_note()
            || pShape->is_shape_rest()) )
-        LOMSE_LOG_ERROR(str(boost::format("Shape is neither note nor rest. Shape type: %s, Imo id=%d")
-                            % pShape->get_name()
-                            % pSO->get_id() ));
+        LOMSE_LOG_ERROR("Shape is neither note nor rest. Shape type: %s, Imo id=%d",
+                        pShape->get_name().c_str(),
+                        pSO->get_id() );
 
     m_pHighlighted->add_highlight( pShape );
 }

--- a/src/mvc/lomse_interactor.cpp
+++ b/src/mvc/lomse_interactor.cpp
@@ -54,9 +54,6 @@
 #include <sstream>
 using namespace std;
 
-//other
-#include <boost/format.hpp>
-
 namespace lomse
 {
 
@@ -117,9 +114,7 @@ Interactor::~Interactor()
 //---------------------------------------------------------------------------------------
 void Interactor::switch_task(int taskType)
 {
-    stringstream s;
-    s << "new task type=" << taskType;
-    LOMSE_LOG_DEBUG(Logger::k_mvc, s.str());
+    LOMSE_LOG_DEBUG(Logger::k_mvc, "new task type=%d", taskType);
 
     delete m_pTask;
     m_pTask = Injector::inject_Task(taskType, this);
@@ -171,9 +166,7 @@ void Interactor::create_graphic_model()
         timing_graphic_model_build_end();
 
         double buildTime = get_elapsed_time_since(m_gmodelBuildStartTime);
-        stringstream msg;
-        msg << "gmodel build time = " << buildTime << " ms.";
-        LOMSE_LOG_INFO(msg.str());
+        LOMSE_LOG_INFO("gmodel build time = %d ms.", (int)buildTime);
     }
 //    m_idLastMouseOver = k_no_imoid;
 }
@@ -471,25 +464,25 @@ void Interactor::task_action_mouse_in_out(Pixels x, Pixels y,
 
     GmoRef gref = find_event_originator_gref(pGmo);
 
-    LOMSE_LOG_DEBUG(Logger::k_events, str(boost::format(
-        "Gmo %d, %s / gref(%d, %d) -------------------")
-         % pGmo->get_gmobj_type() % pGmo->get_name()
-         % gref.first % gref.second ));
+    LOMSE_LOG_DEBUG(Logger::k_events,
+        "Gmo %d, %s / gref(%d, %d) -------------------",
+         pGmo->get_gmobj_type(), pGmo->get_name().c_str(),
+         gref.first, gref.second );
 
     if (m_grefLastMouseOver != k_no_gmo_ref && m_grefLastMouseOver != gref)
     {
-        LOMSE_LOG_DEBUG(Logger::k_events, str(boost::format(
-            "Mouse out. gref(%d %d)")
-            % m_grefLastMouseOver.first % m_grefLastMouseOver.second ));
+        LOMSE_LOG_DEBUG(Logger::k_events,
+            "Mouse out. gref(%d %d)",
+            m_grefLastMouseOver.first, m_grefLastMouseOver.second );
         send_mouse_out_event(m_grefLastMouseOver, x, y);
         m_grefLastMouseOver = k_no_gmo_ref;
     }
 
     if (m_grefLastMouseOver == k_no_gmo_ref && gref != k_no_gmo_ref)
     {
-        LOMSE_LOG_DEBUG(Logger::k_events, str(boost::format(
-            "Mouse in. gref(%d %d)")
-            % gref.first % gref.second ));
+        LOMSE_LOG_DEBUG(Logger::k_events,
+            "Mouse in. gref(%d %d)",
+            gref.first, gref.second );
         send_mouse_in_event(gref, x, y);
         m_grefLastMouseOver = gref;
     }
@@ -1356,10 +1349,10 @@ bool Interactor::discard_score_highlight_event_if_not_valid(SpEventScoreHighligh
 
     if (!pScore || !pScore->is_score())
     {
-        LOMSE_LOG_DEBUG(Logger::k_events, str(boost::format(
-            "Highlight discarded: score id: %d, pScore? %s")
-             % pEvent->get_score_id()
-             % (pScore ? "not null" : "null") ));
+        LOMSE_LOG_DEBUG(Logger::k_events,
+            "Highlight discarded: score id: %d, pScore? %s",
+            pEvent->get_score_id(),
+            (pScore ? "not null" : "null") );
 
         discard_all_highlight();
         return true;
@@ -1424,10 +1417,11 @@ void Interactor::on_visual_highlight(SpEventScoreHighlight pEvent)
 
                 default:
                 {
-                    string msg = str( boost::format("Unknown event type %d.")
-                                    % (*it).first );
-                    LOMSE_LOG_ERROR(msg);
-                    throw runtime_error(msg);
+                    stringstream msg;
+                    msg << "Unknown event type " <<
+                           (*it).first << "." ;
+                    LOMSE_LOG_ERROR(msg.str());
+                    throw runtime_error(msg.str());
                 }
             }
         }
@@ -1596,8 +1590,8 @@ void Interactor::find_parent_link_box_and_notify_event(SpEventInfo pEvent, GmoOb
 {
     while(pGmo && !pGmo->is_box_link())
     {
-        LOMSE_LOG_DEBUG(Logger::k_events, str( boost::format("Gmo type: %d, %s")
-                    % pGmo->get_gmobj_type() % pGmo->get_name() ) );
+        LOMSE_LOG_DEBUG(Logger::k_events, "Gmo type: %d, %s",
+                    pGmo->get_gmobj_type(), pGmo->get_name().c_str() );
         pGmo = pGmo->get_owner_box();
     }
 

--- a/src/parser/mnx/lomse_mnx_analyser.cpp
+++ b/src/parser/mnx/lomse_mnx_analyser.cpp
@@ -2225,12 +2225,12 @@ protected:
 
                 default:
                 {
-                    string msg = str( boost::format(
-                                        "Invalid number of fifths %d")
-                                        % fifths );
-                    error_msg(msg);
-    //                LOMSE_LOG_ERROR(msg);
-    //                throw runtime_error(msg);
+                    stringstream msg;
+                    msg << "Invalid number of fifths " <<
+                           fifths ;
+                    error_msg(msg.str());
+    //                LOMSE_LOG_ERROR(msg.str());
+    //                throw runtime_error(msg.str());
                     return k_key_C;
                 }
             }
@@ -2276,12 +2276,12 @@ protected:
 
                 default:
                 {
-                    string msg = str( boost::format(
-                                        "Invalid number of fifths %d")
-                                        % fifths );
-                    error_msg(msg);
-    //                LOMSE_LOG_ERROR(msg);
-    //                throw runtime_error(msg);
+                    stringstream msg;
+                    msg << "Invalid number of fifths " <<
+                           fifths ;
+                    error_msg(msg.str());
+    //                LOMSE_LOG_ERROR(msg.str());
+    //                throw runtime_error(msg.str());
                     return k_key_a;
                 }
             }

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -3160,12 +3160,12 @@ protected:
 
                 default:
                 {
-                    string msg = str( boost::format(
-                                        "Invalid number of fifths %d")
-                                        % fifths );
-                    error_msg(msg);
-    //                LOMSE_LOG_ERROR(msg);
-    //                throw runtime_error(msg);
+                    stringstream msg;
+                    msg << "Invalid number of fifths " <<
+                           fifths ;
+                    error_msg(msg.str());
+    //                LOMSE_LOG_ERROR(msg.str());
+    //                throw runtime_error(msg.str());
                     return k_key_C;
                 }
             }
@@ -3211,12 +3211,12 @@ protected:
 
                 default:
                 {
-                    string msg = str( boost::format(
-                                        "Invalid number of fifths %d")
-                                        % fifths );
-                    error_msg(msg);
-    //                LOMSE_LOG_ERROR(msg);
-    //                throw runtime_error(msg);
+                    stringstream msg;
+                    msg << "Invalid number of fifths " <<
+                           fifths ;
+                    error_msg(msg.str());
+    //                LOMSE_LOG_ERROR(msg.str());
+    //                throw runtime_error(msg.str());
                     return k_key_a;
                 }
             }

--- a/src/sound/lomse_midi_table.cpp
+++ b/src/sound/lomse_midi_table.cpp
@@ -39,8 +39,6 @@
 #include "lomse_score_utilities.h"
 #include "lomse_im_attributes.h"
 
-#include <boost/format.hpp>
-
 using namespace std;
 
 namespace lomse
@@ -527,58 +525,57 @@ string SoundEventsTable::dump_events_table()
         return "Midi events table is empty";
 
     //headers
-    string msg = "Num.\tTime\t\tCh.\tMeas.\tEvent\t\tPitch\tStep\tVolume\n";
+    stringstream msg;
+    msg << "Num.\tTime\t\tCh.\tMeas.\tEvent\t\tPitch\tStep\tVolume\n";
 
         for(int i=0; i < int(m_events.size()); i++)
         {
             //division line every four entries
             if (i % 4 == 0) {
-                msg += "-------------------------------------------------------------\n";
+                msg << "-------------------------------------------------------------\n";
             }
 
             //list current entry
             SoundEvent* pSE = m_events[i];
-            msg += str( boost::format("%4d:\t%d\t\t%d\t%d\t") %
-                        i % pSE->DeltaTime % pSE->Channel % pSE->Measure );
+            msg << i << ":\t" << pSE->DeltaTime << "\t\t" << pSE->Channel << "\t" << pSE->Measure << "\t";
 
             bool fAddData = true;
             switch (pSE->EventType)
             {
                 case SoundEvent::k_note_on:
-                    msg += "ON        ";
+                    msg << "ON        ";
                     break;
                 case SoundEvent::k_note_off:
-                    msg += "OFF       ";
+                    msg << "OFF       ";
                     break;
                 case SoundEvent::k_visual_on:
-                    msg += "VISUAL ON ";
+                    msg << "VISUAL ON ";
                     break;
                 case SoundEvent::k_visual_off:
-                    msg += "VISUAL OFF";
+                    msg << "VISUAL OFF";
                     break;
                 case SoundEvent::k_end_of_score:
-                    msg += "END TABLE ";
+                    msg << "END TABLE ";
                     break;
                 case SoundEvent::k_rhythm_change:
-                    msg += "RITHM CHG ";
+                    msg << "RITHM CHG ";
                     break;
                 case SoundEvent::k_prog_instr:
-                    msg += "PRG INSTR ";
+                    msg << "PRG INSTR ";
                     break;
                 case SoundEvent::k_jump:
-                    msg += "JUMP      ";
-                    msg += pSE->pJump->dump_entry();
+                    msg << "JUMP      ";
+                    msg << pSE->pJump->dump_entry();
                     fAddData = false;
                     break;
                 default:
-                    msg += str( boost::format("?? %d") % pSE->EventType );
+                    msg << "?? " << pSE->EventType;
             }
             if (fAddData)
-                msg += str( boost::format("\t%d\t%d\t%d\n") %
-                            pSE->NotePitch % pSE->NoteStep % pSE->Volume );
+                msg << "\t" << pSE->NotePitch << "\t" << pSE->NoteStep << "\t" << pSE->Volume << "\n";
         }
 
-    return msg;
+    return msg.str();
 }
 
 //---------------------------------------------------------------------------------------
@@ -587,29 +584,29 @@ string SoundEventsTable::dump_measures_table()
     if (m_measures.size() == 0)
         return "Measures table is empty";
 
+    stringstream msg;
+
     // measures start time table and first event for each measure
     int num = int(m_measures.size()) - 2;
-    string msg =
-        str( boost::format("\n\nMeasures start times and first event (%d measures)\n\n")
-                           % num );
-    msg += "Num.\tTime\tEvent\n";
+    msg << "\n\nMeasures start times and first event (" << num << " measures)\n\n";
+    msg << "Num.\tTime\tEvent\n";
     for(int i=1; i < int(m_measures.size()); i++)
     {
         //division line every four entries
         if (i % 4 == 0)
-            msg += "-------------------------------------------------------------\n";
+            msg << "-------------------------------------------------------------\n";
 
         int nEntry = m_measures[i];
         if (nEntry >= 0)
         {
             SoundEvent* pSE = m_events[nEntry];
-            msg += str( boost::format("%4d:\t%d\t%d\n") % i % pSE->DeltaTime % nEntry );
+            msg << i << ":\t" << pSE->DeltaTime << "\t" << nEntry << "\n";
         }
         else
-            msg += str( boost::format("%4d:\tEmpty entry\n") % i );
+            msg << i << ":\tEmpty entry\n";
     }
 
-    return msg;
+    return msg.str();
 }
 
 //---------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR implements the third alternative of replacing **boost::format** as discussed in #143 and #142.