### PR TITLE
Extended parametrisation of test runner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,6 @@ set( CMAKE_MODULE_PATH "${LOMSE_ROOT_DIR}/cmake-modules" )
 set( FONTS_PATH   "${CMAKE_INSTALL_PREFIX}/share/lomse/fonts" )
 
 # define build options and create the include file "lomse_config.h"
-# note that the file will be updated later when all variables are defined
 include( ${LOMSE_ROOT_DIR}/build-options.cmake )
 
 
@@ -171,22 +170,6 @@ if (LOMSE_BUILD_TESTS)
         link_directories( ${UNITTEST++_LIBRARY} )
         #message("UnitTest++ found: library: ${UNITTEST++_LIBRARY}" )
         #message("UnitTest++ found: include: ${UNITTEST++_INCLUDE_DIR}" )
-        # Check if UnitTest++'s class "Test" has a member named "next",
-        # that would mean UnitTest++ v1.4 or older
-        message(STATUS "Detecting UnitTest++ version")
-        file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/unittest++-version-test.cpp"
-            "#include <UnitTest++.h>\n"
-            "int main() { UnitTest::Test* test; test->next = 0; return 0; }")
-        try_compile(LOMSE_UNITTEST_HAS_NEXT ${CMAKE_CURRENT_BINARY_DIR} "${CMAKE_CURRENT_BINARY_DIR}/unittest++-version-test.cpp"
-            CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${UNITTEST++_INCLUDE_DIR})
-        file(REMOVE "${CMAKE_CURRENT_BINARY_DIR}/unittest++-version-test.cpp")
-        if(LOMSE_UNITTEST_HAS_NEXT)
-            message(STATUS "Detecting UnitTest++ version - done (<1.5)")
-            set(LOMSE_UNITTEST_OLD "1")
-        else()
-            message(STATUS "Detecting UnitTest++ version - done (>=1.5)")
-            set(LOMSE_UNITTEST_OLD "0")
-        endif()
     else()
         message(STATUS "UnitTest++ package not found. Test program will not be built" )
         set (LOMSE_BUILD_TESTS OFF)
@@ -644,19 +627,6 @@ install(FILES  ${CMAKE_CURRENT_BINARY_DIR}/liblomse.pc
         DESTINATION ${LOMSE_PKG_CONFIG_INSTALL} )
 
 message(STATUS "pkg-config install path: ${LOMSE_PKG_CONFIG_INSTALL}" )
-
-
-###############################################################################
-#
-# Configuration of library and testlib is completed. Updating config file.
-#
-###############################################################################
-
-# update include file "lomse_config.h"
-configure_file(
-    "${LOMSE_ROOT_DIR}/lomse_config.h.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/lomse_config.h"
-)
 
 
 ###############################################################################

--- a/lomse_config.h.cmake
+++ b/lomse_config.h.cmake
@@ -49,7 +49,6 @@
 #define LOMSE_PLATFORM_WIN32      @LOMSE_PLATFORM_WIN32@
 #define LOMSE_PLATFORM_UNIX       @LOMSE_PLATFORM_UNIX@
 #define LOMSE_COMPILER_MSVC       @LOMSE_COMPILER_MSVC@
-#define LOMSE_UNITTEST_OLD        @LOMSE_UNITTEST_OLD@
 
 
 //---------------------------------------------------------------------------------------

--- a/src/tests/lomse_the_test_runner.cpp
+++ b/src/tests/lomse_the_test_runner.cpp
@@ -40,19 +40,85 @@ using namespace std;
 using namespace lomse;
 using namespace UnitTest;
 
+const char* basefilename(const char* fullfilename)
+{
+    const char* onlyFilenamePosix = strrchr(fullfilename, '/');
+    const char* onlyFilenameWin = strrchr(fullfilename, '\\');
+    const char* basename = std::max(onlyFilenamePosix, onlyFilenameWin) + 1;
+    return basename;
+}
+
+class MyTestReporterStdout : public UnitTest::TestReporterStdout
+{
+public:
+    MyTestReporterStdout(bool verbose) : m_verbose(verbose) {}
+
+    void ReportTestStart(TestDetails const& test) override
+    {
+        if (m_verbose)
+        {
+            printf("%s / %s / %s\n", basefilename(test.filename), test.suiteName, test.testName);
+        }
+    }
+
+    void ReportFailure(TestDetails const& test, char const* failure) override
+    {
+        if (m_verbose)
+        {
+            printf("    Failure at line %d: %s\n", test.lineNumber, failure);
+        }
+        else
+        {
+            printf("%s(%d): Failure in %s / %s: %s\n",
+                basefilename(test.filename), test.lineNumber, test.suiteName, test.testName, failure);
+        }
+    }
+
+    void ReportSummary(int totalTestCount, int failedTestCount,
+        int failureCount, float secondsElapsed) override
+    {
+        if (failureCount > 0)
+            printf("\nFailure: %d out of %d tests failed (%d failures).\n", failedTestCount, totalTestCount, failureCount);
+        else
+            printf("\nSuccess: %d tests passed.\n", totalTestCount);
+
+        printf("Test time: %.2f seconds.\n", secondsElapsed);
+    }
+
+private:
+    bool m_verbose;
+    string m_lastFailed;
+};
+
+bool TestMatches(TestDetails const& test, const string& name)
+{
+    return name == test.suiteName || name == test.testName ||
+        name == basefilename(test.filename);
+}
+
 int main(int argc, char** argv)
 {
-    //Based on code published here:
-    //  http://stackoverflow.com/questions/3546054/how-do-i-run-a-single-test-with-unittest
-    //
     //invoke without arguments to run all tests:
     //  testlib
     //
     //invoke with arguments to run a single test:
     //  testlib MyTestName
     //
-    //or single suite
-    //  testlib suite MySuite
+    //or single suite:
+    //  testlib MySuite
+    //
+    //or single filename:
+    //  testlib filename.cpp
+    //
+    //exclude Test/Suite/filename:
+    //  testlib -MyTestNameOrSuiteNameOrFilename
+    //
+    //verbose output:
+    //  testlib -v
+    //  testlib --verbose
+    //  testlib -v MyTestName
+    //  testlib -v MySuite
+    //  testlib -v filename.cpp
 
     cout << "Lomse version " << LibraryScope::get_version_long_string()
          << ". Library tests runner." << endl << endl;
@@ -60,58 +126,45 @@ int main(int argc, char** argv)
     cout << "Lomse build date: " << LibraryScope::get_build_date() << endl;
     cout << "Path for tests scores: '" << TESTLIB_SCORES_PATH << "'" << endl << endl;
 
+    bool verbose = argc > 1 && (!strcmp(argv[1], "--verbose") || !strcmp(argv[1], "-v"));
+    int nextArg = verbose ? 2 : 1;
+
+    MyTestReporterStdout reporter(verbose);
+    UnitTest::TestRunner runner(reporter);
+
     int nErrors = 0;
 
-    if( argc > 1 )
+    if (argc > nextArg)
     {
-        //if first arg is "suite", we search for suite names instead of test names
-        const bool fSuite = strcmp( "suite", argv[1] ) == 0;
+        cout << "Running some tests " << endl << endl;
 
-        if (fSuite)
-            cout << "Running tests in suite " << argv[2] << endl << endl;
-        else
-            cout << "Running some tests " << endl << endl;
-
-        //walk list of all tests, add those with a name that
-        //matches one of the arguments  to a new TestList
-        const TestList& allTests( Test::GetTestList() );
-        TestList selectedTests;
-        Test* p = allTests.GetHead();
-        while( p )
-        {
-            for( int i = 1 ; i < argc ; ++i )
+        //run only matching tests
+        nErrors = runner.RunTestsIf(Test::GetTestList(), nullptr,
+            [nextArg, argc, argv](Test* p)
             {
-                if( strcmp( fSuite ? p->m_details.suiteName
-                                   : p->m_details.testName, argv[ i ] ) == 0 )
-                    selectedTests.Add( p );
+                bool hasPositiveArgs = false;
+                bool positiveMatch = false;
+                bool negativeMatch = false;
+                for (int i = nextArg ; i < argc ; ++i)
+                {
+                    const char* arg = argv[i];
+                    bool negative = arg[0] == '-';
+                    negativeMatch |= negative && TestMatches(p->m_details, arg + 1);
+                    positiveMatch |= !negative && TestMatches(p->m_details, arg);
+                    hasPositiveArgs |= !negative;
+                }
+                return (!hasPositiveArgs || positiveMatch) && !negativeMatch;
             }
-            Test* q = p;
-
-#if (LOMSE_UNITTEST_OLD == 1)
-            p = p->next;
-            q->next = nullptr;
-#else
-            p = p->m_nextTest;
-            q->m_nextTest = nullptr;
-#endif
-        }
-
-        //run selected test(s) only
-        UnitTest::TestReporterStdout reporter;
-        UnitTest::TestRunner runner( reporter );
-        nErrors = runner.RunTestsIf( selectedTests, 0, True(), 0 );
+            , 0);
     }
     else
     {
         cout << "Running all tests" << endl << endl;
-        nErrors = UnitTest::RunAllTests();
+        nErrors = runner.RunTestsIf(Test::GetTestList(), nullptr, True(), 0);
     }
 
     #if defined WIN32 || defined _WIN32
-        //system("pause");
-        cin.get();
         _CrtDumpMemoryLeaks();
-
     #endif
 
     return nErrors;


### PR DESCRIPTION
On my Windows machine CMake fails to generate proper project file (it prints something about not being able to find boost libraries although I pass all necessary paths). Still I was able to manually add all tests to Visual Studio project file. Now I can run the tests.

Similar to my Mac machine some tests fail. If a test fails due to memory access error the Windows program can't deal with that and terminates completely (on Mac the program manages to survive, prints a message about unhandled exception and goes on to next test).

## Verbose mode
Unfortunately when the program terminates it doesn't print the name of the test it was running. Hence the first change to test runner: when running `testlib -v` the test runner prints names of tests before executing them. If a test fails the last printed line is the name of the test. Example usage (here a screenshot from Mac, therefore no termination):
```
$ bin/testlib -v DocCommandTest
Lomse version 0.23.0+fd694b9-dirty. Library tests runner.

Lomse build date: 18-Apr-2018 19:11:17
Path for tests scores: '/User/lomse/test-scores/'

Running some tests 

lomse_test_command.cpp / DocCommandTest / add_noterest_0101
    Failure at line 183: (*cursor)->is_note() == true
    Failure at line 184: (*cursor)->to_string() == "(n a4 e v1 p1)"
lomse_test_command.cpp / DocCommandTest / add_noterest_0101_ur
    Failure at line 187: Unhandled exception: test crashed
lomse_test_command.cpp / DocCommandTest / add_noterest_0201
    Failure at line 262: (*cursor)->is_note() == true
    Failure at line 263: (*cursor)->to_string() == "(n f4 e v1 p1)"
...
lomse_test_command.cpp / DocCommandTest / add_chord_note_2702
lomse_test_command.cpp / DocCommandTest / add_chord_note_2703
lomse_test_command.cpp / DocCommandTest / add_chord_note_2704

Failure: 7 out of 92 tests failed (9 failures).
Test time: 0.32 seconds.
```

**Note:** command line parser is very primitive, parameter `-v` must be the first one.

## Exclude tests
I wanted to know how many tests fail but with over 1000 tests it wasn't possible to run each one manually. I needed a way to tell the test runner to skip certain tests. It is now possible by passing test name (or suite name) with prefix `-`:
```
$ bin/testlib -v DocCommandTest -add_noterest_0101 -add_noterest_0101_ur
```
In this example we execute test suite DocCommandTest but tests add_noterest_0101 and add_noterest_0101_ur should be skipped.

## Syntax changes
In addition to passing test name and suite name as parameter it is now also possible to pass test file name. All names are accepted without extra parameter prefixes (do not add `suite` before suite name) and can be used multiple times.
#### Example: run two test suites
```
$ bin/testlib -v MxlAnalyserTest MxlCompilerTest
```
#### Example: run three tests by names
```
$ bin/testlib -v tuplet_01 tuplet_02 tuplet_03
```
#### Example: run tests from file lomse_test_model_builder.cpp
```
$ bin/testlib -v lomse_test_model_builder.cpp
Lomse version 0.23.0+fd694b9-dirty. Library tests runner.

Lomse build date: 18-Apr-2018 19:11:17
Path for tests scores: '/User/lomse/test-scores/'

Running some tests 

lomse_test_model_builder.cpp / ModelBuilderTest / ModelBuilderScore
lomse_test_model_builder.cpp / PitchAssignerTest / AssignPitch_FPitch
lomse_test_model_builder.cpp / PitchAssignerTest / AssignPitch_MidiPitch
lomse_test_model_builder.cpp / PitchAssignerTest / CompilerAssignsPitch
lomse_test_model_builder.cpp / PitchAssignerTest / CloseScoreAssignsPitch_FPitch
lomse_test_model_builder.cpp / PitchAssignerTest / NoPitchWhenPattern
lomse_test_model_builder.cpp / MidiAssignerTest / midi_assigner_01
lomse_test_model_builder.cpp / MidiAssignerTest / midi_assigner_02
lomse_test_model_builder.cpp / MidiAssignerTest / midi_assigner_03
lomse_test_model_builder.cpp / MidiAssignerTest / midi_assigner_04
lomse_test_model_builder.cpp / MidiAssignerTest / midi_assigner_05
lomse_test_model_builder.cpp / MidiAssignerTest / midi_assigner_06

Success: 12 tests passed.
Test time: 0.04 seconds.
```

## Bonus
The test runner doesn't need to access field `Test::m_nextTest` (`Test::next` in older UnitTest++ versions) anymore. That made #137 obsolete. CMake config was updated accordingly.

## Extra
Removed call to `cin.get()` in Windows version. It prevented the usage of the tests from scripts. Windows users should open command prompt window and execute tests there instead of double clicking on testlib.exe in Windows Explorer. That's what user on other OSes do too.