### PR TITLE
Replaced boost::date_time with std::chrono

### DIFF
--- a/include/lomse_interactor.h
+++ b/include/lomse_interactor.h
@@ -39,10 +39,8 @@
 #include "lomse_pitch.h"
 
 #include <iostream>
-#include <ctime>   //clock
-#include <boost/date_time/posix_time/posix_time.hpp>
+#include <chrono>
 using namespace std;
-using namespace boost::posix_time;
 
 ///@cond INTERNALS
 namespace lomse
@@ -94,6 +92,15 @@ enum EEventFlag
     k_kbd_shift   = 8,      ///< 0x08. Keyboard Shift key pressed while mouse event
     k_kbd_ctrl    = 16,     ///< 0x10. Keyboard Ctrol key pressed while mouse event
     k_kbd_alt     = 32,     ///< 0x20. Keyboard Alt key pressed while mouse event
+};
+
+struct ptime
+{
+    ptime(bool init_with_now = false) { if (init_with_now) init_now(); }
+    void init_now() { timepoint = chrono::high_resolution_clock::now(); }
+    chrono::time_point<chrono::high_resolution_clock> timepoint;
+    typedef double duration;
+    duration operator-(const ptime rhs);
 };
 
 //---------------------------------------------------------------------------------------
@@ -1369,7 +1376,6 @@ protected:
     void update_caret_and_view();
     void redraw_caret();
     void send_update_UI_event(EEventType type);
-    ptime get_current_time() const;
     double get_elapsed_time_since(ptime startTime) const;
     Handler* handlers_hit_test(Pixels x, Pixels y);
     void restore_selection();

--- a/include/lomse_spacing_algorithm_gourlay.h
+++ b/include/lomse_spacing_algorithm_gourlay.h
@@ -36,11 +36,6 @@
 #include "lomse_time.h"
 #include "lomse_timegrid_table.h"
 
-//For performance measurements (timing)
-#include <ctime>   //clock
-#include <boost/date_time/posix_time/posix_time.hpp>
-
-
 namespace lomse
 {
 

--- a/include/lomse_system_layouter.h
+++ b/include/lomse_system_layouter.h
@@ -41,11 +41,6 @@
 #include <vector>
 using namespace std;
 
-//For performance measurements (timing)
-#include <ctime>   //clock
-#include <boost/date_time/posix_time/posix_time.hpp>
-
-
 namespace lomse
 {
 

--- a/include/lomse_tasks.h
+++ b/include/lomse_tasks.h
@@ -34,7 +34,6 @@
 #include "lomse_injectors.h"
 
 #include <iostream>
-#include <boost/date_time/posix_time/posix_time.hpp>
 using namespace std;
 
 namespace lomse

--- a/include/lomse_time.h
+++ b/include/lomse_time.h
@@ -32,6 +32,8 @@
 
 #include "lomse_basic.h"
 
+#include <chrono>
+
 namespace lomse
 {
 
@@ -47,6 +49,7 @@ extern bool is_greater_time(TimeUnits t1, TimeUnits t2);
 
 TimeUnits round_half_up(TimeUnits num);
 
+string to_simple_string(chrono::time_point<chrono::system_clock> time, bool microsec = false);
 
 }   //namespace lomse
 

--- a/src/document/lomse_command.cpp
+++ b/src/document/lomse_command.cpp
@@ -45,17 +45,8 @@
 #include "lomse_ldp_exporter.h"
 #include "lomse_internal_model.h"
 
-
 #include <sstream>
 using namespace std;
-
-
-#include <boost/date_time/gregorian/gregorian.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
-#include "boost/date_time/local_time/local_time.hpp"
-
-using namespace std;
-
 
 namespace lomse
 {
@@ -86,13 +77,10 @@ void DocCommand::undo_action(Document* pDoc, DocCursor* UNUSED(pCursor))
     ofstream logger;
     logger.open("forensic_log.txt", std::ofstream::out | std::ofstream::app);
 
-    boost::local_time::local_date_time currentTime(
-        boost::posix_time::second_clock::local_time(),
-        boost::local_time::time_zone_ptr());
     logger << "---------------------------------------------"
            << "---------------------------------------------" << endl;
     logger << "Before Undo, time="
-           << to_simple_string( currentTime.local_time() ) << endl;
+           << to_simple_string(chrono::system_clock::now()) << endl;
     if (get_undo_policy() == k_undo_policy_partial_checkpoint)
         logger << "Undo policy: Partial checkpoint. Obj: " << m_idChk << endl;
     else
@@ -118,13 +106,10 @@ void DocCommand::log_forensic_data(Document* UNUSED(pDoc), DocCursor* pCursor)
     ofstream logger;
     logger.open("forensic_log.txt", std::ofstream::out | std::ofstream::app);
 
-    boost::local_time::local_date_time currentTime(
-        boost::posix_time::second_clock::local_time(),
-        boost::local_time::time_zone_ptr());
     logger << "---------------------------------------------"
            << "---------------------------------------------" << endl;
     logger << "Before executing command, time="
-           << to_simple_string( currentTime.local_time() ) << endl;
+           << to_simple_string(chrono::system_clock::now()) << endl;
     log_command(logger);
     logger << "Cursor: " << pCursor->dump_cursor();
     logger << "Checkpoint data (last id " << m_idChk << "):" << endl;

--- a/src/exporters/lomse_ldp_exporter.cpp
+++ b/src/exporters/lomse_ldp_exporter.cpp
@@ -39,14 +39,6 @@
 #include <sstream>
 using namespace std;
 
-#include <boost/date_time/gregorian/gregorian.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
-#include "boost/date_time/local_time/local_time.hpp"
-
-using namespace std;
-
-
-
 namespace lomse
 {
 
@@ -1287,12 +1279,8 @@ protected:
             string& version = m_pExporter->get_library_version();
             if (!version.empty())
                 m_source << ", version " << version;
-            m_source << ". Date: ";
-
-            boost::local_time::local_date_time currentTime(
-                boost::posix_time::second_clock::local_time(),
-                boost::local_time::time_zone_ptr());
-            m_source << to_simple_string( currentTime.local_time() );
+            m_source << ". Date: "
+                     << to_simple_string(chrono::system_clock::now());
             end_comment();
         }
     }

--- a/src/exporters/lomse_lmd_exporter.cpp
+++ b/src/exporters/lomse_lmd_exporter.cpp
@@ -36,13 +36,9 @@
 #include "lomse_ldp_exporter.h"
 #include "lomse_mnx_exporter.h"
 #include "lomse_logger.h"
+#include "lomse_time.h"
 
 #include <stack>
-#include <ctime>   //clock
-#include <boost/date_time/gregorian/gregorian.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
-#include "boost/date_time/local_time/local_time.hpp"
-
 using namespace std;
 
 namespace lomse
@@ -1878,11 +1874,7 @@ LmdExporter::LmdExporter(LibraryScope& libScope)
     , m_fRemoveNewlines(false)
 {
     m_lomseVersion = libScope.get_version_string();
-
-    boost::local_time::local_date_time currentTime(
-        boost::posix_time::second_clock::local_time(),
-        boost::local_time::time_zone_ptr());
-    m_exportTime = to_simple_string( currentTime.local_time() );
+    m_exportTime = to_simple_string(chrono::system_clock::now());
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/exporters/lomse_mnx_exporter.cpp
+++ b/src/exporters/lomse_mnx_exporter.cpp
@@ -35,13 +35,9 @@
 #include "lomse_im_note.h"
 #include "lomse_mnx_exporter.h"
 #include "lomse_logger.h"
+#include "lomse_time.h"
 
 #include <stack>
-#include <ctime>   //clock
-#include <boost/date_time/gregorian/gregorian.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
-#include "boost/date_time/local_time/local_time.hpp"
-
 using namespace std;
 
 namespace lomse
@@ -1676,11 +1672,7 @@ MnxExporter::MnxExporter(LibraryScope& libScope)
     , m_fProcessingChord(false)
 {
     m_lomseVersion = libScope.get_version_string();
-
-    boost::local_time::local_date_time currentTime(
-        boost::posix_time::second_clock::local_time(),
-        boost::local_time::time_zone_ptr());
-    m_exportTime = to_simple_string( currentTime.local_time() );
+    m_exportTime = to_simple_string(chrono::system_clock::now());
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/layouters/lomse_spacing_algorithm_gourlay.cpp
+++ b/src/graphic_model/layouters/lomse_spacing_algorithm_gourlay.cpp
@@ -370,7 +370,7 @@ void SpAlgGourlay::do_spacing(int iCol, bool fTrace)
 
     if (fTrace || m_libraryScope.dump_column_tables())
     {
-        dbgLogger << endl << boost::posix_time::to_simple_string( boost::posix_time::microsec_clock::local_time() )
+        dbgLogger << endl << to_simple_string(chrono::system_clock::now(), true)
                   << " ******************* Before spacing" << endl;
         m_columns[iCol]->dump(dbgLogger);
     }

--- a/src/module/lomse_time.cpp
+++ b/src/module/lomse_time.cpp
@@ -27,9 +27,15 @@
 // the project at cecilios@users.sourceforge.net
 //---------------------------------------------------------------------------------------
 
+#include "lomse_config.h"
 #include "lomse_time.h"
 
 #include <cmath>
+#include <chrono>
+#include <sstream>
+#include <time.h>
+#include <iomanip>
+using namespace std;
 
 namespace lomse
 {
@@ -60,6 +66,35 @@ TimeUnits round_half_up(TimeUnits num)
     return floor(num * 100.0 + 0.5) / 100.0;
 }
 
+string to_simple_string(chrono::time_point<chrono::system_clock> time, bool microsec)
+{
+    time_t time_sec = chrono::system_clock::to_time_t(time);
+    tm time_tm;
 
+#if (LOMSE_COMPILER_MSVC == 1)
+    localtime_s(&time_tm, &time_sec);
+#else
+    localtime_r(&time_sec, &time_tm);
+#endif
+
+    stringstream ss;
+
+    // we could do 'ss << std::put_time(&time_tm, "%Y-%b-%d %X")' but it's not available in GCC until 5.0
+    // using 'strftime' instead
+
+    vector<char> buf(100);
+    strftime(buf.data(), buf.size(), "%Y-%b-%d %X", &time_tm);
+    ss << buf.data();
+
+    if (microsec)
+    {
+        long long in_micros = chrono::duration_cast<chrono::microseconds>(time.time_since_epoch()).count();
+        long long in_seconds = chrono::duration_cast<chrono::seconds>(time.time_since_epoch()).count();
+        long long micros = in_micros - in_seconds * 1000000;
+        ss << "." << setfill('0') << setw(6) << micros;
+    }
+
+    return ss.str();
+}
 
 }   //namespace lomse

--- a/src/mvc/lomse_interactor.cpp
+++ b/src/mvc/lomse_interactor.cpp
@@ -52,10 +52,17 @@
 #include "lomse_shape_staff.h"
 
 #include <sstream>
+#include <chrono>
 using namespace std;
 
 namespace lomse
 {
+
+ptime::duration ptime::operator-(const ptime rhs)
+{
+    long long millis = chrono::duration_cast<chrono::milliseconds>(timepoint - rhs.timepoint).count();
+	return millis;
+}
 
 //=======================================================================================
 // Interactor implementation
@@ -142,7 +149,7 @@ void Interactor::create_graphic_model()
 
     if (SpDocument spDoc = m_wpDoc.lock())
     {
-        m_gmodelBuildStartTime = get_current_time();
+        m_gmodelBuildStartTime.init_now();
 
         GraphicView* pView = dynamic_cast<GraphicView*>(m_pView);
         Document* pDoc = spDoc.get();
@@ -1620,19 +1627,13 @@ void Interactor::find_parent_link_box_and_notify_event(SpEventInfo pEvent, GmoOb
 }
 
 //---------------------------------------------------------------------------------------
-ptime Interactor::get_current_time() const
-{
-    return microsec_clock::universal_time();
-}
-
-//---------------------------------------------------------------------------------------
 double Interactor::get_elapsed_time_since(ptime startTime) const
 {
     //millisecods
 
-    ptime now = microsec_clock::universal_time();
-    time_duration diff = now - startTime;
-    return double( diff.total_milliseconds() );
+    ptime now(true);
+    ptime::duration diff = now - startTime;
+    return double( diff );
 }
 
 //---------------------------------------------------------------------------------------
@@ -1643,7 +1644,7 @@ void Interactor::timing_start_measurements()
     for (int i=0; i < k_timing_max_value; ++i)
         m_elapsedTimes[i] = 0.0;
 
-    m_renderStartTime = microsec_clock::universal_time();
+    m_renderStartTime.init_now();
     m_visualEffectsStartTime = m_renderStartTime;
 }
 
@@ -1652,9 +1653,9 @@ void Interactor::timing_graphic_model_build_end()
 {
     //gmodel_build ends. gmodel_build = now - render_star
 
-    ptime now = microsec_clock::universal_time();
-    time_duration diff = now - m_renderStartTime;
-    m_elapsedTimes[k_timing_gmodel_build_time] = double( diff.total_milliseconds() );
+    ptime now(true);
+    ptime::duration diff = now - m_renderStartTime;
+    m_elapsedTimes[k_timing_gmodel_build_time] = double( diff );
 }
 
 //---------------------------------------------------------------------------------------
@@ -1662,10 +1663,10 @@ void Interactor::timing_graphic_model_render_end()
 {
     //draw gmodel ends. gmodel_draw = (now - render_start) - gmodel_build
 
-    ptime now = microsec_clock::universal_time();
-    time_duration diff = now - m_renderStartTime;
+    ptime now(true);
+    ptime::duration diff = now - m_renderStartTime;
     m_elapsedTimes[k_timing_gmodel_draw_time] =
-        double( diff.total_milliseconds() ) - m_elapsedTimes[k_timing_gmodel_build_time];
+        double( diff ) - m_elapsedTimes[k_timing_gmodel_build_time];
 }
 
 //---------------------------------------------------------------------------------------
@@ -1673,7 +1674,7 @@ void Interactor::timing_visual_effects_start()
 {
     //draw visual effects start. visual_start = now
 
-    m_visualEffectsStartTime = microsec_clock::universal_time();
+    m_visualEffectsStartTime.init_now();
 }
 
 //---------------------------------------------------------------------------------------
@@ -1682,14 +1683,14 @@ void Interactor::timing_renderization_end()
     //draw end. visual_draw = now - visual_start; total_render = now - render_start;
     //repaint_start=now
 
-    ptime now = microsec_clock::universal_time();
-    time_duration diff = now - m_visualEffectsStartTime;
+    ptime now(true);
+    ptime::duration diff = now - m_visualEffectsStartTime;
     m_elapsedTimes[k_timing_visual_effects_draw_time] =
-        double( diff.total_milliseconds() );
+        double( diff );
 
     diff = now - m_renderStartTime;
     m_elapsedTimes[k_timing_total_render_time] =
-        double( diff.total_milliseconds() );
+        double( diff );
 
     m_repaintStartTime = now;
 }
@@ -1699,9 +1700,9 @@ void Interactor::timing_repaint_done()
 {
     //repaint_time = (now - repaint_start)
 
-    ptime now = microsec_clock::universal_time();
-    time_duration diff = now - m_repaintStartTime;
-    m_elapsedTimes[k_timing_repaint_time] =  double( diff.total_milliseconds() );
+    ptime now(true);
+    ptime::duration diff = now - m_repaintStartTime;
+    m_elapsedTimes[k_timing_repaint_time] =  double( diff );
 }
 
 //---------------------------------------------------------------------------------------


### PR DESCRIPTION
In this PR we replace boost's date_time module with standard library.

There is a new function to convert time to string:
```C++
string to_simple_string(chrono::time_point<chrono::system_clock> time, bool microsec = false);
```
 It is used from four units. I've put the function into `lomse_time.h`. Not sure if this is a correct place.