### PR TITLE
Fixed tests "Dynamic_GeneratesRequest" failing in MSVC

### DIFF
--- a/src/tests/lomse_test_ldp_analyser.cpp
+++ b/src/tests/lomse_test_ldp_analyser.cpp
@@ -10062,7 +10062,7 @@ SUITE(LdpAnalyserTest)
     TEST_FIXTURE(LdpAnalyserTestFixture, Dynamic_GeneratesRequest)
     {
         LomseDoorway* pDoorway = m_libraryScope.platform_interface();
-        pDoorway->set_request_callback(this, wrapper_lomse_request);
+        pDoorway->set_request_callback(static_cast<LdpAnalyserTestFixture*>(this), wrapper_lomse_request);
 
         Document doc(m_libraryScope);
         doc.from_string("(lenmusdoc (vers 0.0)(content "

--- a/src/tests/lomse_test_lmd_analyser.cpp
+++ b/src/tests/lomse_test_lmd_analyser.cpp
@@ -1526,7 +1526,7 @@ SUITE(LmdAnalyserTest)
     TEST_FIXTURE(LmdAnalyserTestFixture, Dynamic_GeneratesRequest)
     {
         LomseDoorway* pDoorway = m_libraryScope.platform_interface();
-        pDoorway->set_request_callback(this, wrapper_lomse_request);
+        pDoorway->set_request_callback(static_cast<LmdAnalyserTestFixture*>(this), wrapper_lomse_request);
 
         Document doc(m_libraryScope);
         XmlParser parser;


### PR DESCRIPTION
In the following example:
```C++
TEST_FIXTURE(LdpAnalyserTestFixture, Dynamic_GeneratesRequest)
{
    void* p1 = this;
    void* p2 = static_cast<LdpAnalyserTestFixture*>(this);
```
In **clang** and **GCC** `p1 == p2` but not in **MSVC**, at least not for Fixture classes.

Therefore storing `this` in `set_request_callback` for the class inherited from `LdpAnalyserTestFixture*` and then type casting it to `LdpAnalyserTestFixture*` in `wrapper_lomse_request` causes access into wrong memory:
```
static void wrapper_lomse_request(void* pThis, Request* pRequest)
{
    static_cast<LdpAnalyserTestFixture*>(pThis)->on_lomse_request(pRequest);
```

This PR fixes the issue by passing to `set_request_callback` the object of the type needed in that callback (type-casted).