### PR TITLE
Do not fail on png warnings

### DIFF
--- a/src/file_system/lomse_image_reader.cpp
+++ b/src/file_system/lomse_image_reader.cpp
@@ -49,6 +49,7 @@ namespace lomse
 //declaration of some internal functions, to avoid compiler warnings
 void read_callback(png_structp png, png_bytep data, png_size_t length);
 void error_callback (png_structp, png_const_charp);
+void warning_callback (png_structp, png_const_charp);
 
 
 //=======================================================================================
@@ -131,6 +132,12 @@ void error_callback (png_structp, png_const_charp)
     throw "error reading png image";
 }
 
+//---------------------------------------------------------------------------------------
+void warning_callback (png_structp, png_const_charp msg)
+{
+    LOMSE_LOG_WARN("warning reading png image: %s", msg);
+}
+
 //=======================================================================================
 // PngImageDecoder members implementation
 //=======================================================================================
@@ -178,7 +185,7 @@ SpImage PngImageDecoder::decode_file(InputStream* file)
     }
 
 
-    png_set_error_fn(pReadStruct, 0, error_callback, error_callback );
+    png_set_error_fn(pReadStruct, 0, error_callback, warning_callback);
 
 
     png_uint_32 width, height;


### PR DESCRIPTION
I had a test failure:
```
Non-standard unknown exception (catch in ImageReader::load_image)
lomse_test_ldp_analyser.cpp(10204): Failure in LdpAnalyserTest / Image_Ok: errormsg.str() == expected.str()
```

Error-callback of pnglib was executed:
```C++
void error_callback (png_structp, png_const_charp)
{
    LOMSE_LOG_ERROR("error reading png image");
    throw "error reading png image";
}
```
The second parameter contained text "iCCP: known incorrect sRGB profile".
Tested with another png image and the test has passed.

It turned out the callback was executed as a warning, not as an error.
The callback was configured:
```C++
png_set_error_fn(pReadStruct, 0, error_callback, error_callback );
```

The last parameter is for warnings. The same function was used for both errors and warnings. The function was throwing an exception.

Since all other programs can read the test png file successfully it would be good if Lomse could read it too.

The change is to setup a separate callback for warnings, where we only log messages but don't abort loading of images.