### PR TITLE
 Replaced boost::thread with std::thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,13 +82,6 @@
 # LOMSE_COMPATIBILITY_LDP_1_5   (Default value: ON)
 #       Enables backwards compatibility for scores in LDP v1.5
 #
-# LOMSE_USE_STATIC_BOOST	(Default value: ON for Windows, OFF for other OS)
-#		When OFF, Lomse will link agains boost dynamic libraries.
-#		When OFF, boost static libraries will be used.
-#
-# LOMSE_USE_MULTITHREADED_BOOST		(Default value: ON)
-#		Can be set to OFF to use the non-multithreaded boost libraries.
-#
 #-------------------------------------------------------------------------------------
 
 cmake_minimum_required(VERSION 2.8.10)
@@ -166,77 +159,19 @@ include( ${LOMSE_ROOT_DIR}/build-options.cmake )
 if (LOMSE_BUILD_TESTS)
     find_package(UnitTest++)
     if(UNITTEST++_FOUND)
+        get_filename_component(UNITTEST++_LINK_DIR ${UNITTEST++_LIBRARY} DIRECTORY)
         include_directories(${UNITTEST++_INCLUDE_DIR})
-        link_directories( ${UNITTEST++_LIBRARY} )
-        #message("UnitTest++ found: library: ${UNITTEST++_LIBRARY}" )
-        #message("UnitTest++ found: include: ${UNITTEST++_INCLUDE_DIR}" )
+        link_libraries( ${UNITTEST++_LIBRARY} )
+        link_directories( ${UNITTEST++_LINK_DIR} )        
+        message(STATUS "UnitTest++ found: libraries= ${UNITTEST++_LIBRARY}" )
+        message(STATUS "UnitTest++ found: include= ${UNITTEST++_INCLUDE_DIR}" )
+        message(STATUS "UnitTest++ found: libdir= ${UNITTEST++_LINK_DIR}" )
     else()
         message(STATUS "UnitTest++ package not found. Test program will not be built" )
         set (LOMSE_BUILD_TESTS OFF)
     endif()
 endif(LOMSE_BUILD_TESTS)
 
-# Check for Boost >= 1.42.0
-set(Boost_ADDITIONAL_VERSIONS "1.42" "1.42.0" "1.43" "1.43.0" "1.44" "1.44.0"
-    "1.45" "1.45.0" "1.46" "1.46.0" "1.47" "1.47.0" "1.48" "1.48.0" "1.49" "1.49.0"
-    "1.50" "1.50.0" "1.51" "1.51.0" "1.52" "1.52.0" "1.53" "1.53.0" "1.54" "1.54.0"
-    "1.55" "1.55.0" "1.56" "1.56.0" "1.57" "1.57.0" "1.58" "1.58.0" "1.59" "1.59.0"
-    "1.60" "1.60.0" "1.61" "1.61.0" )
-set(Boost_USE_STATIC_LIBS       ${LOMSE_USE_STATIC_BOOST})
-set(Boost_USE_MULTITHREADED     ${LOMSE_USE_MULTITHREADED_BOOST})
-set(Boost_USE_STATIC_RUNTIME    OFF)
-#set(Boost_DEBUG                 TRUE)
-unset(Boost_INCLUDE_DIR CACHE)
-unset(Boost_LIBRARY_DIRS CACHE)
-find_package(Boost 1.42.0 COMPONENTS date_time thread REQUIRED)
-if(Boost_FOUND)
-    include_directories(${Boost_INCLUDE_DIRS})
-    link_libraries( ${Boost_LIBRARIES} )
-    link_directories( ${Boost_LIBRARY_DIRS} )
-    set(BOOST_VERSION   "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}" )
-    if (NOT ".${Boost_SUBMINOR_VERSION}" STREQUAL "." )
-	    set(BOOST_VERSION   "${BOOST_VERSION}.${Boost_SUBMINOR_VERSION}" )
-	endif()
-    message(STATUS "Boost found: lib version= ${Boost_LIB_VERSION}, version=${BOOST_VERSION}" )
-    #string(REGEX REPLACE "_" "." Boost_LIB_VERSION "${Boost_LIB_VERSION}" )
-    set(BOOST_DEPENDENCIES 
-        "libboost-thread${BOOST_VERSION}, libboost-date-time${BOOST_VERSION}")
-    message(STATUS "Boost found: libraries: ${Boost_LIBRARIES}" )
-    message(STATUS "Boost found: include= ${Boost_INCLUDE_DIRS}" )
-    message(STATUS "Boost found: libdir= ${Boost_LIBRARY_DIRS}" )
-    message(STATUS "Boost dependencies: ${BOOST_DEPENDENCIES}" )
-
-	if ((NOT Boost_USE_STATIC_LIBS) AND WIN32)
-		# Setting Boost_USE_STATIC_LIBS to OFF is NOT enough to get you dynamic
-		# linking when using MSVC & Borland compilers. By default, they use
-		# automatic linking when including things in Boost. So, the following
-		# is necessary. See:
-		# https://stackoverflow.com/questions/6646405/how-do-you-add-boost-libraries-in-cmakelists-txt
-
-	  	# disable autolinking with boost
-	  	add_definitions( -DBOOST_ALL_NO_LIB )
-
-	  	# force all boost libraries to dynamic link.
-	  	add_definitions( -DBOOST_ALL_DYN_LINK )
-	endif()
-
-else()
-    message(SEND_ERROR "Boost package not found. Reason: ${Boost_ERROR_REASON}" )
-endif()
-
-
-#Additional Boost libraries required for unit tests
-if (LOMSE_BUILD_TESTS)
-    find_package(Boost 1.42.0 COMPONENTS system REQUIRED)
-    if(Boost_FOUND)
-        include_directories(${Boost_INCLUDE_DIRS})
-        link_libraries( ${Boost_LIBRARIES} )
-        link_directories( ${Boost_LIBRARY_DIRS} )
-    else()
-        message(SEND_ERROR "Boost 'system' package not found. Reason: ${Boost_ERROR_REASON}. Test program will not be built" )
-        set (LOMSE_BUILD_TESTS OFF)
-    endif()
-endif(LOMSE_BUILD_TESTS)
 
 # Check for FreeType
 find_package(Freetype REQUIRED)                    
@@ -283,7 +218,7 @@ endif()
 
 #dependencies for building and for pkg-config file
 set(LOMSE_REQUIRES "freetype2, libpng, zlib")
-set(LOMSE_DEPENDENCIES "libfreetype6, libpng12-0 (>=1.2.42), zlib1g (>= ${ZLIB_VERSION_STRING}), ${BOOST_DEPENDENCIES} ")
+set(LOMSE_DEPENDENCIES "libfreetype6, libpng12-0 (>=1.2.42), zlib1g (>= ${ZLIB_VERSION_STRING})")
 
 
 # include directories to be installed
@@ -384,11 +319,14 @@ if(LOMSE_BUILD_TESTS)
     file(GLOB TESTLIB_SRC "${LOMSE_SRC_DIR}/tests/*.cpp" )
     add_executable(${TESTLIB} ${TESTLIB_SRC})
 
+    # Check for pthreads
+    find_package (Threads)
+    
     # libraries to link
     if (BUILD_SHARED_LIB)
-        target_link_libraries ( ${TESTLIB} lomse-shared libunittest++.a )
+        target_link_libraries ( ${TESTLIB} lomse-shared libunittest++.a ${CMAKE_THREAD_LIBS_INIT} )
     else()      
-        target_link_libraries ( ${TESTLIB} lomse.so libunittest++.a )
+        target_link_libraries ( ${TESTLIB} lomse.so libunittest++.a ${CMAKE_THREAD_LIBS_INIT} )
     endif()
 
     # dependencies
@@ -442,7 +380,6 @@ if (LOMSE_BUILD_EXAMPLE)
 
         target_link_libraries( ${EXAMPLE1}
             lomse.lib
-            ${Boost_LIBRARIES}
             ${FREETYPE_LIBRARIES}
             ${PNG_LIBRARIES}
             ${ZLIB_LIBRARIES}
@@ -463,7 +400,6 @@ if (LOMSE_BUILD_EXAMPLE)
 
         target_link_libraries ( ${EXAMPLE1} 
             liblomse.so
-            ${Boost_LIBRARIES}
             ${FREETYPE_LIBRARIES}
             ${PNG_LIBRARIES}
             ${ZLIB_LIBRARIES}

--- a/build-options.cmake
+++ b/build-options.cmake
@@ -31,22 +31,6 @@ else()
     option( LOMSE_COMPATIBILITY_LDP_1_5  "Enable compatibility for LDP v1.5" ON)
 endif()
 
-if(DEFINED LOMSE_USE_STATIC_BOOST)
-    option( LOMSE_USE_STATIC_BOOST  "Link agains boost static libraries" ${LOMSE_USE_STATIC_BOOST})
-else()
-	if (WIN32)
-    	option( LOMSE_USE_STATIC_BOOST  "Link agains boost static libraries" ON)
-	else()
-    	option( LOMSE_USE_STATIC_BOOST  "Link agains boost static libraries" OFF)
-	endif()
-endif()
-
-if(DEFINED LOMSE_USE_MULTITHREADED_BOOST)
-    option( LOMSE_USE_MULTITHREADED_BOOST  "Use the multithreaded boost libraries" ${LOMSE_USE_MULTITHREADED_BOOST})
-else()
-    option( LOMSE_USE_MULTITHREADED_BOOST  "Use the multithreaded boost libraries" ON)
-endif()
-
 
 #libraries to build
 option(LOMSE_BUILD_STATIC_LIB "Build the static library" OFF)
@@ -72,8 +56,6 @@ message(STATUS "Run tests after building = ${LOMSE_RUN_TESTS}")
 message(STATUS "Create Debug build = ${LOMSE_DEBUG}")
 message(STATUS "Enable debug logs = ${LOMSE_ENABLE_DEBUG_LOGS}")
 message(STATUS "Compatibility for LDP v1.5 = ${LOMSE_COMPATIBILITY_LDP_1_5}")
-message(STATUS "Link agains boost static libraries = ${LOMSE_USE_STATIC_BOOST}")
-message(STATUS "Use the multithreaded boost libraries = ${LOMSE_USE_MULTITHREADED_BOOST}")
 
 
 

--- a/include/lomse_basic.h
+++ b/include/lomse_basic.h
@@ -35,6 +35,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <algorithm>   //min
 using namespace std;
 
 

--- a/include/lomse_caret.h
+++ b/include/lomse_caret.h
@@ -39,10 +39,6 @@
 using namespace std;
 
 #include "lomse_events_dispatcher.h"
-#if (LOMSE_USE_BOOST_ASIO == 1)
-    #include <boost/asio.hpp>
-    #include <boost/bind.hpp>
-#endif
 
 namespace lomse
 {
@@ -67,10 +63,6 @@ protected:
     USize m_size;           //caret size
     int m_type;
     string m_timecode;      //timecode for current position
-#if (LOMSE_USE_BOOST_ASIO == 1)
-    int m_blinkTime;            //milliseconds.
-    boost::asio::deadline_timer m_timer;
-#endif
     GmoBoxSystem* m_pBoxSystem;     //active system: the one on which the caret is placed
     URect m_bounds;         //the real bounds of the caret drawing
 
@@ -111,12 +103,6 @@ public:
     //properties
     inline bool is_blink_enabled() const { return m_fBlinkEnabled; }
     inline bool is_displayed() const { return m_fBlinkStateOn; }
-
-#if (LOMSE_USE_BOOST_ASIO == 1)
-    inline int get_blink_time() { return m_blinkTime; }
-    inline void set_blink_time(int milliseconds) { m_blinkTime = milliseconds; }
-    void handle_timeout(boost::system::error_code const& cError);
-#endif
 
 protected:
     void schedule_the_timer();

--- a/include/lomse_caret.h
+++ b/include/lomse_caret.h
@@ -105,7 +105,6 @@ public:
     inline bool is_displayed() const { return m_fBlinkStateOn; }
 
 protected:
-    void schedule_the_timer();
     void draw_caret(ScreenDrawer* pDrawer);
 
     void draw_caret_as_top_level(ScreenDrawer* pDrawer);

--- a/include/lomse_events_dispatcher.h
+++ b/include/lomse_events_dispatcher.h
@@ -36,12 +36,12 @@
 #include "lomse_injectors.h"
 #include "lomse_events.h"
 
-#include <boost/thread/thread.hpp>
-#include <boost/thread/condition_variable.hpp>
 #if (LOMSE_USE_BOOST_ASIO == 1)
     #include <boost/asio.hpp>
 #endif
 
+#include <thread>
+#include <mutex>
 #include <queue>
 using namespace std;
 
@@ -52,9 +52,9 @@ namespace lomse
 
 
 //---------------------------------------------------------------------------------------
-typedef boost::thread EventsThread;
-typedef boost::mutex QueueMutex;
-typedef boost::unique_lock<boost::mutex> QueueLock;
+typedef std::thread EventsThread;
+typedef std::mutex QueueMutex;
+typedef std::unique_lock<std::mutex> QueueLock;
 
 
 

--- a/include/lomse_events_dispatcher.h
+++ b/include/lomse_events_dispatcher.h
@@ -30,15 +30,9 @@
 #ifndef __LOMSE_EVENTS_DISPATCHER_H__
 #define __LOMSE_EVENTS_DISPATCHER_H__
 
-#define LOMSE_USE_BOOST_ASIO        0
-
 #include "lomse_build_options.h"
 #include "lomse_injectors.h"
 #include "lomse_events.h"
-
-#if (LOMSE_USE_BOOST_ASIO == 1)
-    #include <boost/asio.hpp>
-#endif
 
 #include <thread>
 #include <mutex>
@@ -69,11 +63,6 @@ protected:
     QueueMutex m_mutex;             //to control queue access
     bool m_fStopLoop;
     queue< pair<SpEventInfo, Observer*> > m_events;
-#if (LOMSE_USE_BOOST_ASIO == 1)
-    boost::asio::io_service m_ioService;
-    boost::asio::io_service::work* m_pFakeWork;
-    boost::thread_group m_threads;
-#endif
 
 public:
     EventsDispatcher();
@@ -83,9 +72,6 @@ public:
     void stop_events_loop();
 
     void post_event(Observer* pObserver, SpEventInfo pEvent);
-#if (LOMSE_USE_BOOST_ASIO == 1)
-    inline boost::asio::io_service& get_io_service() { return m_ioService; }
-#endif
 
 protected:
     inline bool stop_event_received() { return m_fStopLoop; }

--- a/include/lomse_injectors.h
+++ b/include/lomse_injectors.h
@@ -33,14 +33,12 @@
 #include "lomse_ldp_factory.h"
 #include "lomse_build_options.h"
 #include "lomse_events.h"
-#include "lomse_events_dispatcher.h"    // LOMSE_USE_BOOST_ASIO
+#include "lomse_events_dispatcher.h"
 #include "lomse_import_options.h"
 
 
 #include <iostream>
 using namespace std;
-
-//#include <boost/asio.hpp>
 
 namespace lomse
 {
@@ -158,9 +156,6 @@ public:
     FontStorage* font_storage();
     inline string& fonts_path() { return m_sFontsPath; }
     EventsDispatcher* get_events_dispatcher();
-#if (LOMSE_USE_BOOST_ASIO == 1)
-    boost::asio::io_service& get_io_service();
-#endif
 
     //callbacks
     void post_event(SpEventInfo pEvent);

--- a/include/lomse_internal_model.h
+++ b/include/lomse_internal_model.h
@@ -34,6 +34,7 @@
 #include <list>
 #include <vector>
 #include <map>
+#include <sstream>
 #include "lomse_visitor.h"
 #include "lomse_tree.h"
 #include "lomse_basic.h"

--- a/include/lomse_score_player.h
+++ b/include/lomse_score_player.h
@@ -34,9 +34,8 @@
 
 
 #include <vector>
-
-#include <boost/thread/thread.hpp>
-#include <boost/thread/condition_variable.hpp>
+#include <thread>
+#include <condition_variable>
 
 namespace lomse
 {
@@ -60,11 +59,8 @@ class Metronome;
 #define k_play_metronome        true
 
 //---------------------------------------------------------------------------------------
-typedef boost::thread SoundThread;
-//typedef boost::mutex SoundMutex;
-//typedef boost::unique_lock<boost::mutex> SoundLock;
-typedef boost::condition_variable SoundFlag;
-
+typedef std::thread SoundThread;
+typedef std::condition_variable SoundFlag;
 
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/layouters/lomse_spacing_algorithm_gourlay.cpp
+++ b/src/graphic_model/layouters/lomse_spacing_algorithm_gourlay.cpp
@@ -41,6 +41,7 @@
 #include "lomse_calligrapher.h"
 
 #include <vector>
+#include <cmath>   //abs
 using namespace std;
 
 

--- a/src/graphic_model/lomse_caret.cpp
+++ b/src/graphic_model/lomse_caret.cpp
@@ -49,41 +49,14 @@ Caret::Caret(GraphicView* view, LibraryScope& libraryScope)
     , m_fBlinkEnabled(false)
     , m_type(k_top_level)
     , m_timecode("1.0.0.0")
-#if (LOMSE_USE_BOOST_ASIO == 1)
-    , m_blinkTime(500)              //500 milliseconds
-    , m_timer( libraryScope.get_io_service() )
-#endif
     , m_pBoxSystem(nullptr)
 {
     schedule_the_timer();
 }
 
-#if (LOMSE_USE_BOOST_ASIO == 1)
-//---------------------------------------------------------------------------------------
-void Caret::handle_timeout(boost::system::error_code const& cError)
-{
-    if (cError.value() == boost::asio::error::operation_aborted)
-        return;
-
-    if (cError && cError.value() != boost::asio::error::operation_aborted)
-        return;     //TODO: throw an exception?
-
-    //repaint/erase the caret
-    m_fBlinkStateOn = !m_fBlinkStateOn;
-
-    // Schedule the timer again...
-    schedule_the_timer();
-}
-#endif
-
 //---------------------------------------------------------------------------------------
 void Caret::schedule_the_timer()
 {
-#if (LOMSE_USE_BOOST_ASIO == 1)
-    m_timer.expires_from_now(boost::posix_time::milliseconds(m_blinkTime));
-    m_timer.async_wait(boost::bind(&Caret::handle_timeout, this,
-                       boost::asio::placeholders::error));
-#endif
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/lomse_caret.cpp
+++ b/src/graphic_model/lomse_caret.cpp
@@ -51,12 +51,6 @@ Caret::Caret(GraphicView* view, LibraryScope& libraryScope)
     , m_timecode("1.0.0.0")
     , m_pBoxSystem(nullptr)
 {
-    schedule_the_timer();
-}
-
-//---------------------------------------------------------------------------------------
-void Caret::schedule_the_timer()
-{
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/lomse_overlays_generator.cpp
+++ b/src/graphic_model/lomse_overlays_generator.cpp
@@ -88,7 +88,6 @@ void OverlaysGenerator::update_all_visual_effects(ScreenDrawer* pDrawer)
         m_pCanvasBuffer->copy_from(m_savedBuffer);
 
     m_damagedRect = URect(0.0, 0.0, 0.0, 0.0);
-    stringstream msg;
     int overlays = 0;
     list<VisualEffect*>::const_iterator it;
     for (it = m_effects.begin(); it != m_effects.end(); ++it)

--- a/src/graphic_model/lomse_shape_volta_bracket.cpp
+++ b/src/graphic_model/lomse_shape_volta_bracket.cpp
@@ -35,6 +35,7 @@
 #include "lomse_drawer.h"
 #include "lomse_shape_barline.h"
 
+#include <cmath>   //abs
 
 namespace lomse
 {

--- a/src/module/lomse_events_dispatcher.cpp
+++ b/src/module/lomse_events_dispatcher.cpp
@@ -29,7 +29,6 @@
 
 #include "lomse_events_dispatcher.h"
 
-#include <boost/thread/thread.hpp>
 #if (LOMSE_USE_BOOST_ASIO == 1)
     #include <boost/asio.hpp>
     #include <boost/bind.hpp>
@@ -107,13 +106,7 @@ void EventsDispatcher::stop_events_loop()
 void EventsDispatcher::thread_main()
 {
 #if (LOMSE_DIRECT_INVOCATION == 0)
-    try
-    {
-        run_events_loop();
-    }
-    catch (boost::thread_interrupted&)
-    {
-    }
+    run_events_loop();
 #endif
 }
 
@@ -145,14 +138,14 @@ void EventsDispatcher::post_event(Observer* pObserver, SpEventInfo pEvent)
 
 void EventsDispatcher::run_events_loop()
 {
-    boost::posix_time::milliseconds waitTime(5);   //5ms
+    std::chrono::milliseconds waitTime(5);   //5ms
 
     while (!stop_event_received())
     {
         if (pending_events())
             dispatch_next_event();
         else
-            boost::this_thread::sleep(waitTime);
+            std::this_thread::sleep_for(waitTime);
     }
 }
 

--- a/src/module/lomse_events_dispatcher.cpp
+++ b/src/module/lomse_events_dispatcher.cpp
@@ -29,11 +29,6 @@
 
 #include "lomse_events_dispatcher.h"
 
-#if (LOMSE_USE_BOOST_ASIO == 1)
-    #include <boost/asio.hpp>
-    #include <boost/bind.hpp>
-#endif
-
 namespace lomse
 {
 
@@ -46,21 +41,12 @@ namespace lomse
 EventsDispatcher::EventsDispatcher()
     : m_pThread(nullptr)
     , m_fStopLoop(false)
-#if (LOMSE_USE_BOOST_ASIO == 1)
-    , m_pFakeWork(nullptr)
-#endif
 {
 }
 
 //---------------------------------------------------------------------------------------
 EventsDispatcher::~EventsDispatcher()
 {
-#if (LOMSE_USE_BOOST_ASIO == 1)
-    m_ioService.stop();
-    m_threads.join_all();   //join all the threads and wait for them to exit
-
-    delete m_pFakeWork;
-#endif
 }
 
 //---------------------------------------------------------------------------------------
@@ -76,18 +62,6 @@ void EventsDispatcher::start_events_loop()
 #if (LOMSE_DIRECT_INVOCATION == 0)
     delete m_pThread;
     m_pThread = LOMSE_NEW EventsThread(&EventsDispatcher::thread_main, this);
-#endif
-
-#if (LOMSE_USE_BOOST_ASIO == 1)
-     // create some fake work to keep the io_service live forever.
-    m_pFakeWork = LOMSE_NEW boost::asio::io_service::work(m_ioService);
-
-    //create the worker threads
-//    for(size_t t = 0; t < boost::thread::hardware_concurrency(); t++)
-    {
-        //m_threads.create_thread([&]() { m_ioService.run(); } );
-        m_threads.create_thread(boost::bind(&asio::io_service::run, &m_ioService));
-    }
 #endif
 }
 
@@ -122,15 +96,6 @@ void EventsDispatcher::post_event(Observer* pObserver, SpEventInfo pEvent)
     }
 #endif
 }
-
-////---------------------------------------------------------------------------------------
-//void EventsDispatcher::post_timed_event(Observer* pObserver, SpEventInfo pEvent)
-//{
-//#if (LOMSE_USE_BOOST_ASIO == 1)
-//    // this will be executed in one of the threads
-//    m_ioService.post(boost::bind(a_long_running_task, 123));
-//#endif
-//}
 
 //---------------------------------------------------------------------------------------
 // Methods to be executed in the thread

--- a/src/module/lomse_injectors.cpp
+++ b/src/module/lomse_injectors.cpp
@@ -183,15 +183,6 @@ EventsDispatcher* LibraryScope::get_events_dispatcher()
     return m_pDispatcher;
 }
 
-#if (LOMSE_USE_BOOST_ASIO == 1)
-//---------------------------------------------------------------------------------------
-boost::asio::io_service& LibraryScope::get_io_service()
-{
-    EventsDispatcher* pDispatcher = get_events_dispatcher();
-    return pDispatcher->get_io_service();
-}
-#endif
-
 //---------------------------------------------------------------------------------------
 double LibraryScope::get_screen_ppi() const
 {

--- a/src/render/lomse_font_storage.cpp
+++ b/src/render/lomse_font_storage.cpp
@@ -41,8 +41,7 @@
 
 #include "lomse_build_options.h"
 
-#include <boost/algorithm/string.hpp>   //to upper conversion
-
+#include <locale>   //to upper conversion
 using namespace agg;
 
 namespace lomse
@@ -193,7 +192,10 @@ std::string FontSelector::find_font(const std::string& language,
         return fullpath + fontFile;
 
     //transform name to capital letters for comparisons
-    string fontname = boost::to_upper_copy(name);
+    const locale& loc = locale();
+    string fontname;
+    for (string::value_type a : name)
+        fontname += std::toupper(a, loc);
 
     //music font
     if (fontname == "BRAVURA")

--- a/src/tests/lomse_test_score_player.cpp
+++ b/src/tests/lomse_test_score_player.cpp
@@ -100,7 +100,7 @@ public:
         //force to wait until the score if fully played
         while (m_fPlaying)
         {
-            boost::this_thread::sleep( boost::posix_time::milliseconds(100) );
+            std::this_thread::sleep_for( std::chrono::milliseconds(100) );
         }
         //delete m_pThread;
         m_pThread = nullptr;
@@ -123,7 +123,7 @@ public:
         //force to wait until the score if fully played
         while (m_fPlaying)
         {
-            boost::this_thread::sleep( boost::posix_time::milliseconds(100) );
+            std::this_thread::sleep_for( std::chrono::milliseconds(100) );
         }
         //delete m_pThread;
         m_pThread = nullptr;


### PR DESCRIPTION
In this PR we replace `boost::thread` with `std::thread`. That was the last module holding us with boost and therefore the CMake config was adjusted and dependency from boost there was removed.

## Changes
Although partially explained in #131 for the sake of completeness here full description of changes which were made:
- `boost::thread`, `boost::mutex`, etc. replaced with their analogues from `std`;
- `ScorePlayer` used `timed_join` and `interrupt` which don't exist in standard library. `timed_join` was replaced with `join`. I do not consider this to be a big issue because:
  * ScorePlayer already implements a proper signaling for interruption;
  * external thread termination is dangerous anyway and should be avoided;
- `boost::asio` has no replacement. Since `LOMSE_USE_BOOST_ASIO` was an experimental feature, all code related to ASIO was removed without replacement;
- one instance of `boost::to_upper_copy` was replaced with direct implementation using `std::toupper`. This is not related to `boost:thread` but I felt the change of three lines wasn't worth a separate PR. It's a separate commit though;
- CMake configuration was adjusted accordingly:
  * reference to package **boost** removed;
  * for **testlib** added reference to package **Threads** (resolves to **pthreads** on POSIX);
  * fixed a small bug in UnitTest++ library search paths; the full path to library was previously added to search path and the path to library wasn't added at all; that didn't produce issues because the same path was added by boost package; now, without boost, UnitTest++ library may be not found during linking. This was fixed.

## Testing
My testing is limited to **testlib**. Currently threads are used only in **Score Player**.

Another place is **Event Dispatcher** but by default threads are not active there due to `#define LOMSE_DIRECT_INVOCATION 1`. I've tried to deactivate direct invocation but many tests were crashing after that - in both `boost::thread` and `std::thread` versions. Adding `m_pThread->join()` to `EventsDispatcher::stop_events_loop()` fixed test failures but this is not included in the PR (consider adding it if you plan to use threaded version of event dispatcher).

## Building
Tested all of this on Mac (Clang) and Windows (MSVC).

For the first time I was able to run CMake on Windows without errors; previously it had issues finding boost (despite passing all necessary paths). The generated project file for MSVC was almost working: the library was built successfully but testlib building failed at linking stage when linker attempted to use liblomse.so (which obviously can't exist on Windows). This has to be looked into but that's a separate unrelated issue.