### PR TITLE
Make dependencies from zlib and pnglib optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,25 @@ include( ${LOMSE_ROOT_DIR}/build-options.cmake )
 #
 ###############################################################################
 
+#dependencies for building and for pkg-config file (intitially empty but will be enhanced)
+set(LOMSE_REQUIRES "")
+set(LOMSE_DEPENDENCIES "")
+
+# include directories to be installed
+set( INCLUDES_LOMSE  ${LOMSE_ROOT_DIR}/include )
+set( INCLUDES_AGG  ${LOMSE_ROOT_DIR}/src/agg/include )
+set( INCLUDES_UTFCPP  ${LOMSE_ROOT_DIR}/packages/utfcpp )
+set( INCLUDES_MINIZIP  ${LOMSE_ROOT_DIR}/packages/minizip )
+set( INCLUDES_PUGIXML  ${LOMSE_ROOT_DIR}/packages )
+include_directories(
+    ${INCLUDES_LOMSE}
+    ${INCLUDES_AGG}
+    ${LOMSE_ROOT_DIR}/src/agg/font_freetype
+    ${INCLUDES_UTFCPP}
+    ${INCLUDES_PUGIXML}
+)
+
+
 # Check for UnitTest++. Required for unit test
 if (LOMSE_BUILD_TESTS)
     find_package(UnitTest++)
@@ -182,60 +201,54 @@ if( FREETYPE_FOUND )
     message(STATUS "Freetype found: libraries= ${FREETYPE_LIBRARIES}" )
     message(STATUS "Freetype found: include= ${FREETYPE_INCLUDE_DIRS}" )
     message(STATUS "Freetype found: libdir= ${FREETYPE_LINK_DIR}" )
+    set(LOMSE_REQUIRES "${LOMSE_REQUIRES}, freetype2")
+    set(LOMSE_DEPENDENCIES "${LOMSE_DEPENDENCIES}, libfreetype6")
 else()
     message(SEND_ERROR "FreeType package not found.")
 endif()
 
 
 # Check for libpng
-find_package(PNG REQUIRED)                    
-if( PNG_FOUND )
-    include_directories( ${PNG_INCLUDE_DIRS} )
-    link_libraries( ${PNG_LIBRARIES} )
-    link_directories( ${PNG_LINK_DIR} )        
-    message(STATUS "libpng found: libraries= ${PNG_LIBRARIES}" )
-    message(STATUS "libpng found: include= ${PNG_INCLUDE_DIRS}" )
-    message(STATUS "libpng found: libdir= ${PNG_LINK_DIR}" )
-else()
-    message(SEND_ERROR "libpng package not found.")
+if( LOMSE_ENABLE_PNG )
+    find_package(PNG REQUIRED)                    
+    if( PNG_FOUND )
+        include_directories( ${PNG_INCLUDE_DIRS} )
+        link_libraries( ${PNG_LIBRARIES} )
+        link_directories( ${PNG_LINK_DIR} )        
+        message(STATUS "libpng found: libraries= ${PNG_LIBRARIES}" )
+        message(STATUS "libpng found: include= ${PNG_INCLUDE_DIRS}" )
+        message(STATUS "libpng found: libdir= ${PNG_LINK_DIR}" )
+        set(LOMSE_REQUIRES "${LOMSE_REQUIRES}, libpng")
+        set(LOMSE_DEPENDENCIES "${LOMSE_DEPENDENCIES}, libpng12-0 (>=1.2.42)")
+    else()
+        message(SEND_ERROR "libpng package not found.")
+    endif()
 endif()
 
 
-# Check for zlib
-find_package(ZLIB REQUIRED)
-if( ZLIB_FOUND )
-    include_directories( ${ZLIB_INCLUDE_DIR} )
-    link_libraries( ${ZLIB_LIBRARIES} )
-    link_directories( ${ZLIB_LINK_DIR} )        
-    message(STATUS "zlib found: libraries= ${ZLIB_LIBRARIES}" )
-    message(STATUS "zlib found: include= ${ZLIB_INCLUDE_DIRS}" )
-    message(STATUS "zlib found: libdir= ${ZLIB_LINK_DIR}" )
-    message(STATUS "zlib version: ${ZLIB_VERSION_STRING}" )
-else()
-    message(SEND_ERROR "zlib package not found.")
+if( LOMSE_ENABLE_COMPRESSION )
+    # Check for zlib
+    find_package(ZLIB REQUIRED)
+    if( ZLIB_FOUND )
+        include_directories( ${ZLIB_INCLUDE_DIR} )
+        link_libraries( ${ZLIB_LIBRARIES} )
+        link_directories( ${ZLIB_LINK_DIR} )        
+        message(STATUS "zlib found: libraries= ${ZLIB_LIBRARIES}" )
+        message(STATUS "zlib found: include= ${ZLIB_INCLUDE_DIRS}" )
+        message(STATUS "zlib found: libdir= ${ZLIB_LINK_DIR}" )
+        message(STATUS "zlib version: ${ZLIB_VERSION_STRING}" )
+        set(LOMSE_REQUIRES "${LOMSE_REQUIRES}, zlib")
+        set(LOMSE_DEPENDENCIES "${LOMSE_DEPENDENCIES}, zlib1g (>= ${ZLIB_VERSION_STRING})")
+        include_directories( ${INCLUDES_MINIZIP} )
+    else()
+        message(SEND_ERROR "zlib package not found.")
+    endif()
 endif()
 
 
-#dependencies for building and for pkg-config file
-set(LOMSE_REQUIRES "freetype2, libpng, zlib")
-set(LOMSE_DEPENDENCIES "libfreetype6, libpng12-0 (>=1.2.42), zlib1g (>= ${ZLIB_VERSION_STRING})")
-
-
-# include directories to be installed
-set( INCLUDES_LOMSE  ${LOMSE_ROOT_DIR}/include )
-set( INCLUDES_AGG  ${LOMSE_ROOT_DIR}/src/agg/include )
-set( INCLUDES_UTFCPP  ${LOMSE_ROOT_DIR}/packages/utfcpp )
-set( INCLUDES_MINIZIP  ${LOMSE_ROOT_DIR}/packages/minizip )
-set( INCLUDES_PUGIXML  ${LOMSE_ROOT_DIR}/packages )
-include_directories(
-    ${INCLUDES_LOMSE}
-    ${INCLUDES_AGG}
-    ${LOMSE_ROOT_DIR}/src/agg/font_freetype
-    ${INCLUDES_UTFCPP}
-    ${INCLUDES_MINIZIP}
-    ${INCLUDES_PUGIXML}
-)
-
+# strip leading commas from LOMSE_REQUIRES and LOMSE_DEPENDENCIES
+string( REGEX REPLACE "^, " "" LOMSE_REQUIRES ${LOMSE_REQUIRES})
+string( REGEX REPLACE "^, " "" LOMSE_DEPENDENCIES ${LOMSE_DEPENDENCIES})
 
 link_directories( ${LIBRARY_OUTPUT_PATH} )
 
@@ -459,11 +472,13 @@ if( UNIX )
             FILES_MATCHING PATTERN "*.h"
                            PATTERN ".svn" EXCLUDE )
 
-    # copy minizip includes
-    install(DIRECTORY "${INCLUDES_MINIZIP}/"
-            DESTINATION "${LOMSE_INCLUDEDIR}"
-            FILES_MATCHING PATTERN "*.h"
-                           PATTERN ".svn" EXCLUDE )
+    if( LOMSE_ENABLE_COMPRESSION )
+        # copy minizip includes
+        install(DIRECTORY "${INCLUDES_MINIZIP}/"
+                DESTINATION "${LOMSE_INCLUDEDIR}"
+                FILES_MATCHING PATTERN "*.h"
+                            PATTERN ".svn" EXCLUDE )
+    endif()
 
     # copy utfcpp includes
     install(DIRECTORY "${INCLUDES_UTFCPP}/"
@@ -507,11 +522,13 @@ elseif( WIN32 )
             FILES_MATCHING PATTERN "*.h"
                            PATTERN ".svn" EXCLUDE )
 
-    # copy minizip includes
-    install(DIRECTORY "${INCLUDES_MINIZIP}/"
-            DESTINATION "${LOMSE_INCLUDEDIR}"
-            FILES_MATCHING PATTERN "*.h"
+    if( LOMSE_ENABLE_COMPRESSION )
+        # copy minizip includes
+        install(DIRECTORY "${INCLUDES_MINIZIP}/"
+                DESTINATION "${LOMSE_INCLUDEDIR}"
+                FILES_MATCHING PATTERN "*.h"
                            PATTERN ".svn" EXCLUDE )
+    endif()
 
     # copy utfcpp includes
     install(DIRECTORY "${INCLUDES_UTFCPP}/"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,8 +110,9 @@
 #	messages. For instance:
 #		cmake -G "Unix Makefiles" -DLOMSE_ENABLE_COMPRESSION=OFF ....
 #
-#	**Important**: deactivating compression will also deactivate support for
-#	PNG images because libpng depends on zlib.
+#	**Important**: trying to disable compression without also disabling png
+#   has no effect because libpng depends on zlib. Therefore, when png is
+#   active (LOMSE_ENABLE_PNG=ON) then compression is automatically enabled.
 #
 #
 # d) Other options (ON / OFF values):

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 #--------------------------------------------------------------------------------------
 # This file is part of the Lomse library.
-# Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+# Lomse is copyrighted work (c) 2010-2018. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
@@ -49,38 +49,75 @@
 #
 #   cmake -G "CodeBlocks - Unix Makefiles"  ...
 #
-# Installation options
-# ---------------------
 #
-# The default installation prefix is "/usr/local". Therefore, libraries (binaries)
-# will be installed at "/usr/local/lib" and include files at
-# "/usr/local/include/lomse". You can change the default location 
-# by specifying option CMAKE_INSTALL_PREFIX. For instance:
+#---------------------------------------------------------------------------
+# Build options
+#---------------------------------------------------------------------------
 #
-#   cmake -DCMAKE_INSTALL_PREFIX=/usr  ...
-#
-# Also, a pkg-config file, liblomse.pc, will be installed. The default
-# location is "/usr/lib/pkgconfig". You can change this default location
-# by using the option -DLOMSE_PKG_CONFIG_INSTALL=/new/pkgconfig/path.
-# For instance:
-#
-#   cmake -DLOMSE_PKG_CONFIG_INSTALL=/usr/lib/x86_64-linux-gnu/pkgconfig  ...
+# Please note that default values can be changed directly in the CMake GUI or
+# through the command line by prefixing the option's name with '-D':
+# i.e.:    cmake -DLOMSE_DEBUG=ON  ....
 #
 #
-# Additional build options (ON / OFF values):
+# a) Installation options
 # --------------------------------------------
-# Values can be changed directly in the CMake GUI or through
-# the command line by prefixing a variable's name with '-D':
-# i.e.:    cmake -DLOMSE_DEBUG=ON  ...
+#
+# MAKE_INSTALL_PREFIX  (Default: "/usr/local")
+# 	The default installation prefix is "/usr/local". Therefore, libraries
+#	(binaries) will be installed at "/usr/local/lib" and include files at
+# 	"/usr/local/include/lomse". You can change the default location 
+# 	by specifying option CMAKE_INSTALL_PREFIX. For instance:
+#   	cmake -DCMAKE_INSTALL_PREFIX=/usr  ....
+#
+# LOMSE_PKG_CONFIG_INSTALL  (Default "/usr/lib/pkgconfig")
+# 	As part of the Lomse instalation process, a pkg-config file, named
+#	liblomse.pc, is installed. The default location is "/usr/lib/pkgconfig".
+#	You can change this default location by using the option
+#	-DLOMSE_PKG_CONFIG_INSTALL=/new/pkgconfig/path. For instance:
+#   	cmake -DLOMSE_PKG_CONFIG_INSTALL=/usr/lib/x86_64-linux-gnu/pkgconfig  ....
+#
+#
+# b) Debug options (ON / OFF values):
+# --------------------------------------------
 #
 # LOMSE_ENABLE_DEBUG_LOGS   (Default value: OFF)
-#       Enable debug logs (performance loss). Doesn't require a debug build.
+#	Enable debug logs (performance loss). Doesn't require a debug build.
 #
 # LOMSE_DEBUG   (Default value: OFF)      
-#       Force to create a debug build, with debug symbols.
+#	Force to create a debug build, with debug symbols.
 #
+#
+# c) Options to reduce dependencies from other libraries (ON / OFF values):
+# --------------------------------------------------------------------------
+#
+# If your application will not deal with compressed files or with scores
+# containing png images, it is possible to reduce dependencies from third
+# party librraries by removing the code that deals with compressed files
+# or with PNG images.
+#
+# LOMSE_ENABLE_PNG   (Default value: ON)
+#	Build with support for PNG images. This requires libpng library.
+#	By setting this to OFF Lomse will ignore any png image embedded in the
+#	documents. But Lomse will not fail in those cases, just will log error
+#	messages. For instance:
+#		cmake -G "Unix Makefiles" -DLOMSE_ENABLE_PNG=OFF ....
+#
+# LOMSE_ENABLE_COMPRESSION   (Default value: ON)
+#	Build with support for compressed files. This requires zlib library.
+#	By setting this to OFF Lomse will not be able to deal with compressed files,
+#	such as MusicXML files in compressed format, or with png images embedded in
+#	the documents. But Lomse will not fail in those cases, just will log error
+#	messages. For instance:
+#		cmake -G "Unix Makefiles" -DLOMSE_ENABLE_COMPRESSION=OFF ....
+#
+#	**Important**: deactivating compression will also deactivate support for
+#	PNG images because libpng depends on zlib.
+#
+#
+# d) Other options (ON / OFF values):
+# --------------------------------------------
 # LOMSE_COMPATIBILITY_LDP_1_5   (Default value: ON)
-#       Enables backwards compatibility for scores in LDP v1.5
+#       Enables backwards compatibility for accepting scores in LDP v1.5 syntax
 #
 #-------------------------------------------------------------------------------------
 

--- a/add-sources.cmake
+++ b/add-sources.cmake
@@ -199,10 +199,16 @@ set(SOUND_FILES
 )
 
 set(LOMSE_PACKAGES_FILES
-    ${LOMSE_PKG_DIR}/minizip/unzip.c
-    ${LOMSE_PKG_DIR}/minizip/ioapi.c
     ${LOMSE_PKG_DIR}/pugixml/pugixml.cpp
 )
+
+if( LOMSE_ENABLE_COMPRESSION )
+    set(LOMSE_PACKAGES_FILES
+        ${LOMSE_PACKAGES_FILES}
+        ${LOMSE_PKG_DIR}/minizip/unzip.c
+        ${LOMSE_PKG_DIR}/minizip/ioapi.c
+    )
+endif()
 
 set(ALL_LOMSE_SOURCES 
     ${AGG_FILES} ${DOCUMENT_FILES} ${EXPORTERS_FILES} ${FILE_SYSTEM_FILES}

--- a/build-options.cmake
+++ b/build-options.cmake
@@ -48,6 +48,13 @@ endif()
 #Build the example-1 program that uses the library
 option(LOMSE_BUILD_EXAMPLE "Build the example-1 program" OFF)
 
+#optional dependencies
+option(LOMSE_ENABLE_COMPRESSION "Enable compressed formats (requires zlib)" ON)
+option(LOMSE_ENABLE_PNG "Enable png format (requires pnglib and zlib)" ON)
+if (LOMSE_ENABLE_PNG)
+    set(LOMSE_ENABLE_COMPRESSION ON)
+endif()      
+
 
 message(STATUS "Build the static library = ${LOMSE_BUILD_STATIC_LIB}")
 message(STATUS "Build the shared library = ${LOMSE_BUILD_SHARED_LIB}")
@@ -56,6 +63,8 @@ message(STATUS "Run tests after building = ${LOMSE_RUN_TESTS}")
 message(STATUS "Create Debug build = ${LOMSE_DEBUG}")
 message(STATUS "Enable debug logs = ${LOMSE_ENABLE_DEBUG_LOGS}")
 message(STATUS "Compatibility for LDP v1.5 = ${LOMSE_COMPATIBILITY_LDP_1_5}")
+message(STATUS "Enable compressed formats = ${LOMSE_ENABLE_COMPRESSION}")
+message(STATUS "Enable png format = ${LOMSE_ENABLE_PNG}")
 
 
 

--- a/build-options.cmake
+++ b/build-options.cmake
@@ -52,7 +52,10 @@ option(LOMSE_BUILD_EXAMPLE "Build the example-1 program" OFF)
 option(LOMSE_ENABLE_COMPRESSION "Enable compressed formats (requires zlib)" ON)
 option(LOMSE_ENABLE_PNG "Enable png format (requires pnglib and zlib)" ON)
 if (LOMSE_ENABLE_PNG)
-    set(LOMSE_ENABLE_COMPRESSION ON)
+	if (NOT LOMSE_ENABLE_COMPRESSION)
+        message(STATUS "**WARNING**: Enabling PNG requires enabling compression. LOMSE_ENABLE_COMPRESSION set to ON" )
+    	set(LOMSE_ENABLE_COMPRESSION ON)
+	endif()
 endif()      
 
 

--- a/include/lomse_image_reader.h
+++ b/include/lomse_image_reader.h
@@ -74,6 +74,7 @@ public:
     SpImage decode_file(InputStream* file);
 };
 
+#if (LOMSE_ENABLE_PNG == 1)
 //---------------------------------------------------------------------------------------
 // PngImageDecoder: knows how to read a PNG image
 class PngImageDecoder : public ImageDecoder
@@ -87,7 +88,7 @@ public:
     SpImage decode_file(InputStream* file);
 
 };
-
+#endif // LOMSE_ENABLE_PNG
 
 }   //namespace lomse
 

--- a/liblomse.pc.cmake
+++ b/liblomse.pc.cmake
@@ -7,7 +7,7 @@ Name: liblomse
 Description: LenMus open music score edition library
 Version: @LOMSE_VERSION_STRING@
 Requires: @LOMSE_REQUIRES@
-Libs: -L${libdir} -llomse -lboost_system -lboost_thread -lboost_date_time
+Libs: -L${libdir} -llomse -lpthread
 Cflags: -I${includedir}
 
 

--- a/lomse_config.h.cmake
+++ b/lomse_config.h.cmake
@@ -76,6 +76,12 @@
 // Enable debug logs. It is independent of build mode: debug or release
 #define LOMSE_ENABLE_DEBUG_LOGS     @LOMSE_ENABLE_DEBUG_LOGS@
 
+// Enable compressed formats (requires zlib)
+#define LOMSE_ENABLE_COMPRESSION    @LOMSE_ENABLE_COMPRESSION@
+
+// Enable png format (requires pnglib and zlib)
+#define LOMSE_ENABLE_PNG    @LOMSE_ENABLE_PNG@
+
 
 #endif  // __LOMSE_CONFIG_H__
 

--- a/src/file_system/lomse_file_system.cpp
+++ b/src/file_system/lomse_file_system.cpp
@@ -28,9 +28,11 @@
 //---------------------------------------------------------------------------------------
 
 #include "lomse_file_system.h"
-
-#include "lomse_zip_stream.h"
 #include "lomse_logger.h"
+
+#if (LOMSE_ENABLE_COMPRESSION == 1)
+	#include "lomse_zip_stream.h"
+#endif
 
 #include <iostream>
 #include <sstream>
@@ -207,8 +209,10 @@ InputStream* FileSystem::open_input_stream(const string& filelocator)
             {
                 case DocLocator::k_none:
                     return LOMSE_NEW LocalInputStream(filelocator);
+#if (LOMSE_ENABLE_COMPRESSION == 1)
                 case DocLocator::k_zip:
                     return LOMSE_NEW ZipInputStream(filelocator);
+#endif
                 default:
                 {
                     LOMSE_LOG_ERROR("Invalid file locator protocol");

--- a/src/file_system/lomse_image_reader.cpp
+++ b/src/file_system/lomse_image_reader.cpp
@@ -31,8 +31,10 @@
 
 #include "lomse_logger.h"
 
-#include <png.h>
-#include <pngconf.h>
+#if (LOMSE_ENABLE_PNG == 1)
+	#include <png.h>
+	#include <pngconf.h>
+#endif
 
 #include <iostream>
 #include <sstream>
@@ -46,11 +48,12 @@ using ::free;
 namespace lomse
 {
 
+#if (LOMSE_ENABLE_PNG == 1)
 //declaration of some internal functions, to avoid compiler warnings
 void read_callback(png_structp png, png_bytep data, png_size_t length);
 void error_callback (png_structp, png_const_charp);
 void warning_callback (png_structp, png_const_charp);
-
+#endif
 
 //=======================================================================================
 // ImageReader implementation
@@ -62,6 +65,7 @@ SpImage ImageReader::load_image(const string& locator)
     {
         pFile = FileSystem::open_input_stream(locator);
         //find a reader that can decode the file
+#if (LOMSE_ENABLE_PNG == 1)
         {
             //PNG Format
             PngImageDecoder decoder;
@@ -72,6 +76,7 @@ SpImage ImageReader::load_image(const string& locator)
                 return img;
             }
         }
+#endif
         {
             //JPG Format
             JpgImageDecoder decoder;
@@ -107,6 +112,9 @@ SpImage ImageReader::load_image(const string& locator)
     }
     return SpImage( LOMSE_NEW Image() );   //compiler happy
 }
+
+
+#if (LOMSE_ENABLE_PNG == 1)
 
 //=======================================================================================
 // PngImageDecoder implementation
@@ -282,6 +290,7 @@ SpImage PngImageDecoder::decode_file(InputStream* file)
     return SpImage(pImage);
 }
 
+#endif // LOMSE_ENABLE_PNG
 
 
 //=======================================================================================

--- a/src/file_system/lomse_zip_stream.cpp
+++ b/src/file_system/lomse_zip_stream.cpp
@@ -27,6 +27,9 @@
 // the project at cecilios@users.sourceforge.net
 //---------------------------------------------------------------------------------------
 
+#include "lomse_config.h"
+#if (LOMSE_ENABLE_COMPRESSION == 1)
+
 #include "lomse_zip_stream.h"
 
 #include "lomse_logger.h"
@@ -415,3 +418,5 @@ unsigned char* ZipInputStream::get_as_string()
 
 
 }  //namespace lomse
+
+#endif  // LOMSE_ENABLE_COMPRESSION

--- a/src/parser/lmd/lomse_lmd_compiler.cpp
+++ b/src/parser/lmd/lomse_lmd_compiler.cpp
@@ -37,8 +37,10 @@
 #include "lomse_internal_model.h"
 #include "lomse_document.h"
 #include "lomse_file_system.h"
-#include "lomse_zip_stream.h"
 
+#if (LOMSE_ENABLE_COMPRESSION == 1)
+	#include "lomse_zip_stream.h"
+#endif
 
 using namespace std;
 
@@ -82,6 +84,7 @@ ImoDocument* LmdCompiler::compile_file(const std::string& filename)
     DocLocator locator(m_fileLocator);
     if (locator.get_inner_protocol() == DocLocator::k_zip)
     {
+#if (LOMSE_ENABLE_COMPRESSION == 1)
         InputStream* pFile = FileSystem::open_input_stream(m_fileLocator);
         ZipInputStream* zip  = static_cast<ZipInputStream*>(pFile);
 
@@ -90,6 +93,9 @@ ImoDocument* LmdCompiler::compile_file(const std::string& filename)
 
         delete pFile;
         delete buffer;
+#else
+		throw runtime_error("Could not open compressed file: Lomse was compiled without compression support");
+#endif
     }
     else //k_file
         m_pParser->parse_file(filename);

--- a/src/parser/lmd/lomse_lmd_compiler.cpp
+++ b/src/parser/lmd/lomse_lmd_compiler.cpp
@@ -94,7 +94,9 @@ ImoDocument* LmdCompiler::compile_file(const std::string& filename)
         delete pFile;
         delete buffer;
 #else
-		throw runtime_error("Could not open compressed file: Lomse was compiled without compression support");
+        LOMSE_LOG_ERROR("Could not open compressed file '%s'. Lomse was "
+                        "compiled without compression support.", filename.c_str());
+        return nullptr;
 #endif
     }
     else //k_file

--- a/src/parser/mnx/lomse_mnx_compiler.cpp
+++ b/src/parser/mnx/lomse_mnx_compiler.cpp
@@ -38,8 +38,11 @@
 #include "lomse_internal_model.h"
 #include "lomse_document.h"
 #include "lomse_file_system.h"
-#include "lomse_zip_stream.h"
 #include "lomse_ldp_compiler.h"
+
+#if (LOMSE_ENABLE_COMPRESSION == 1)
+	#include "lomse_zip_stream.h"
+#endif
 
 
 using namespace std;
@@ -84,6 +87,7 @@ ImoDocument* MnxCompiler::compile_file(const std::string& filename)
     DocLocator locator(m_fileLocator);
     if (locator.get_inner_protocol() == DocLocator::k_zip)
     {
+#if (LOMSE_ENABLE_COMPRESSION == 1)
         InputStream* pFile = FileSystem::open_input_stream(m_fileLocator);
         ZipInputStream* zip  = static_cast<ZipInputStream*>(pFile);
 
@@ -92,6 +96,9 @@ ImoDocument* MnxCompiler::compile_file(const std::string& filename)
 
         delete pFile;
         delete buffer;
+#else
+		throw runtime_error("Could not open compressed file: Lomse was compiled without compression support");
+#endif
     }
     else //k_file
         m_pParser->parse_file(filename);

--- a/src/parser/mnx/lomse_mnx_compiler.cpp
+++ b/src/parser/mnx/lomse_mnx_compiler.cpp
@@ -97,7 +97,9 @@ ImoDocument* MnxCompiler::compile_file(const std::string& filename)
         delete pFile;
         delete buffer;
 #else
-		throw runtime_error("Could not open compressed file: Lomse was compiled without compression support");
+        LOMSE_LOG_ERROR("Could not open compressed file '%s'. Lomse was "
+                        "compiled without compression support.", filename.c_str());
+        return nullptr;
 #endif
     }
     else //k_file

--- a/src/parser/mxl/lomse_mxl_compiler.cpp
+++ b/src/parser/mxl/lomse_mxl_compiler.cpp
@@ -37,8 +37,11 @@
 #include "lomse_internal_model.h"
 #include "lomse_document.h"
 #include "lomse_file_system.h"
-#include "lomse_zip_stream.h"
 #include "lomse_ldp_compiler.h"
+
+#if (LOMSE_ENABLE_COMPRESSION == 1)
+	#include "lomse_zip_stream.h"
+#endif
 
 
 using namespace std;
@@ -83,6 +86,7 @@ ImoDocument* MxlCompiler::compile_file(const std::string& filename)
     DocLocator locator(m_fileLocator);
     if (locator.get_inner_protocol() == DocLocator::k_zip)
     {
+#if (LOMSE_ENABLE_COMPRESSION == 1)
         InputStream* pFile = FileSystem::open_input_stream(m_fileLocator);
         ZipInputStream* zip  = static_cast<ZipInputStream*>(pFile);
 
@@ -91,6 +95,9 @@ ImoDocument* MxlCompiler::compile_file(const std::string& filename)
 
         delete pFile;
         delete buffer;
+#else
+		throw runtime_error("Could not open compressed file: Lomse was compiled without compression support");
+#endif
     }
     else //k_file
         m_pParser->parse_file(filename);

--- a/src/tests/lomse_test_document.cpp
+++ b/src/tests/lomse_test_document.cpp
@@ -375,6 +375,32 @@ SUITE(DocumentTest)
               "(barline simple))))))" );
     }
 
+    TEST_FIXTURE(DocumentTestFixture, creation_011)
+    {
+        //Opening compressed file (LMB)
+
+        stringstream errormsg;
+        Document doc(m_libraryScope, errormsg);
+        doc.from_file(m_scores_path + "10014-compressed-flat-lmd.zip#zip:lenmusdoc-example.lmd",
+                      Document::k_format_lmd);
+        ImoDocument* pImoDoc = doc.get_im_root();
+#if (LOMSE_ENABLE_COMPRESSION == 1)
+        //@011. Compression enabled. Compressed LMB file read ok
+        CHECK( pImoDoc != nullptr );
+        CHECK( pImoDoc->get_owner() == &doc );
+        CHECK( doc.is_dirty() == true );
+        //cout << doc.to_string() << endl;
+        CHECK( doc.to_string().compare(0, 36, "(lenmusdoc (vers 0.0)(content (TODO:") == 0 );
+#else
+        //@011. Compression disabled. Error when opening LMB compressed file
+        CHECK( pImoDoc != nullptr );
+        CHECK( pImoDoc->get_owner() == &doc );
+        CHECK( doc.is_dirty() == true );
+//        cout << doc.to_string() << endl;
+        CHECK( doc.to_string() == "(lenmusdoc (vers 0.0)(content))" );
+#endif
+    }
+
     TEST_FIXTURE(DocumentTestFixture, get_score_100)
     {
         //100. in empty doc returns nullptr

--- a/src/tests/lomse_test_image_reader.cpp
+++ b/src/tests/lomse_test_image_reader.cpp
@@ -81,6 +81,8 @@ SUITE(ImageReaderTest)
 //        doc.from_file(m_scores_path + "08041-read-jpg-image.lms");
 //    }
 
+#if (LOMSE_ENABLE_PNG == 1)
+
     TEST_FIXTURE(ImageReaderTestFixture, ImageReader_can_decode_png_1)
     {
         string path = m_scores_path + "test-image-1.png";
@@ -98,5 +100,7 @@ SUITE(ImageReaderTest)
         CHECK( dec.can_decode(file) == false );
         delete file;
     }
+
+#endif // LOMSE_ENABLE_PNG
 
 }

--- a/src/tests/lomse_test_ldp_analyser.cpp
+++ b/src/tests/lomse_test_ldp_analyser.cpp
@@ -10186,6 +10186,7 @@ SUITE(LdpAnalyserTest)
         if (pRoot && !pRoot->is_document()) delete pRoot;
     }
 
+#if (LOMSE_ENABLE_PNG == 1)
     // image ----------------------------------------------------------------------------
 
     TEST_FIXTURE(LdpAnalyserTestFixture, Image_Ok)
@@ -10211,6 +10212,7 @@ SUITE(LdpAnalyserTest)
         delete tree->get_root();
         if (pRoot && !pRoot->is_document()) delete pRoot;
     }
+#endif // LOMSE_ENABLE_PNG
 
     // list -----------------------------------------------------------------------------
 

--- a/src/tests/lomse_test_zip_stream.cpp
+++ b/src/tests/lomse_test_zip_stream.cpp
@@ -32,6 +32,8 @@
 #include "lomse_config.h"
 #include "lomse_build_options.h"
 
+#if (LOMSE_ENABLE_COMPRESSION == 1)
+
 //classes related to these tests
 #include "lomse_injectors.h"
 #include "lomse_zip_stream.h"
@@ -400,3 +402,5 @@ SUITE(ZipInputStreamTest)
     }
 
 }
+
+#endif // LOMSE_ENABLE_COMPRESSION


### PR DESCRIPTION
As previously discussed in #131 this PR implements the possibility to build Lomse without explicit dependency from zlib and pnglib.

**Note:** Freetype may still require zlib but that's regulated outside of Lomse build process. In particular on Windows official builds of Freetype don't require separate zlib (Freetype.dll probably has zlib statically integrated).

By default zlib and pnglib are used in Lomse like before and all features are enabled. To build without pnglib and/or zlib there are two CMake options (both `ON` by default):
 - LOMSE_ENABLE_COMPRESSION;
 - LOMSE_ENABLE_PNG.

In the following example we run CMake providing these two options:
```shell
cmake -G "Unix Makefiles" -DLOMSE_ENABLE_PNG=OFF -DLOMSE_ENABLE_COMPRESSION=OFF  ../lomse
```

**Note:** Pnglib can be deactivated separately but deactivating of zlib also requires deactivating of pnglib because pnglib depends on zlib. Therefore `LOMSE_ENABLE_COMPRESSION=OFF` also requires `LOMSE_ENABLE_PNG=OFF`.

Status of the new options is printed during running CMake similar to other options:
```
-- Compatibility for LDP v1.5 = ON
-- Enable compressed formats = OFF
-- Enable png format = OFF
```

`lomse_config.h` contains two new preprocessor defines:
```C++
// Enable compressed formats (requires zlib)
#define LOMSE_ENABLE_COMPRESSION    @LOMSE_ENABLE_COMPRESSION@

// Enable png format (requires pnglib and zlib)
#define LOMSE_ENABLE_PNG    @LOMSE_ENABLE_PNG@
```

Code parts depending on zlib or pnglib are guarded using these defines, for example:
```C++
#if (LOMSE_ENABLE_PNG == 1)
// PngImageDecoder: knows how to read a PNG image
class PngImageDecoder : public ImageDecoder
... 
};
#endif // LOMSE_ENABLE_PNG
```

### Testing
Tested on Mac (Clang) with default options and with deactivated libraries. All compiles successfully, all tests pass.

My tests on Linux were limited to Travis build with default options (zlib and pnglib are both enabled).

Also tested on Windows, library compiles successfully. As mentioned in other PR testlib application still fails to link due to some misconfiguration. That's a separate issue not related to current PR. I don't know how to fix this yet, that needs a separate investigation.

### Extras
I've found that library config file `liblomse.pc.cmake` was still referencing boost libraries. I've fixed this within this PR but in a separate commit. I thought it wasn't worth a separate PR.

---
This PR has option **Allow edits from maintainers** activated. Please feel free to commit any necessary modifications or tell me if you want me to change something.

Thanks for very quick reviewing and merging of my PRs!