### PR TITLE
Check with multiple compilers on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,84 @@
+sudo: false
+dist: trusty
 language: cpp
 
-compiler: gcc
+matrix:
+  include:
 
-before_install:
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo apt-get update -qq
-  - sudo apt-get install -y build-essential
-  - sudo apt-get install -y cmake libboost-date-time-dev libboost-thread-dev libboost-system-dev
-  - sudo apt-get install -y libportmidi-dev libsqlite3-0 libsqlite3-dev
-  - sudo apt-get install -y libfreetype6-dev libpng++-dev zlib1g-dev libwxgtk3.0-dev
-  - sudo apt-get install -y libunittest++-dev
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-4.9
-      - g++-4.9
+    - os: linux
+      env:
+        - COMPILER=gcc-4.9 
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+            - cmake
+            - libfreetype6-dev
+            - libpng++-dev
+            - zlib1g-dev
+            - libunittest++-dev
+
+    - os: linux
+      env:
+        - COMPILER=gcc-4.9 
+        - CXXFLAGS="-D_GLIBCXX_DEBUG"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+            - cmake
+            - libfreetype6-dev
+            - libpng++-dev
+            - zlib1g-dev
+            - libunittest++-dev
+
+    - os: linux
+      env:
+        - COMPILER=gcc-7
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+            - cmake
+            - libfreetype6-dev
+            - libpng++-dev
+            - zlib1g-dev
+            - libunittest++-dev
+
+    - os: linux
+      env:
+        - COMPILER=gcc-7
+        - CXXFLAGS="-D_GLIBCXX_DEBUG"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+            - cmake
+            - libfreetype6-dev
+            - libpng++-dev
+            - zlib1g-dev
+            - libunittest++-dev
+
+    - os: osx
+      env:
+        - COMPILER=clang 
+      install:
+        - brew install unittest-cpp
 
 script:
-  - mkdir build
-  - cd build
-  - cmake -G "Unix Makefiles"  ..
+  - export CC=$COMPILER
+  - export CXX=${CC/gcc/g++}
+  - export CXX=${CXX/clang/clang++}
+  - $CXX --version
+  - mkdir build && cd build
+  - cmake -G "Unix Makefiles" ..
   - make
   - ./bin/testlib

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,4 +81,4 @@ script:
   - mkdir build && cd build
   - cmake -G "Unix Makefiles" ..
   - make
-  - ./bin/testlib
+  - ./bin/testlib; if [ $? -ne 0 ]; then ./bin/testlib -v; exit 1; fi


### PR DESCRIPTION
In this PR Travis config is extended to check Lomse with multiple compilers:
- **GCC 4.9** on Linux, default C++ library;
- **GCC 4.9** on Linux, debug C++ library (-D_GLIBCXX_DEBUG);
- **GCC 7** on Linux, default C++ library;
- **GCC 7** on Linux, debug C++ library (-D_GLIBCXX_DEBUG);
- **Clang 4.2** on macOS.

### Why these compilers?
GCC 4.9 is the oldest GCC version supported by Lomse.

GCC 7 is the current stable version.

Clang is the default compiler on macOS and FreeBSD. Travis offers testing on macOS.

### Even more compilers
It's easy to add GCC 5 and GCC 6 to the test matrix. Not so easy but also possible to add Clang 3.6, 3.9, 4.0 and 5.0 on Linux.

However Travis limits the number of parallel jobs running. They don't define a hard number but in my experience only five jobs are running simultaneously. With five compiler configurations defined in Travis config they all are tested simultaneously and you have the Travis result (pass or failure) in no additional time. By adding more compilers to test matrix only five configurations run at first, the others run after the first jobs are completed. This doubles test time (or triples, etc. if you have more than 10 test configurations).

### Build failures
As you can see from the status of Travis build for this PR it has failed. There are compilation errors on GCC 7 caused by stronger conversion rules introduced in GCC 5. I haven't fixed these errors to demonstrate the usefulness of testing on multiple compilers ;)