### PR TITLE
ScorePlayer thread start synchronisation

### DIFF
--- a/include/lomse_score_player.h
+++ b/include/lomse_score_player.h
@@ -86,6 +86,7 @@ class ScorePlayer
 protected:
     LibraryScope&       m_libScope;
     SoundThread*        m_pThread;      //execution thread
+    std::mutex          m_startMutex;   //mutex so synchronize thread start
     MidiServerBase*     m_pMidi;        //MIDI server to receive MIDI events
     bool                m_fPaused;      //execution is paused
     bool                m_fShouldStop;  //request to stop playback

--- a/src/sound/lomse_score_player.cpp
+++ b/src/sound/lomse_score_player.cpp
@@ -190,9 +190,11 @@ void ScorePlayer::play_segment(int nEvStart, int nEvEnd)
     //Create a new thread. It starts inmediately to execute do_play()
     delete m_pThread;
     m_fPlaying = true;
+    m_startMutex.lock();
     m_pThread = LOMSE_NEW SoundThread(&ScorePlayer::thread_main, this,
                                 nEvStart, nEvEnd, m_fVisualTracking,
                                 m_nMM, m_pInteractor);
+    m_startMutex.unlock();
     LOMSE_LOG_DEBUG(Logger::k_score_player, "<<[ScorePlayer::play_segment]");
 }
 
@@ -201,6 +203,11 @@ void ScorePlayer::thread_main(int nEvStart, int nEvEnd, bool fVisualTracking,
                               long nMM, Interactor* pInteractor)
 {
     LOMSE_LOG_DEBUG(Logger::k_score_player, ">>[ScorePlayer::thread_main]");
+
+    // waiting for "play_segment" to initialize "m_pThread" 
+    m_startMutex.lock();
+    m_startMutex.unlock();
+
     if (pInteractor && !m_fPostEvents)
         pInteractor->enable_forced_view_updates(false);
     fVisualTracking &= (pInteractor != nullptr);


### PR DESCRIPTION
`ScorePlayer` has member `m_pThread` pointing to playback thread. It is initialised in `ScorePlayer::play_segment`:
```C++
m_pThread = LOMSE_NEW SoundThread(&ScorePlayer::thread_main, this,
```

and then used in `ScorePlayer::do_play`:
```C++
if (!m_pMidi || !m_pThread)
{
      LOMSE_LOG_DEBUG(Logger::k_score_player, "<< Enter. No Midi or no thread. << Exit");
      return;
}
```

Depending on how thread scheduler on OS works the new thread may become active before the first thread continues execution. In this case `m_pThread` may be not yet initialised when it is checked in `do_play`, causing do_play to immediately terminate.

This happens pretty often on Windows causing ScorePlayerTest to fail. In theory this may happen on other OSes too but I didn't see this test failed on Linux or macOS yet.

The proposed fix uses mutex to ensure the main function of the new thread is executed after `m_pThread` is initialised.