### PR TITLE
Appveyor integration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,55 @@
+# version format
+version: 0.{build}
+
+# branches to build
+branches:
+  # blacklist
+  except:
+    - gh-pages
+
+# Build worker image (VM template)
+image: Visual Studio 2015
+
+# clone directory
+clone_folder: c:\projects\lomse
+
+# set clone depth
+clone_depth: 5                      # clone entire repository history if not defined
+
+# environment variables
+environment:
+  FREETYPE_URL: https://github.com/ubawurinna/freetype-windows-binaries/releases/download/v2.9/freetype-2.9.zip
+  UNITTESTCPP_URL: https://github.com/unittest-cpp/unittest-cpp/archive/v2.0.0.zip
+
+# scripts that run after cloning repository
+install:
+  # Fetching and compiling dependencies
+  - cd ..
+  - mkdir ExternalLibraries
+  - cd ExternalLibraries
+  # Preparing FreeType
+  - curl -fsSL -o freetype.zip %FREETYPE_URL%
+  - 7z x -ofreetype freetype.zip
+  # Preparing UnitTest++
+  - curl -fsSL -o unittest-cpp.zip %UNITTESTCPP_URL%
+  - 7z x unittest-cpp.zip
+  - cd unittest-cpp-2.0.0
+  - cmake .
+  - cmake --build . --target UnitTest++
+  - cd ..\.. 
+
+# to run your custom scripts instead of automatic MSBuild
+build_script:
+  # Compile Lomse
+  - mkdir build
+  - cd build
+  - cmake -DLOMSE_ENABLE_COMPRESSION=OFF -DLOMSE_ENABLE_PNG=OFF  -DFREETYPE_INCLUDE_DIRS=C:\projects\ExternalLibraries\freetype\include -DFREETYPE_LIBRARY=C:\projects\ExternalLibraries\freetype\win32\freetype.lib -DUNITTEST++_INCLUDE_DIR=C:\projects\ExternalLibraries\unittest-cpp-2.0.0\UnitTest++ -DUNITTEST++_LIBRARY=C:\projects\ExternalLibraries\unittest-cpp-2.0.0\Debug\UnitTest++.lib ../lomse
+  - cmake --build .
+  - copy ..\ExternalLibraries\freetype\win32\freetype.dll .\bin\Debug
+
+# to run your custom scripts instead of automatic tests
+test_script:
+  # Run Lomse Tests. If failed re-run in verbose mode
+  - ps: |
+      .\bin\Debug\testlib
+      if (-not $?) { .\bin\Debug\testlib -v; $host.SetShouldExit(1) }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,14 +374,13 @@ if(LOMSE_BUILD_TESTS)
     find_package (Threads)
     
     # libraries to link
-    if (BUILD_SHARED_LIB)
+    if (LOMSE_BUILD_SHARED_LIB)
         target_link_libraries ( ${TESTLIB} lomse-shared libunittest++.a ${CMAKE_THREAD_LIBS_INIT} )
+        add_dependencies(testlib lomse-shared)
     else()      
-        target_link_libraries ( ${TESTLIB} lomse.so libunittest++.a ${CMAKE_THREAD_LIBS_INIT} )
+        target_link_libraries ( ${TESTLIB} lomse unittest++ ${CMAKE_THREAD_LIBS_INIT} )
+        add_dependencies(testlib lomse-static)
     endif()
-
-    # dependencies
-    add_dependencies(testlib lomse-shared)
 
     # once generated, run tests
     if (LOMSE_RUN_TESTS)

--- a/build-options.cmake
+++ b/build-options.cmake
@@ -33,8 +33,22 @@ endif()
 
 
 #libraries to build
-option(LOMSE_BUILD_STATIC_LIB "Build the static library" OFF)
-option(LOMSE_BUILD_SHARED_LIB "Build the shared library" ON)
+if (WIN32)
+    set(LOMSE_BUILD_STATIC_LIB ON)
+    set(LOMSE_BUILD_SHARED_LIB OFF)
+else()
+    set(LOMSE_BUILD_STATIC_LIB OFF)
+    set(LOMSE_BUILD_SHARED_LIB ON)
+endif()
+
+option(LOMSE_BUILD_STATIC_LIB "Build the static library" ${LOMSE_BUILD_STATIC_LIB})
+option(LOMSE_BUILD_SHARED_LIB "Build the shared library" ${LOMSE_BUILD_SHARED_LIB})
+
+if (WIN32)
+    if (LOMSE_BUILD_SHARED_LIB AND MSVC)
+        message(FATAL_ERROR "Shared C++ libraries (C++ DLL) are not supported by MSVC")
+    endif()
+endif()
 
 #Build the test units runner program 'testlib'
 option(LOMSE_BUILD_TESTS "Build testlib program" ON)


### PR DESCRIPTION
This implements CI on Windows via Appveyor platform.
You need to create a (free) account on [appveyor.com](https://ci.appveyor.com/signup):
![image](https://user-images.githubusercontent.com/3368402/41478734-14f8edc2-70c9-11e8-8f86-6b19d2bd1839.png)

Then create new project and link it with your GitHub project. You don't have to do any config there as it will read all settings from `.appveyor.yml` in your repository. You may want to change UI setting **Default branch** though, it's used when you click "new build" in appveyor UI. That should allow you to test Appveyor integration in the PR-branch before merging into master.

## Some details
- Builds are performed using Visual Studio 2015 in debug mode.
- Required libraries Freetype and UnitTest++ are downloaded from their websites.
- Freetype is downloaded in compiled form.
- UnitTest++ is downloaded in source code and then compiled.
- zlib and pnglib projects do not provide precompiled usable libraries. Compiling them isn't that straightforward. To make it easier I just switched off compression and png support when building Lomse. Since this isn't the core functionality I think it's enough to have them tested on Linux.

## Fixed CMake config for Windows
CMake config was trying to build shared library (DLL) like it does on other platforms. However Visual C++ doesn't support shared C++ libraries. There are workarounds but they are so complex and error prone that no one sane would do that unless forced. Therefore CMake config for Windows was adjusted to create static library by default.

There is a chance that MinGW can produce and use shared libraries; it should be able to continue doing that since the changes are local to Visual C++.