### PR TITLE
Allow to define the duration of one beat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added new methods for controlling scroll and visual tracking during playback, when using an external player. A new sample 'extplayer' has been added to the 'examples' folder.
 - The algorithm for auto-scroll has been improved.
 - Added Interactor method to customize visual tracking effects
+- Added Interactor method to define what is a beat. This allows, for example, to subdivide metronome or to decide which note duration corresponds to a metronome click. It is also usefull for methods that specify a location by using measure/beat parameters.
 - Fixes for removing Microsoft compiler warnings.
 
 

--- a/docs/api/doxyfile
+++ b/docs/api/doxyfile
@@ -22,7 +22,7 @@ PROJECT_NAME           = "Lomse library. API documentation"
 PROJECT_NUMBER         = 0.25.0
 PROJECT_BRIEF          =
 PROJECT_LOGO           = ./images/logo_100x195.png
-OUTPUT_DIRECTORY       = ../../../zz_build-api
+OUTPUT_DIRECTORY       = ../../zz_build-api
 CREATE_SUBDIRS         = NO
 OUTPUT_LANGUAGE        = English
 

--- a/docs/api/doxyfile
+++ b/docs/api/doxyfile
@@ -625,7 +625,7 @@ WARN_IF_UNDOCUMENTED   = YES
 WARN_IF_DOC_ERROR      = YES
 WARN_NO_PARAMDOC       = NO
 WARN_FORMAT            = "$file:$line: $text"
-WARN_LOGFILE           = ../../../api-docs/doxygen.log
+WARN_LOGFILE           = ../../zz_build-api/doxygen.log
 
 #---------------------------------------------------------------------------
 # Configuration options related to the input files

--- a/include/lomse_document.h
+++ b/include/lomse_document.h
@@ -576,7 +576,7 @@ public:
         measure/beat parameters to define a location. This value is shared by all
         scores contained in the document and can be changed at any time.
         Changes while the score is being played back are ignored until playback finishes.
-        @param beatType A value from enum EBeatDuration.
+        @param beatType A value from enum #EBeatDuration.
         @param duration The duration (in Lomse Time Units) for one beat. You can use
             a value from enum ENoteDuration casted to TimeUnits. This parameter is
             required only when value for parameter `beatType` is `k_beat_specified`.

--- a/include/lomse_document.h
+++ b/include/lomse_document.h
@@ -78,6 +78,22 @@ enum EDocLayoutOptions
 ///@endcond
 
 
+//---------------------------------------------------------------------------------------
+/** @ingroup enumerations
+
+    This enum defines the duration of one beat, for metronome and for methods that use
+    measure/beat to define a location.
+
+	@#include <lomse_document.h>
+*/
+enum EBeatDuration
+{
+    k_beat_implied = 0,     ///< Implied by the time signature; e.g. 3/8 = one beat
+    k_beat_bottom_ts,       ///< Use the bottom number of the time signature; e.g. 3/8 = three beats
+    k_beat_specified,       ///< Use specified note value
+};
+
+
 //------------------------------------------------------------------------------------
 /** The %Document class is a facade object that contains, basically, the @IM, a model
     similar to the DOM in HTML. By accessing and modifying this internal model you
@@ -123,6 +139,8 @@ protected:
     ImoDocument*    m_pImoDoc;
     unsigned int    m_flags;
     int             m_modified;
+    int             m_beatType;
+    TimeUnits       m_beatDuration;
 
 public:
     /// Constructor
@@ -539,6 +557,31 @@ public:
         returns @true.
     */
     bool is_editable();
+
+    /** Define the duration for one beat, for metronome and for methods that use
+        measure/beat parameters to define a location. This value is shared by all
+        scores contained in the document and can be changed at any time.
+        @param beatType A value from enum EBeatDuration.
+        @param duration The duration (in Lomse Time Units) for one beat. You can use
+            a value from enum ENoteDuration casted to TimeUnits. This parameter is
+            required only when value for parameter `beatType` is `k_beat_specified`.
+            For all other values, if a non-zero value is specified, the value
+            will be used for the beat duration in scores without time signature.
+    */
+    void define_beat(int beatType, TimeUnits duration);
+
+    /** Return the beat type to use for scores in this document.
+
+        See define_beat()
+    */
+    inline int get_beat_type() { return m_beatType; }
+
+    /** Return the duration for beats to use in scores without time signature and when
+        beat type is `k_beat__specified`.
+
+        See define_beat()
+    */
+    inline TimeUnits get_beat_duration() { return m_beatDuration; }
 
     /** Return @true if the document has been modified (if it is dirty).
         This flag is automatically cleared when the graphic model for the

--- a/include/lomse_document.h
+++ b/include/lomse_document.h
@@ -88,9 +88,23 @@ enum EDocLayoutOptions
 */
 enum EBeatDuration
 {
-    k_beat_implied = 0,     ///< Implied by the time signature; e.g. 3/8 = one beat
-    k_beat_bottom_ts,       ///< Use the bottom number of the time signature; e.g. 3/8 = three beats
-    k_beat_specified,       ///< Use specified note value
+    k_beat_implied = 0,     ///< Implied by the time signature; e.g. 4/4 = four
+                            ///< beats, 6/8 = two beats, 3/8 = one beat.
+                            ///< The number of implied beats for a time signature is
+                            ///< provided by method ImoTimeSignature::get_num_pulses().
+                            ///< Basically, for simple time signatures, such as 4/4,
+                            ///< 3/4, 2/4, 3/8, and 2/2, the number of beats is given by
+                            ///< the time signature top number, with the exception of
+                            ///< 3/8 which is normally conducted in one beat. In compound
+                            ///< time signatures (6/x, 12/x, and 9/x) the number of beats
+                            ///< is given by dividing the top number by three.
+
+    k_beat_bottom_ts,       ///< Use the note duration implied by the time signature
+                            ///< bottom number; e.g. 3/8 = use eighth notes. Notice
+                            ///< that the number of beats will coincide with the
+                            ///< time signature top number, e.g. 3 beats for 3/8.
+
+    k_beat_specified,       ///< Use specified note value for beat duration.
 };
 
 
@@ -561,6 +575,7 @@ public:
     /** Define the duration for one beat, for metronome and for methods that use
         measure/beat parameters to define a location. This value is shared by all
         scores contained in the document and can be changed at any time.
+        Changes while the score is being played back are ignored until playback finishes.
         @param beatType A value from enum EBeatDuration.
         @param duration The duration (in Lomse Time Units) for one beat. You can use
             a value from enum ENoteDuration casted to TimeUnits. This parameter is
@@ -568,7 +583,7 @@ public:
             For all other values, if a non-zero value is specified, the value
             will be used for the beat duration in scores without time signature.
     */
-    void define_beat(int beatType, TimeUnits duration);
+    void define_beat(int beatType, TimeUnits duration=0.0);
 
     /** Return the beat type to use for scores in this document.
 

--- a/include/lomse_interactor.h
+++ b/include/lomse_interactor.h
@@ -335,7 +335,7 @@ public:
         measure/beat parameters to define a location. This value is shared by all
         scores contained in the document and can be changed at any time.
         Changes while the score is being played back are ignored until playback finishes.
-        @param beatType A value from enum EBeatDuration.
+        @param beatType A value from enum #EBeatDuration.
         @param duration The duration (in Lomse Time Units) for one beat. You can use
             a value from enum ENoteDuration casted to double. This parameter is
             required only when value for parameter `beatType` is `k_beat_specified`.

--- a/include/lomse_interactor.h
+++ b/include/lomse_interactor.h
@@ -331,6 +331,18 @@ public:
     */
     void switch_task(int taskType);
 
+    /** Define the duration for one beat, for metronome and for methods that use
+        measure/beat parameters to define a location. This value is shared by all
+        scores contained in the document and can be changed at any time.
+        @param beatType A value from enum EBeatDuration.
+        @param duration The duration (in Lomse Time Units) for one beat. You can use
+            a value from enum ENoteDuration casted to double. This parameter is
+            required only when value for parameter `beatType` is `k_beat_specified`.
+            For all other values, if a non-zero value is specified, the value
+            will be used for the beat duration in scores without time signature.
+    */
+    void define_beat(int beatType, TimeUnits duration=0.0);
+
     //@}    //operating modes
 
 

--- a/include/lomse_interactor.h
+++ b/include/lomse_interactor.h
@@ -334,6 +334,7 @@ public:
     /** Define the duration for one beat, for metronome and for methods that use
         measure/beat parameters to define a location. This value is shared by all
         scores contained in the document and can be changed at any time.
+        Changes while the score is being played back are ignored until playback finishes.
         @param beatType A value from enum EBeatDuration.
         @param duration The duration (in Lomse Time Units) for one beat. You can use
             a value from enum ENoteDuration casted to double. This parameter is

--- a/include/lomse_measures_table.h
+++ b/include/lomse_measures_table.h
@@ -50,7 +50,8 @@ protected:
     int         m_index;            //index of this element in ImMeasuresTable
 	TimeUnits   m_timepos;          //measure starts at this timepos
 	ImoId       m_firstId;          //id of first note/rest in measure
-	TimeUnits   m_beatDuration;     //applicable TS to this measure
+    TimeUnits   m_bottomBeat;       //applicable TS bottom number (as note duration)
+    TimeUnits   m_impliedBeat;      //implied beat duration for applicable TS
 
 	ColStaffObjsEntry* m_pCsoEntry; //ptr to barline (end of this measure) or nullptr
 	                                //when no end barline
@@ -63,7 +64,8 @@ public:
     inline int get_table_index() const { return m_index; }
 	inline TimeUnits get_timepos() const { return m_timepos; }
 	inline ImoId get_first_id() const { return m_firstId; }
-	inline TimeUnits get_beat_duration() const { return m_beatDuration; }
+	inline TimeUnits get_implied_beat_duration() const { return m_bottomBeat; }
+	inline TimeUnits get_bottom_ts_beat_duration() const { return m_impliedBeat; }
     inline ColStaffObjsEntry* get_entry() const { return m_pCsoEntry; }
 
     //debug
@@ -77,7 +79,8 @@ protected:
     friend class MeasuresTableBuilder;
 	inline void set_timepos(TimeUnits timepos) { m_timepos = timepos; }
 	inline void set_first_id(ImoId id) { m_firstId = id; }
-	inline void set_beat_duration(TimeUnits duration) { m_beatDuration = duration; }
+	inline void set_implied_beat_duration(TimeUnits duration) { m_bottomBeat = duration; }
+	inline void set_bottom_ts_beat_duration(TimeUnits duration) { m_impliedBeat = duration; }
 	inline void set_entry(ColStaffObjsEntry* entry) { m_pCsoEntry = entry; }
 
 };

--- a/include/lomse_midi_table.h
+++ b/include/lomse_midi_table.h
@@ -106,8 +106,8 @@ public:
         , EventType(nEventType)
         , Channel(nChannel)
         , NotePitch(midiPitch)
-        , Volume(nVolume)
         , NoteStep(nStep)
+        , Volume(nVolume)
         , pSO(pStaffObj)
         , Measure(nMeasure)
     {
@@ -117,8 +117,8 @@ public:
         , EventType(nEventType)
         , Channel(0)
         , NotePitch(0)
-        , Volume(0)
         , NoteStep(0)
+        , Volume(0)
         , pJump(pJumpEntry)
         , Measure(nMeasure)
     {
@@ -145,13 +145,16 @@ public:
     union {
         int     NotePitch;      //k_note_xxx: MIDI pitch
         int     Instrument;     //k_prog_instr: MIDI instrument
-        int     NumPulses;      //k_rhythm_change: num. metronome pulses per measure
+        int     TopNumber;      //k_rhythm_change: top number of TS
     };
     union {
-        int     Volume;             //k_note_xxx: for notes
-        int     MeasureDuration;    //k_rhythm_change: In LDP duration units
+        int     NoteStep;       //k_note_xxx: Note step 0..6 : 0-Do, ... 6-Si
+        int     BeatDuration;   //k_rhythm_change: bottom num. of TS (as duration)
     };
-    int             NoteStep;   //k_note_xxx: Note step 0..6 : 0-Do, ... 6-Si
+    union {
+        int     Volume;         //k_note_xxx: for notes
+        int     NumPulses;      //k_rhythm_change: implied number of beats per measure
+    };
     union {
         ImoStaffObj*    pSO;        //staffobj who originated the event (for visual highlight)
         JumpEntry*      pJump;      //jump entry, for playback jumps

--- a/include/lomse_score_algorithms.h
+++ b/include/lomse_score_algorithms.h
@@ -148,6 +148,9 @@ protected:
     static ColStaffObjsIterator find_barline_with_time_lower_or_equal(ImoScore* pScore,
                                              int instr, TimeUnits maxTime);
 
+    static TimeUnits get_beat_duration_for(ImoScore* pScore,
+                                           ImMeasuresTableEntry* measure);
+
 };
 
 

--- a/include/lomse_score_player.h
+++ b/include/lomse_score_player.h
@@ -350,11 +350,11 @@ protected:
     long m_nMtrPulseDuration;   //a beat duration, in DeltaTime units
     int m_beatType;             //beat definition to use
     TimeUnits m_beatDuration;   //for no time signature or beatType == k_beat_specified
+    float m_conversionFactor;   //to convert TimeUnits (delta time) to millisecs
 
     inline long delta_to_milliseconds(long deltaTime) {
-        return deltaTime * m_nMtrClickIntval / m_nMtrPulseDuration;
+        return long( float(deltaTime) * m_conversionFactor );
     }
-
 
 
 };

--- a/include/lomse_score_player.h
+++ b/include/lomse_score_player.h
@@ -341,11 +341,15 @@ protected:
     void thread_main(int nEvStart, int nEvEnd, bool fVisualTracking, long nMM,
                      Interactor* pInteractor);
     void end_of_playback_housekeeping(bool fVisualTracking, Interactor* pInteractor);
+    void set_new_beat_information(SoundEvent* pEvent, long* pMeasureDuration,
+                                  long* pMtrNumPulses);
 
     //helper, for do_play()
     //-----------------------------------------------------------------------------------
     long m_nMtrClickIntval;     //metronome interval duration, in milliseconds
     long m_nMtrPulseDuration;   //a beat duration, in DeltaTime units
+    int m_beatType;             //beat definition to use
+    TimeUnits m_beatDuration;   //for no time signature or beatType == k_beat_specified
 
     inline long delta_to_milliseconds(long deltaTime) {
         return deltaTime * m_nMtrClickIntval / m_nMtrPulseDuration;

--- a/scripts/build-api-docs.sh
+++ b/scripts/build-api-docs.sh
@@ -33,9 +33,8 @@ fi
 
 #paths
 ROOT="${LOMSE}"
-PROJECTS=$(dirname "${ROOT}")
 DOXY="${ROOT}/docs/api"
-HTML="${PROJECTS}/api-docs"
+HTML="${LOMSE}/zz_build-api"
 echo "ROOT = ${ROOT}"
 echo "PROJECTS = ${PROJECTS}"
 echo "DOXY = ${DOXY}"

--- a/src/document/lomse_document.cpp
+++ b/src/document/lomse_document.cpp
@@ -150,6 +150,8 @@ Document::Document(LibraryScope& libraryScope, ostream& reporter)
     , m_pImoDoc(nullptr)
     , m_flags(k_dirty)
     , m_modified(0)
+    , m_beatType(k_beat_implied)
+    , m_beatDuration( TimeUnits(k_duration_quarter) )
 {
 }
 
@@ -406,6 +408,31 @@ bool Document::is_editable()
     //TODO: How to mark a document as 'not editable'?
     //For now, all documents are editable
     return true;
+}
+
+//---------------------------------------------------------------------------------------
+void Document::define_beat(int beatType, TimeUnits duration)
+{
+    switch (beatType)
+    {
+        case k_beat_implied:
+        case k_beat_bottom_ts:
+            m_beatType = beatType;
+            if (is_greater_time(duration, 0.0))
+                m_beatDuration = duration;
+            break;
+
+        case k_beat_specified:
+            if (is_greater_time(duration, 0.0))
+            {
+                m_beatType = beatType;
+                m_beatDuration = duration;
+            }
+            break;
+
+        default:
+            LOMSE_LOG_ERROR("Invalid beat type %d. Ignored.", beatType);;
+    }
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -5192,7 +5192,7 @@ int ImoTimeSignature::get_num_pulses()
 
     //In simple time signatures, such as  4/4, 3/4, 2/4, 3/8, and 2/2, the number
     //of beats is given by the top number, with the exception of 3/8 which is
-    //marked in one beat.
+    //conducted in one beat.
     //TODO: Any other exception?
     //In compound time signatures (6/x, 12/x, and 9/x) the number of beats is given
     //by dividing the top number by three.

--- a/src/internal_model/lomse_measures_table.cpp
+++ b/src/internal_model/lomse_measures_table.cpp
@@ -46,7 +46,8 @@ ImMeasuresTableEntry::ImMeasuresTableEntry(ColStaffObjsEntry* pEntry)
     : m_index(-1)
     , m_timepos(LOMSE_NO_TIME)
     , m_firstId(-1)
-    , m_beatDuration(LOMSE_NO_DURATION)
+    , m_bottomBeat(LOMSE_NO_DURATION)
+    , m_impliedBeat(LOMSE_NO_DURATION)
     , m_pCsoEntry(pEntry)
 {
     if (pEntry != nullptr)
@@ -58,7 +59,8 @@ ImMeasuresTableEntry::ImMeasuresTableEntry()
     : m_index(-1)
     , m_timepos(LOMSE_NO_TIME)
     , m_firstId(-1)
-    , m_beatDuration(LOMSE_NO_DURATION)
+    , m_bottomBeat(LOMSE_NO_DURATION)
+    , m_impliedBeat(LOMSE_NO_DURATION)
     , m_pCsoEntry(nullptr)
 {
 }
@@ -67,7 +69,9 @@ ImMeasuresTableEntry::ImMeasuresTableEntry()
 string ImMeasuresTableEntry::dump()
 {
     stringstream s;
-    s << m_index << "\t" << m_timepos << "\t" << m_beatDuration << "\t";
+    s << m_index << "\t" << m_timepos << "\t" << m_bottomBeat << "\t"
+      << m_impliedBeat << "\t";
+
     if (m_pCsoEntry != nullptr)
         s << m_pCsoEntry->to_string_with_ids();
     s << endl;

--- a/src/internal_model/lomse_model_builder.cpp
+++ b/src/internal_model/lomse_model_builder.cpp
@@ -426,7 +426,8 @@ void MeasuresTableBuilder::build(ImoScore* pScore)
         if (pSO->is_time_signature())
         {
             ImoTimeSignature* pTS = static_cast<ImoTimeSignature*>(pSO);
-            m_measures[iInstr]->set_beat_duration( pTS->get_beat_duration() );
+            m_measures[iInstr]->set_implied_beat_duration( pTS->get_beat_duration() );
+            m_measures[iInstr]->set_bottom_ts_beat_duration( pTS->get_ref_note_duration() );
         }
 
         //if not intermediate barline finish current measure
@@ -471,7 +472,10 @@ void MeasuresTableBuilder::start_new_measure(int iInstr, ColStaffObjsEntry* pCso
     m_measures[iInstr] = pTable->add_entry(pCsoEntry);
 
     if (prevMeasure != nullptr)
-        m_measures[iInstr]->set_beat_duration( prevMeasure->get_beat_duration() );
+    {
+        m_measures[iInstr]->set_implied_beat_duration( prevMeasure->get_implied_beat_duration() );
+        m_measures[iInstr]->set_bottom_ts_beat_duration( prevMeasure->get_bottom_ts_beat_duration() );
+    }
 }
 
 

--- a/src/internal_model/lomse_score_algorithms.cpp
+++ b/src/internal_model/lomse_score_algorithms.cpp
@@ -303,9 +303,29 @@ TimeUnits ScoreAlgorithms::get_timepos_for(ImoScore* pScore, int iMeasure, int i
     {
         timepos = measure->get_timepos();
         if (iBeat >= 0)
-            timepos += measure->get_beat_duration() * iBeat;
+        {
+            timepos += get_beat_duration_for(pScore, measure) * iBeat;
+        }
     }
     return timepos;
+}
+
+//---------------------------------------------------------------------------------------
+TimeUnits ScoreAlgorithms::get_beat_duration_for(ImoScore* pScore,
+                                                 ImMeasuresTableEntry* measure)
+{
+    //get current definition for 'beat'
+    Document* pDoc = pScore->get_the_document();
+    TimeUnits beatType = pDoc->get_beat_type();
+
+    //use current definition for providing beat duration
+    if (beatType == k_beat_implied)
+        return measure->get_implied_beat_duration();
+
+    if (beatType == k_beat_bottom_ts)
+        return measure->get_bottom_ts_beat_duration();
+
+    return pDoc->get_beat_duration();
 }
 
 

--- a/src/mvc/lomse_interactor.cpp
+++ b/src/mvc/lomse_interactor.cpp
@@ -130,6 +130,13 @@ void Interactor::switch_task(int taskType)
 }
 
 //---------------------------------------------------------------------------------------
+void Interactor::define_beat(int beatType, TimeUnits duration)
+{
+    if (SpDocument spDoc = m_wpDoc.lock())
+        spDoc->define_beat(beatType, duration);
+}
+
+//---------------------------------------------------------------------------------------
 GraphicModel* Interactor::get_graphic_model()
 {
     if (!m_pGraphicModel)

--- a/src/sound/lomse_midi_table.cpp
+++ b/src/sound/lomse_midi_table.cpp
@@ -434,11 +434,12 @@ void SoundEventsTable::add_rythm_change(StaffObjsCursor& cursor, int measure,
                                         ImoTimeSignature* pTS)
 {
     TimeUnits rTime = cursor.time() + cursor.anacrusis_missing_time();
-    int measureDuration = int( pTS->get_measure_duration() );
+    int topNumber = pTS->get_top_number();
     int numBeats = pTS->get_num_pulses();
+    int beatDuration = int( pTS->get_ref_note_duration() );
 
-    store_event(rTime, SoundEvent::k_rhythm_change, 0, numBeats,
-                measureDuration, 0, pTS, measure);
+    store_event(rTime, SoundEvent::k_rhythm_change, 0, topNumber,
+                numBeats, beatDuration, pTS, measure);
 }
 
 //---------------------------------------------------------------------------------------
@@ -537,7 +538,8 @@ string SoundEventsTable::dump_events_table()
 
             //list current entry
             SoundEvent* pSE = m_events[i];
-            msg << i << ":\t" << pSE->DeltaTime << "\t\t" << pSE->Channel << "\t" << pSE->Measure << "\t";
+            msg << i << ":\t" << pSE->DeltaTime << "\t\t" << pSE->Channel << "\t"
+                << pSE->Measure << "\t";
 
             bool fAddData = true;
             switch (pSE->EventType)
@@ -572,7 +574,8 @@ string SoundEventsTable::dump_events_table()
                     msg << "?? " << pSE->EventType;
             }
             if (fAddData)
-                msg << "\t" << pSE->NotePitch << "\t" << pSE->NoteStep << "\t" << pSE->Volume << "\n";
+                msg << "\t" << pSE->NotePitch << "\t" << pSE->NoteStep
+                    << "\t" << pSE->Volume << "\n";
         }
 
     return msg.str();

--- a/src/tests/lomse_test_midi_table.cpp
+++ b/src/tests/lomse_test_midi_table.cpp
@@ -157,6 +157,8 @@ SUITE(MidiTableTest)
 
     TEST_FIXTURE(MidiTableTestFixture, ProgramSounds)
     {
+        //@001. program_sounds_for_instruments(). Event added
+
         Document doc(m_libraryScope);
         doc.from_string("(lenmusdoc (vers 0.0) (content (score (vers 1.6) "
             "(instrument (musicData (clef G)(n c4 q) )) )))" );
@@ -175,6 +177,8 @@ SUITE(MidiTableTest)
 
     TEST_FIXTURE(MidiTableTestFixture, ProgramSoundsMidiInfo)
     {
+        //@002. program_sounds_for_instruments(). Midi info from instrument added
+
         Document doc(m_libraryScope);
         doc.from_string("(lenmusdoc (vers 0.0) (content (score (vers 1.6) "
             "(instrument (infoMIDI 2 0)(musicData (clef G)(n c4 q) )) )))" );
@@ -193,6 +197,8 @@ SUITE(MidiTableTest)
 
     TEST_FIXTURE(MidiTableTestFixture, CreateEvents_OneNote)
     {
+        //@010. create_events(). Note.
+
         Document doc(m_libraryScope);
         doc.from_string("(lenmusdoc (vers 0.0) (content (score (vers 1.6) "
             "(instrument (musicData (clef G)(n c4 q) )) )))" );
@@ -213,6 +219,8 @@ SUITE(MidiTableTest)
 
     TEST_FIXTURE(MidiTableTestFixture, CreateEvents_OneRest)
     {
+        //@011. create_events(). Rest.
+
         Document doc(m_libraryScope);
         doc.from_string("(lenmusdoc (vers 0.0) (content (score (vers 1.6) "
             "(instrument (musicData (clef G)(r q) )) )))" );
@@ -234,6 +242,8 @@ SUITE(MidiTableTest)
 
     TEST_FIXTURE(MidiTableTestFixture, CreateEvents_RestNoVisible)
     {
+        //@012. create_events(). Invisible rest.
+
         Document doc(m_libraryScope);
         doc.from_string("(lenmusdoc (vers 0.0) (content (score (vers 1.6) "
             "(instrument (musicData (clef G)(r q noVisible)(n c4 q) )) )))" );
@@ -255,6 +265,8 @@ SUITE(MidiTableTest)
 
     TEST_FIXTURE(MidiTableTestFixture, CreateEvents_TwoNotesTied)
     {
+        //@013. create_events(). Two tied notes.
+
         Document doc(m_libraryScope);
         doc.from_string("(lenmusdoc (vers 0.0) (content (score (vers 1.6) "
             "(instrument (musicData (clef G)(n c4 q l)(n c4 e) )) )))" );
@@ -279,6 +291,8 @@ SUITE(MidiTableTest)
 
     TEST_FIXTURE(MidiTableTestFixture, BarlineIncrementsMeasureCount)
     {
+        //@020. create_events(). Barline increments measure count
+
         Document doc(m_libraryScope);
         doc.from_string("(lenmusdoc (vers 0.0) (content (score (vers 1.6) "
             "(instrument (musicData (clef G)(n c4 q)(barline)(n c4 e) )) )))" );
@@ -304,6 +318,8 @@ SUITE(MidiTableTest)
 
     TEST_FIXTURE(MidiTableTestFixture, TimeSignatureAddsRythmChange)
     {
+        //@030. create_events(). Time signature adds rhythm change
+
         Document doc(m_libraryScope);
         doc.from_string("(lenmusdoc (vers 0.0) (content (score (vers 1.6) "
             "(instrument (musicData (clef G)(time 2 4) )) )))" );
@@ -318,14 +334,17 @@ SUITE(MidiTableTest)
         CHECK( (*it)->EventType == SoundEvent::k_prog_instr );
         ++it;
         CHECK( (*it)->EventType == SoundEvent::k_rhythm_change );
+        CHECK( (*it)->TopNumber == 2 );
+        CHECK( (*it)->BeatDuration == 64 );
         CHECK( (*it)->NumPulses == 2 );
-        CHECK( (*it)->MeasureDuration == 128 );
         //cout << ", NumPulses = " << (*it)->NumPulses
-        //     << ", MeasureDuration = " << (*it)->MeasureDuration << endl;
+        //     << ", TopNumber = " << (*it)->TopNumber << endl;
     }
 
     TEST_FIXTURE(MidiTableTestFixture, TimeSignatureInfoOk)
     {
+        //@031. create_events(). Time signature info ok
+
         Document doc(m_libraryScope);
         doc.from_string("(lenmusdoc (vers 0.0) (content (score (vers 1.6) "
             "(instrument (musicData (clef G)(time 6 8) )) )))" );
@@ -340,14 +359,17 @@ SUITE(MidiTableTest)
         CHECK( (*it)->EventType == SoundEvent::k_prog_instr );
         ++it;
         CHECK( (*it)->EventType == SoundEvent::k_rhythm_change );
+        CHECK( (*it)->TopNumber == 6 );
+        CHECK( (*it)->BeatDuration == 32 );
         CHECK( (*it)->NumPulses == 2 );
-        CHECK( (*it)->MeasureDuration == 192 );
         //cout << ", NumPulses = " << (*it)->NumPulses
-        //     << ", MeasureDuration = " << (*it)->MeasureDuration << endl;
+        //     << ", TopNumber = " << (*it)->TopNumber << endl;
     }
 
     TEST_FIXTURE(MidiTableTestFixture, CloseTableAddsEvent)
     {
+        //@100. close_table() adds end_of_score event
+
         Document doc(m_libraryScope);
         doc.from_string("(lenmusdoc (vers 0.0) (content (score (vers 1.6) "
             "(instrument (musicData (r q) )) )))" );
@@ -364,6 +386,8 @@ SUITE(MidiTableTest)
 
     TEST_FIXTURE(MidiTableTestFixture, CloseTableFinalTime)
     {
+        //@101. close_table() Final time computed ok
+
         Document doc(m_libraryScope);
         doc.from_string("(lenmusdoc (vers 0.0) (content (score (vers 1.6) "
             "(instrument (musicData (r q) )) )))" );
@@ -388,6 +412,8 @@ SUITE(MidiTableTest)
 
     TEST_FIXTURE(MidiTableTestFixture, EventsSorted)
     {
+        //@200. Events are sorted ok
+
         Document doc(m_libraryScope);
         doc.from_string("(lenmusdoc (vers 0.0) (content (score (vers 1.6) "
             "(instrument (musicData (clef G)(chord (n c4 q)(n e4 q)) )) )))" );

--- a/src/tests/lomse_test_model_builder.cpp
+++ b/src/tests/lomse_test_model_builder.cpp
@@ -790,7 +790,8 @@ SUITE(MeasuresTableBuilderTest)
         CHECK( builder.my_get_current_measure(0) == pMeasure );
         CHECK( pMeasure->get_entry() == pCSO->front() );
         CHECK( pMeasure->get_timepos() == 0.0f );
-        CHECK( pMeasure->get_beat_duration() == LOMSE_NO_DURATION );
+        CHECK( pMeasure->get_implied_beat_duration() == LOMSE_NO_DURATION );
+        CHECK( pMeasure->get_bottom_ts_beat_duration() == LOMSE_NO_DURATION );
     }
 
     TEST_FIXTURE(MeasuresTableBuilderTestFixture, measures_table_builder_003)
@@ -819,7 +820,8 @@ SUITE(MeasuresTableBuilderTest)
         CHECK( builder.my_get_current_measure(0) == pMeasure );
         CHECK( pMeasure->get_entry() == pCSO->front() );
         CHECK( pMeasure->get_timepos() == 0.0f );
-        CHECK( pMeasure->get_beat_duration() == LOMSE_NO_DURATION );
+        CHECK( pMeasure->get_implied_beat_duration() == LOMSE_NO_DURATION );
+        CHECK( pMeasure->get_bottom_ts_beat_duration() == LOMSE_NO_DURATION );
 
         pInstr = pScore->get_instrument(1);
         pTable = pInstr->get_measures_table();
@@ -829,7 +831,8 @@ SUITE(MeasuresTableBuilderTest)
         CHECK( pMeasure != nullptr );
         CHECK( builder.my_get_current_measure(1) == pMeasure );
         CHECK( pMeasure->get_timepos() == 0.0f );
-        CHECK( pMeasure->get_beat_duration() == LOMSE_NO_DURATION );
+        CHECK( pMeasure->get_implied_beat_duration() == LOMSE_NO_DURATION );
+        CHECK( pMeasure->get_bottom_ts_beat_duration() == LOMSE_NO_DURATION );
     }
 
     TEST_FIXTURE(MeasuresTableBuilderTestFixture, measures_table_builder_004)
@@ -860,7 +863,8 @@ SUITE(MeasuresTableBuilderTest)
         CHECK( builder.my_get_current_measure(0) == pMeasure );
         CHECK( pMeasure->get_entry() == pCSO->front() );
         CHECK( pMeasure->get_timepos() == 0.0f );
-        CHECK( pMeasure->get_beat_duration() == 64.0f );
+        CHECK( pMeasure->get_implied_beat_duration() == 64.0f );
+        CHECK( pMeasure->get_bottom_ts_beat_duration() == 64.0f );
 //        cout << test_name() << endl;
 //        cout << pTable->dump();
 
@@ -872,7 +876,8 @@ SUITE(MeasuresTableBuilderTest)
         CHECK( pMeasure != nullptr );
         CHECK( builder.my_get_current_measure(1) == pMeasure );
         CHECK( pMeasure->get_timepos() == 0.0f );
-        CHECK( pMeasure->get_beat_duration() == 64.0f );
+        CHECK( pMeasure->get_implied_beat_duration() == 64.0f );
+        CHECK( pMeasure->get_bottom_ts_beat_duration() == 64.0f );
 //        cout << test_name() << endl;
 //        cout << pTable->dump();
 
@@ -906,7 +911,8 @@ SUITE(MeasuresTableBuilderTest)
         ImMeasuresTableEntry* pMeasure = pTable->get_measure(0);
         CHECK( pMeasure != nullptr );
         CHECK( pMeasure->get_timepos() == 0.0f );
-        CHECK( pMeasure->get_beat_duration() == 64.0f );
+        CHECK( pMeasure->get_implied_beat_duration() == 64.0f );
+        CHECK( pMeasure->get_bottom_ts_beat_duration() == 64.0f );
         CHECK( pMeasure->get_entry() == pCSO->front() );
     }
 
@@ -943,7 +949,8 @@ SUITE(MeasuresTableBuilderTest)
         CHECK( pMeasure != nullptr );
         CHECK( builder.my_get_current_measure(0) == pMeasure );
         CHECK( pMeasure->get_timepos() == 64.0f );
-        CHECK( pMeasure->get_beat_duration() == 64.0f );
+        CHECK( pMeasure->get_implied_beat_duration() == 64.0f );
+        CHECK( pMeasure->get_bottom_ts_beat_duration() == 64.0f );
     }
 
     TEST_FIXTURE(MeasuresTableBuilderTestFixture, measures_table_builder_007)
@@ -980,13 +987,15 @@ SUITE(MeasuresTableBuilderTest)
         pMeasure = pTable->get_measure(1);
         CHECK( pMeasure != nullptr );
         CHECK( pMeasure->get_timepos() == 128.0f );
-        CHECK( pMeasure->get_beat_duration() == 64.0f );
+        CHECK( pMeasure->get_implied_beat_duration() == 64.0f );
+        CHECK( pMeasure->get_bottom_ts_beat_duration() == 64.0f );
 
         pMeasure = pTable->get_measure(2);
         CHECK( pMeasure != nullptr );
         CHECK( builder.my_get_current_measure(0) == pMeasure );
         CHECK( pMeasure->get_timepos() == 256.0f );
-        CHECK( pMeasure->get_beat_duration() == 96.0f );
+        CHECK( pMeasure->get_implied_beat_duration() == 96.0f );
+        CHECK( pMeasure->get_bottom_ts_beat_duration() == 32.0f );
     }
 
 };

--- a/src/tests/lomse_test_score_algorithms.cpp
+++ b/src/tests/lomse_test_score_algorithms.cpp
@@ -681,5 +681,55 @@ SUITE(ScoreAlgorithmsTest)
         CHECK( is_equal_time(timepos, 448.0) );
     }
 
+    TEST_FIXTURE(ScoreAlgorithmsTestFixture, get_timepos_for_207)
+    {
+        //@207. timepos computed correctly for k_beat_bottom_ts
+
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument (musicData "
+            "(clef G)(time 6 8)(n c4 e)(n e4 e)(n g4 e)(n c4 e)(n e4 e)(n g4 e)(barline)"
+            "(n c4 e)(n e4 e)(n g4 e)(n c4 e)(n e4 e)(n g4 e)(barline)"
+            "(n c4 e)(n e4 e)(n g4 e)(n c4 e)(n e4 e)(n g4 e)(barline)"
+            "(n c4 e)(n e4 e)(n g4 e)(n c4 e)(n e4 e)(n g4 e)(barline)"
+            "(n c4 e)(n e4 e)(n g4 e)"
+            ")))"
+        );
+        ImoScore* pScore =
+            static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+        doc.define_beat(k_beat_bottom_ts);
+
+        //measure 2, beat 3: 192+32+32 = 256
+        TimeUnits timepos = ScoreAlgorithms::get_timepos_for(pScore, 1, 2, 0);
+
+//        cout << test_name() << endl;
+//        cout << "timepos=" << timepos << endl;
+        CHECK( is_equal_time(timepos, 256.0) );
+    }
+
+    TEST_FIXTURE(ScoreAlgorithmsTestFixture, get_timepos_for_208)
+    {
+        //@208. timepos computed correctly for k_beat_specified
+
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument (musicData "
+            "(clef G)(time 6 8)(n c4 e)(n e4 e)(n g4 e)(n c4 e)(n e4 e)(n g4 e)(barline)"
+            "(n c4 e)(n e4 e)(n g4 e)(n c4 e)(n e4 e)(n g4 e)(barline)"
+            "(n c4 e)(n e4 e)(n g4 e)(n c4 e)(n e4 e)(n g4 e)(barline)"
+            "(n c4 e)(n e4 e)(n g4 e)(n c4 e)(n e4 e)(n g4 e)(barline)"
+            "(n c4 e)(n e4 e)(n g4 e)"
+            ")))"
+        );
+        ImoScore* pScore =
+            static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+        doc.define_beat(k_beat_specified, 73.0);
+
+        //measure 2, beat 3: 192+73+73 = 338
+        TimeUnits timepos = ScoreAlgorithms::get_timepos_for(pScore, 1, 2, 0);
+
+//        cout << test_name() << endl;
+//        cout << "timepos=" << timepos << endl;
+        CHECK( is_equal_time(timepos, 338.0) );
+    }
+
 }
 


### PR DESCRIPTION
The interface for this new facility is the new method Interactor::define_beat(). This method defines the duration for one beat, for metronome and for methods that use measure/beat parameters to define a location. This value is shared by all scores contained in the document and can be changed at any time.
Changes while the score is being played back are ignored until playback finishes.

Default value when nothing specified is `k_beat_implied` meaning that Lomse will use the duration implied by the time signature; e.g. 4/4 = four beats, 6/8 = two beats, 3/8 = one beat, ...
