### PR TITLE
Methods using measure/location analogous to those using measure/beat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,18 @@
 
 ##### COMPATIBLE CHANGES
 
-- Added new methods for controlling scroll and visual tracking during playback, when using an external player. A new sample 'extplayer' has been added to the 'examples' folder.
 - The algorithm for auto-scroll has been improved.
+- During playback, when the time signature changes, metronome clicks
+  interval is now adjusted for maintaining notes duration equivalence.
+- Added new methods for controlling scroll and visual tracking during
+  playback, when using an external player. A new sample 'extplayer' has
+  been added to the 'examples' folder.
 - Added Interactor method to customize visual tracking effects
-- Added Interactor method to define what is a beat. This allows, for example, to subdivide metronome or to decide which note duration corresponds to a metronome click. It is also usefull for methods that specify a location by using measure/beat parameters.
+- Added Interactor method to define what is a beat. This allows, for
+  example, to subdivide metronome or to decide which note duration
+  corresponds to a metronome click. It is also usefull for methods that
+  specify a location by using measure/beat parameters.
 - Fixes for removing Microsoft compiler warnings.
-
-
 
 
 
@@ -25,7 +30,13 @@ Version [0.25.0] (29/Jun/2018)
 
 ##### BACKWARDS INCOMPATIBLE CHANGES WITH 0.24.0
 
-* Until now all visual tracking effects were named score highlight effects due to the fact that highlighting notes/rests was the first programmed visual effect. But, currently, Lomse supports more visual tracking effects and, for coherence and to use more descriptive names, all references to score highlight effects have been changed, when appropriate, to 'visual tracking' effects. In particular, the more important changes that will affect your code are:
+* Until now all visual tracking effects were named score highlight effects
+  due to the fact that highlighting notes/rests was the first programmed
+  visual effect. But, currently, Lomse supports more visual tracking
+  effects and, for coherence and to use more descriptive names, all
+  references to score highlight effects have been changed, when appropriate,
+  to 'visual tracking' effects. In particular, the more important changes
+  that will affect your code are:
 	- Class `EventScoreHighlight` changed to `EventVisualTracking`.
 	- Type `SpEventcoreHighlight` changed to `SpEventVisualTracking`.
 	- Enum item `k_highlight_event` changed to `k_tracking_event`.
@@ -37,12 +48,16 @@ Version [0.25.0] (29/Jun/2018)
 
 ##### COMPATIBLE CHANGES
 
-* Added method `Interactor::set_visual_tracking_mode(int mode)` for selecting the visual trackin effect to use. A new enum `EVisualTrackingMode` defines valid modes.
+* Added method `Interactor::set_visual_tracking_mode(int mode)` for
+  selecting the visual trackin effect to use. A new enum `EVisualTrackingMode`
+  defines valid modes.
 * Changes to allow extension '.musicxml' for uncompressed MusicXML files.
-* Added some initial code to deal with `global` elements in experimental MNX importer.
+* Added some initial code to deal with `global` elements in experimental
+  MNX importer.
 * Changes to allow compilers other than GCC and MSVC.
 * Several fixes to make Lomse buildable in macOS with clang compiler.
-* Several changes for trying to reduce or eliminate dependencies from other libraries. In particular:
+* Several changes for trying to reduce or eliminate dependencies from
+  other libraries. In particular:
 	- PR #144 Replaced boost::format with standard functions
 	- PR #146 Replaced boost::variant with union class
 

--- a/include/lomse_interactor.h
+++ b/include/lomse_interactor.h
@@ -735,6 +735,27 @@ public:
     */
     virtual void scroll_to_measure_if_necessary(ImoId scoreId, int iMeasure, int iBeat=0, int iInstr=0);
 
+    /** This method invokes Lomse auto-scrolling algorithm to determine if scroll is
+        necessary, and if that is the case, it will set a new origin for the
+        viewport so that requested score location is visible in the viewport.
+        @param scoreId ID of the score to which all other parameters refer to.
+        @param iMeasure The index to the desired measure. First measure in the
+            instrument, including a possible anacrusis start measure, is always measure 0.
+        @param location Time units from the start of the measure.
+        @param iInstr The index to the instrument to which the measure refers. If not
+            specified, iInstr 0 is assumed. Normally,
+            all instruments in the score use the same time signature. In these cases all
+            score parts have the same number of measures and iInstr is not needed.
+            But in polymetric music not all instruments use the same time signature and
+            this implies that the instruments have different number of measures; in these
+            cases the measure number alone is not enough for determining
+            the location.
+
+        See @ref viewport-concept
+    */
+    virtual void scroll_to_measure_if_necessary(ImoId scoreId, int iMeasure,
+                                                TimeUnits location=0.0, int iInstr=0);
+
     /** This method forces to set a new origin for the viewport so that requested score
         location is visible in the viewport.
         @param scoreId ID of the score to which all other parameters refer to.
@@ -753,6 +774,26 @@ public:
         See @ref viewport-concept
     */
     virtual void scroll_to_measure(ImoId scoreId, int iMeasure, int iBeat=0, int iInstr=0);
+
+    /** This method forces to set a new origin for the viewport so that requested score
+        location is visible in the viewport.
+        @param scoreId ID of the score to which all other parameters refer to.
+        @param iMeasure The index to the desired measure. First measure in the
+            instrument, including a possible anacrusis start measure, is always measure 0.
+        @param location Time units from the start of the measure.
+        @param iInstr The index to the instrument to which the measure refers. If not
+            specified, iInstr 0 is assumed. Normally,
+            all instruments in the score use the same time signature. In these cases all
+            score parts have the same number of measures and iInstr is not needed.
+            But in polymetric music not all instruments use the same time signature and
+            this implies that the instruments have different number of measures; in these
+            cases the measure number alone is not enough for determining
+            the location.
+
+        See @ref viewport-concept
+    */
+    virtual void scroll_to_measure(ImoId scoreId, int iMeasure, TimeUnits location=0.0,
+                                   int iInstr=0);
 
     //@}    //interface to GraphicView. Viewport / scroll
 
@@ -917,6 +958,20 @@ public:
     */
     virtual void move_tempo_line(ImoId scoreId, int iMeasure, int iBeat, int iInstr=0);
 
+    /** Move the tempo line to the given measure and relative location inside the measure.
+        @param scoreId  Id. of the score to which all other parameters refer.
+        @param iMeasure Measure number (0..n) in instrument iInstr.
+        @param location Time units from the start of the measure.
+        @param iInstr Number of the instrument (0..m) to which the measures refer to.
+            Take into account that for polymetric music (music in which not all
+            instruments have the same time signature), the measure number is not an
+            absolute value, common to all the score instruments (score parts), but it
+            is relative to an instrument. For normal scores, just providing measure
+            number and location will do the job.
+    */
+    virtual void move_tempo_line(ImoId scoreId, int iMeasure, TimeUnits location,
+                                 int iInstr=0);
+
     /** Move the tempo line to the given measure and beat and change the viewport, if
         necessary, for ensuring that the requested measure/beat is visible.
         @param scoreId  Id. of the score to which all other parameters refer.
@@ -931,6 +986,22 @@ public:
     */
     virtual void move_tempo_line_and_scroll_if_necessary(ImoId scoreId, int iMeasure,
                                                          int iBeat, int iInstr=0);
+
+    /** Move the tempo line to the given measure and relative location inside the measure,
+        and change the viewport, if
+        necessary, for ensuring that the requested measure/beat is visible.
+        @param scoreId  Id. of the score to which all other parameters refer.
+        @param iMeasure Measure number (0..n) in instrument iInstr.
+        @param location Time units from the start of the measure.
+        @param iInstr Number of the instrument (0..m) to which the measures refer to.
+            Take into account that for polymetric music (music in which not all
+            instruments have the same time signature), the measure number is not an
+            absolute value, common to all the score instruments (score parts), but it
+            is relative to an instrument. For normal scores, just providing measure
+            number and location will do the job.
+    */
+    virtual void move_tempo_line_and_scroll_if_necessary(ImoId scoreId, int iMeasure,
+                                                         TimeUnits location, int iInstr=0);
 
     /** @param pSO This note or rest will be highlighted
         @todo Document Interactor::highlight_object    */
@@ -1519,6 +1590,7 @@ protected:
 
     //To select mode for do_move_tempo_line_and_scroll()
     enum { k_only_tempo_line=0, k_scroll_and_tempo_line, k_only_scroll };
+    void do_move_tempo_line_and_scroll(ImoId scoreId, const MeasureLocator& ml,int mode);
     void do_move_tempo_line_and_scroll(ImoId scoreId, int iMeasure, int iBeat,
                                        int iInstr, int mode);
 

--- a/include/lomse_score_algorithms.h
+++ b/include/lomse_score_algorithms.h
@@ -144,6 +144,12 @@ public:
     static TimeUnits get_timepos_for(ImoScore* pScore, int iMeasure, int iBeat,
                                      int iInstr=0);
 
+    /** Return the time position for the specified measure locator.
+        @param pScore Pointer to the score to wich all other parameters refer.
+        @param ml The measure locator to convert.
+    */
+    static TimeUnits get_timepos_for(ImoScore* pScore, const MeasureLocator& ml);
+
 protected:
     static ColStaffObjsIterator find_barline_with_time_lower_or_equal(ImoScore* pScore,
                                              int instr, TimeUnits maxTime);

--- a/src/internal_model/lomse_score_algorithms.cpp
+++ b/src/internal_model/lomse_score_algorithms.cpp
@@ -311,6 +311,23 @@ TimeUnits ScoreAlgorithms::get_timepos_for(ImoScore* pScore, int iMeasure, int i
 }
 
 //---------------------------------------------------------------------------------------
+TimeUnits ScoreAlgorithms::get_timepos_for(ImoScore* pScore, const MeasureLocator& ml)
+{
+    if (ml.iInstr < 0 || ml.iInstr >= pScore->get_num_instruments())
+        return 0.0;
+
+    ImoInstrument* pInstr = pScore->get_instrument(ml.iInstr);
+    ImMeasuresTable* pTable = pInstr->get_measures_table();
+    ImMeasuresTableEntry* measure = pTable->get_measure(ml.iMeasure);
+    TimeUnits timepos = 0.0f;
+    if (measure)
+    {
+        timepos = measure->get_timepos() + ml.location;
+    }
+    return timepos;
+}
+
+//---------------------------------------------------------------------------------------
 TimeUnits ScoreAlgorithms::get_beat_duration_for(ImoScore* pScore,
                                                  ImMeasuresTableEntry* measure)
 {

--- a/src/tests/lomse_test_score_algorithms.cpp
+++ b/src/tests/lomse_test_score_algorithms.cpp
@@ -731,5 +731,224 @@ SUITE(ScoreAlgorithmsTest)
         CHECK( is_equal_time(timepos, 338.0) );
     }
 
+
+    // get timepos for measure locator --------------------------------------------------
+
+    TEST_FIXTURE(ScoreAlgorithmsTestFixture, get_timepos_for_300)
+    {
+        //@300. measure too high. Return 0.0.
+
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument (musicData "
+            "(clef G)(time 2 4)(n c4 q)(n e4 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n c4 e)"
+            ")))"
+        );
+        ImoScore* pScore =
+            static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+
+        //measure 22, beat 2
+        MeasureLocator ml(0, 22, 1);
+        TimeUnits timepos = ScoreAlgorithms::get_timepos_for(pScore, ml);
+
+//        cout << test_name() << endl;
+//        cout << "timepos=" << timepos << endl;
+        CHECK( is_equal_time(timepos, 0.0) );
+    }
+
+    TEST_FIXTURE(ScoreAlgorithmsTestFixture, get_timepos_for_301)
+    {
+        //@301. measure negative. Return 0.0
+
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument (musicData "
+            "(clef G)(time 2 4)(n c4 q)(n e4 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n c4 e)"
+            ")))"
+        );
+        ImoScore* pScore =
+            static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+
+        //measure -4
+        MeasureLocator ml(0, -4, 1);
+        TimeUnits timepos = ScoreAlgorithms::get_timepos_for(pScore, ml);
+
+//        cout << test_name() << endl;
+//        cout << "timepos=" << timepos << endl;
+        CHECK( is_equal_time(timepos, 0.0) );
+    }
+
+    TEST_FIXTURE(ScoreAlgorithmsTestFixture, get_timepos_for_302)
+    {
+        //@302. location too high. Take as valid
+
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument (musicData "
+            "(clef G)(time 2 4)(n c4 q)(n e4 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n c4 e)"
+            ")))"
+        );
+        ImoScore* pScore =
+            static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+
+        //measure 2, loc 256
+        MeasureLocator ml(0, 1, 256);
+        TimeUnits timepos = ScoreAlgorithms::get_timepos_for(pScore, 1, 2, 0);
+
+//        cout << test_name() << endl;
+//        cout << "timepos=" << timepos << endl;
+        CHECK( is_equal_time(timepos, 256.0) );
+    }
+
+    TEST_FIXTURE(ScoreAlgorithmsTestFixture, get_timepos_for_303)
+    {
+        //@303. location negative. Take as valid
+
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument (musicData "
+            "(clef G)(time 2 4)(n c4 q)(n e4 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n c4 e)"
+            ")))"
+        );
+        ImoScore* pScore =
+            static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+
+        //measure 3, location -64: 256-64 = 192
+        MeasureLocator ml(0, 2, -64);
+        TimeUnits timepos = ScoreAlgorithms::get_timepos_for(pScore, ml);
+
+//        cout << test_name() << endl;
+//        cout << "timepos=" << timepos << endl;
+        CHECK( is_equal_time(timepos, 192.0) );
+    }
+
+    TEST_FIXTURE(ScoreAlgorithmsTestFixture, get_timepos_for_304)
+    {
+        //@304. instrument negative. Return 0.0
+
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument (musicData "
+            "(clef G)(time 2 4)(n c4 q)(n e4 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n c4 e)"
+            ")))"
+        );
+        ImoScore* pScore =
+            static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+
+        //measure 3, loc 64
+        MeasureLocator ml(-3, 3, 64);
+        TimeUnits timepos = ScoreAlgorithms::get_timepos_for(pScore, ml);
+
+//        cout << test_name() << endl;
+//        cout << "timepos=" << timepos << endl;
+        CHECK( is_equal_time(timepos, 0.0) );
+    }
+
+    TEST_FIXTURE(ScoreAlgorithmsTestFixture, get_timepos_for_305)
+    {
+        //@305. instrument too high. Return 0.0
+
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument (musicData "
+            "(clef G)(time 2 4)(n c4 q)(n e4 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n c4 e)"
+            ")))"
+        );
+        ImoScore* pScore =
+            static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+
+        //measure 3, location 64
+        MeasureLocator ml(2, 3, 64);
+        TimeUnits timepos = ScoreAlgorithms::get_timepos_for(pScore, ml);
+
+//        cout << test_name() << endl;
+//        cout << "timepos=" << timepos << endl;
+        CHECK( is_equal_time(timepos, 0.0) );
+    }
+
+    TEST_FIXTURE(ScoreAlgorithmsTestFixture, get_timepos_for_306)
+    {
+        //@306. valid parameters return correct values
+
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument (musicData "
+            "(clef G)(time 2 4)(n c4 q)(n e4 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n e4 q)(n g4 q)(barline)"
+            "(n c5 q)(n e5 q)(barline)"
+            "(n c4 e)"
+            ")))"
+        );
+        ImoScore* pScore =
+            static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+
+        //measure 2, location 64 ==> 128+64 = 192
+        MeasureLocator ml(0, 1, 64);
+        TimeUnits timepos = ScoreAlgorithms::get_timepos_for(pScore, ml);
+//        cout << test_name() << endl;
+//        cout << "timepos=" << timepos << endl;
+        CHECK( is_equal_time(timepos, 192.0) );
+
+        //measure 1, location 0 ==> 0
+        MeasureLocator ml2(0, 0, 0);
+        timepos = ScoreAlgorithms::get_timepos_for(pScore, ml2);
+//        cout << test_name() << endl;
+//        cout << "timepos=" << timepos << endl;
+        CHECK( is_equal_time(timepos, 0.0) );
+
+        //measure 8, location 0 ==> 896
+        MeasureLocator ml3(0, 7, 0);
+        timepos = ScoreAlgorithms::get_timepos_for(pScore, ml3);
+//        cout << test_name() << endl;
+//        cout << "timepos=" << timepos << endl;
+        CHECK( is_equal_time(timepos, 896.0) );
+
+        //measure 4, location 64 ==> 384+64 = 448
+        MeasureLocator ml4(0, 3, 64);
+        timepos = ScoreAlgorithms::get_timepos_for(pScore, ml4);
+//        cout << test_name() << endl;
+//        cout << "timepos=" << timepos << endl;
+        CHECK( is_equal_time(timepos, 448.0) );
+    }
+
 }
 


### PR DESCRIPTION
To avoid having to use beats and to have better control of the desired position, this PR implements methods for moving the tempo line visual effect and doing scroll using measure/location to specify the required position. These methods area analogous to those using measure/beat. But instead of beat, the displacement from start of measure, in lomse time units, is provided.

For instance, if current beat is a quarter note, moving the tempo line to measure 7 beat 2 will be the same than moving it to measure 7 location 64. 