### PR TITLE
Changes for dealing with measure properties in the internal model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
   example, to subdivide metronome or to decide which note duration
   corresponds to a metronome click. It is also usefull for methods that
   specify a location by using measure/beat parameters.
+- The internal model now has information about measure attributes, such
+  as the displayed measure number. All importers now parse and
+  store this information.
+Deal with measure container in internal model
 - Fixes for removing Microsoft compiler warnings.
 
 

--- a/docs/api/mainpages/im-modification.h
+++ b/docs/api/mainpages/im-modification.h
@@ -1,11 +1,3 @@
-/*
-
-See:  https://github.com/0xfe/vexflow/wiki/The-VexFlow-Tutorial
-
-For images: use LenMus at full screen and Zoom out six times
-
-*/
-
 ﻿/**
 @page page-im-modification The low level edition API
 

--- a/docs/api/mainpages/internal-model.h
+++ b/docs/api/mainpages/internal-model.h
@@ -583,5 +583,55 @@ For instance, here are the objects involved in modeling some relationships:
 
 
 @todo Finish this by describing the ImoAuxRelObjs (e.g. Lyrics)
+
+
+
+@subsection internal-model-scores-measures-intro  How measures are modelled
+<!---------------------------------------------------------------------------------->
+
+Initially, the idea of using a *measure container* to hold the staff objects was considered. But measures only exist when time signatures and barlines exist, and Lomse should be able to represent multi-metric and non-measured music.
+
+The approach followed in Lomse has been to represent the music as a linearized sequence of staff objects (notes, rests, etc.) with explicit barline objects. As a measure extends from one barline to the next one, both representations (with or without measures containers) are equivalent: given the barlines it is easy to deduce measure limits in data which has no such measure containers; and given the measure containers, it is easy to produce a linearized sequence with only barlines. So both approaches are equivalent. But by using a measure container, Lomse will have to force a special case for music that has no measures. Therefore, the decision was not to include measure containers in the internal model. But as not all barlines defines the boundaries for measures (e.g. intermediate barlines) it is necessary to identify these barlines.
+
+Nevertheless, as the concept of measure is very important in most common Western music, there are attributes (e.g. the displayed measure number) that have to be captured when they exist. In Lomse, the barlines contain the measure attributes for the measure that is ending in that barline, such as the displayed measure number. For accessing to this information use method `ImoBarline::get_measure_info`.
+
+And for non-measured scores or when the score is incomplete and the last measure is not finished in a barline, the attributes for this last incomplete measure, if exist, are stored in the ImoInstrument object, and are accessible by method `ImoInstrument::get_last_measure_info()`. Notice that this method will return @nullptr when the score finishes in barline.
+
+
+@subsubsection internal-model-scores-measures-needs  Tables related to measures
+<!---------------------------------------------------------------------------------->
+
+For any method based on measure location information (e.g., for scrolling to measure/beat or for visual tracking effects during payback), it is necessary to solve two needs:
+
+a) The first one is to convert the measure location data into timepos data. This information is inmutable for an internal model the conversion method can be provided by the internal model.
+
+b) And the second one is for converting timepos data into spacial position in the graphic model and vice-versa (e.g., to determine the timepos for a mouse position). As this information is specific for each graphic model, the conversion method must be provided by the graphic model.
+
+For solving these two needs there exist two objects: ImMeasuresTable and TimeGridTable objects.
+
+
+<b>The ImMeasuresTable object</b>
+<!---------------------------------------------------------------------------------->
+
+For solving the need to convert measure location data (e.g. measure/beat) into timepos data, the internal model contains a measures table. In fact, it is necessary to maintain a table per instrument, as for multi-metric music the number of measures is different in each score part (instrument).
+
+The table is contained and managed by class ImMeasuresTable. Each ImoInstrument object contains an instance, with the specific information for that instrument. For single-metric scores, the tables in all instruments will contain the same data, as the number of measures will be the same for all instruments. Each table is accesible by method ImoInstrument::get_measures_table();
+
+ImMeasuresTable objects are created by the model builder (class ModelBuilder) once the ColSatffObjs object is created. 
+
+
+
+<b>The TimeGridTable object</b>
+<!---------------------------------------------------------------------------------->
+
+For solving the need to convert timepos data into spacial position in the graphic model and vice-versa, the TimeGridTable object is responsible for supplying all occupied timepos and their positions.
+
+There exist a TimeGridTable object for each system. It is owned by the GmoBoxSystem object, which provide access to it. Each %TimeGridTable object contains a table with the relation timepos <-> x-position for all positions currently occupied by staff objects in the system. The last position is normally the position of the barline at the end of the system. The system provides the y-position and the table the x-postion. 
+
+
+
+*/
+
+
 */
 

--- a/docs/api/mainpages/internal-model.h
+++ b/docs/api/mainpages/internal-model.h
@@ -218,7 +218,6 @@ The following diagram shows current hierarchy of objects. Those marked with '(A)
       |     +-- (ImoFigBassIntervalInfo)
       |     +-- ImoInstrGroup -- data in ImoInstrument(*)
       |     +-- ImoLineStyle -- data in ImoTextBox, ImoLine(*)
-      |     +-- ImoMeasureInfo -- data in ImoInstrument and ImoBarline
       |     +-- ImoPageInfo -- data in ImoDocument, ImoScore
       |     +-- ImoStaffInfo -- data in ImoInstrument(list)
       |     +-- ImoStyle - data in ImoStyles (std::map)

--- a/docs/api/mainpages/internal-model.h
+++ b/docs/api/mainpages/internal-model.h
@@ -218,6 +218,7 @@ The following diagram shows current hierarchy of objects. Those marked with '(A)
       |     +-- (ImoFigBassIntervalInfo)
       |     +-- ImoInstrGroup -- data in ImoInstrument(*)
       |     +-- ImoLineStyle -- data in ImoTextBox, ImoLine(*)
+      |     +-- ImoMeasureInfo -- data in ImoInstrument and ImoBarline
       |     +-- ImoPageInfo -- data in ImoDocument, ImoScore
       |     +-- ImoStaffInfo -- data in ImoInstrument(list)
       |     +-- ImoStyle - data in ImoStyles (std::map)

--- a/include/lomse_internal_model.h
+++ b/include/lomse_internal_model.h
@@ -5265,9 +5265,9 @@ public:
 
 protected:
 
-    friend class MxlAnalyser;
     friend class LdpAnalyser;
     friend class ElementAnalyser;
+    friend class MeasureMxlAnalyser;
     friend class MnxAnalyser;
     inline void set_index(int index) { m_mnxIndex = index; }
     inline void set_count(int value) { m_count = value; }

--- a/include/lomse_internal_model.h
+++ b/include/lomse_internal_model.h
@@ -99,6 +99,7 @@ class ImoList;
 class ImoListItem;
 class ImoLyrics;
 class ImoLyricsTextInfo;
+class ImoMeasureInfo;
 class ImoMultiColumn;
 class ImoMusicData;
 class ImoNote;
@@ -560,6 +561,7 @@ enum EImoObjType
     k_imo_instr_group,
     k_imo_line_style,
     k_imo_lyrics_text_info,
+    k_imo_measure_info,
     k_imo_midi_info,
     k_imo_page_info,
     k_imo_sound_info,
@@ -1198,477 +1200,145 @@ public:
     }
 
     //groups
-    inline bool is_dto()
-    {
-        return m_objtype > k_imo_dto
-               && m_objtype < k_imo_dto_last;
-    }
-    inline bool is_simpleobj()
-    {
-        return m_objtype > k_imo_simpleobj
-               && m_objtype < k_imo_simpleobj_last;
-    }
-    inline bool is_collection()
-    {
-        return m_objtype > k_imo_collection
-               && m_objtype < k_imo_collection_last;
-    }
-    inline bool is_reldataobj()
-    {
-        return m_objtype > k_imo_reldataobj
-               && m_objtype < k_imo_reldataobj_last;
-    }
-    inline bool is_containerobj()
-    {
-        return m_objtype > k_imo_containerobj
-               && m_objtype < k_imo_containerobj_last;
-    }
-    inline bool is_contentobj()
-    {
-        return m_objtype > k_imo_contentobj
-               && m_objtype < k_imo_contentobj_last;
-    }
-    inline bool is_scoreobj()
-    {
-        return m_objtype > k_imo_scoreobj
-               && m_objtype < k_imo_scoreobj_last;
-    }
-    inline bool is_staffobj()
-    {
-        return m_objtype > k_imo_staffobj
-               && m_objtype < k_imo_staffobj_last;
-    }
-    inline bool is_auxobj()
-    {
-        return m_objtype > k_imo_auxobj
-               && m_objtype < k_imo_auxobj_last;
-    }
-    inline bool is_relobj()
-    {
-        return m_objtype > k_imo_relobj
-               && m_objtype < k_imo_relobj_last;
-    }
-    inline bool is_auxrelobj()
-    {
-        return m_objtype > k_imo_auxrelobj
-               && m_objtype < k_imo_auxobj_last;
-    }
-    inline bool is_block_level_obj()
-    {
-        return m_objtype > k_imo_block_level_obj
-               && m_objtype < k_imo_block_level_obj_last;
-    }
-    inline bool is_blocks_container()
-    {
-        return m_objtype > k_imo_blocks_container
-               && m_objtype < k_imo_blocks_container_last;
-    }
-    inline bool is_inlines_container()
-    {
-        return m_objtype > k_imo_inlines_container
-               && m_objtype < k_imo_inlines_container_last;
-    }
-    inline bool is_box_inline()
-    {
-        return m_objtype > k_imo_box_inline
-               && m_objtype < k_imo_box_inline_last;
-    }
-    inline bool is_inline_level_obj()
-    {
-        return m_objtype > k_imo_inline_level_obj
-               && m_objtype < k_imo_inline_level_obj_last;
-    }
-    inline bool is_articulation()
-    {
-        return m_objtype > k_imo_articulation
-               && m_objtype < k_imo_articulation_last;
-    }
+    inline bool is_dto() { return m_objtype > k_imo_dto
+                                  && m_objtype < k_imo_dto_last; }
+    inline bool is_simpleobj() { return m_objtype > k_imo_simpleobj
+                                        && m_objtype < k_imo_simpleobj_last; }
+    inline bool is_collection() { return m_objtype > k_imo_collection
+                                         && m_objtype < k_imo_collection_last; }
+    inline bool is_reldataobj() { return m_objtype > k_imo_reldataobj
+                                         && m_objtype < k_imo_reldataobj_last; }
+    inline bool is_containerobj() { return m_objtype > k_imo_containerobj
+                                           && m_objtype < k_imo_containerobj_last; }
+    inline bool is_contentobj() { return m_objtype > k_imo_contentobj
+                                         && m_objtype < k_imo_contentobj_last; }
+    inline bool is_scoreobj() { return m_objtype > k_imo_scoreobj
+                                       && m_objtype < k_imo_scoreobj_last; }
+    inline bool is_staffobj() { return m_objtype > k_imo_staffobj
+                                       && m_objtype < k_imo_staffobj_last; }
+    inline bool is_auxobj() { return m_objtype > k_imo_auxobj
+                                     && m_objtype < k_imo_auxobj_last; }
+    inline bool is_relobj() { return m_objtype > k_imo_relobj
+                                     && m_objtype < k_imo_relobj_last; }
+    inline bool is_auxrelobj() { return m_objtype > k_imo_auxrelobj
+                                        && m_objtype < k_imo_auxobj_last; }
+    inline bool is_block_level_obj() { return m_objtype > k_imo_block_level_obj
+                                              && m_objtype < k_imo_block_level_obj_last; }
+    inline bool is_blocks_container() { return m_objtype > k_imo_blocks_container
+                                               && m_objtype < k_imo_blocks_container_last; }
+    inline bool is_inlines_container() { return m_objtype > k_imo_inlines_container
+                                                && m_objtype < k_imo_inlines_container_last; }
+    inline bool is_box_inline() { return m_objtype > k_imo_box_inline
+                                         && m_objtype < k_imo_box_inline_last; }
+    inline bool is_inline_level_obj() { return m_objtype > k_imo_inline_level_obj
+                                               && m_objtype < k_imo_inline_level_obj_last; }
+    inline bool is_articulation() { return m_objtype > k_imo_articulation
+                                           && m_objtype < k_imo_articulation_last; }
 
     //items
-    inline bool is_anonymous_block()
-    {
-        return m_objtype == k_imo_anonymous_block;
-    }
-    inline bool is_articulation_symbol()
-    {
-        return m_objtype == k_imo_articulation_symbol;
-    }
-    inline bool is_articulation_line()
-    {
-        return m_objtype == k_imo_articulation_line;
-    }
-    inline bool is_attachments()
-    {
-        return m_objtype == k_imo_attachments;
-    }
-    inline bool is_barline()
-    {
-        return m_objtype == k_imo_barline;
-    }
-    inline bool is_beam()
-    {
-        return m_objtype == k_imo_beam;
-    }
-    inline bool is_beam_data()
-    {
-        return m_objtype == k_imo_beam_data;
-    }
-    inline bool is_beam_dto()
-    {
-        return m_objtype == k_imo_beam_dto;
-    }
-    inline bool is_bezier_info()
-    {
-        return m_objtype == k_imo_bezier_info;
-    }
-    inline bool is_border_dto()
-    {
-        return m_objtype == k_imo_border_dto;
-    }
-    inline bool is_button()
-    {
-        return m_objtype == k_imo_button;
-    }
-    inline bool is_chord()
-    {
-        return m_objtype == k_imo_chord;
-    }
-    inline bool is_clef()
-    {
-        return m_objtype == k_imo_clef;
-    }
-    inline bool is_color_dto()
-    {
-        return m_objtype == k_imo_color_dto;
-    }
-    inline bool is_content()
-    {
-        return m_objtype == k_imo_content;
-    }
-    inline bool is_control()
-    {
-        return m_objtype >= k_imo_control
-               && m_objtype < k_imo_control_end;
-    }
-    inline bool is_cursor_info()
-    {
-        return m_objtype == k_imo_cursor_info;
-    }
-    inline bool is_direction()
-    {
-        return m_objtype == k_imo_direction;
-    }
-    inline bool is_document()
-    {
-        return m_objtype == k_imo_document;
-    }
-    inline bool is_dynamic()
-    {
-        return m_objtype == k_imo_dynamic;
-    }
-    inline bool is_dynamics_mark()
-    {
-        return m_objtype == k_imo_dynamics_mark;
-    }
-    inline bool is_fermata()
-    {
-        return m_objtype == k_imo_fermata;
-    }
-    inline bool is_figured_bass()
-    {
-        return m_objtype == k_imo_figured_bass;
-    }
-    inline bool is_figured_bass_info()
-    {
-        return m_objtype == k_imo_figured_bass_info;
-    }
-    inline bool is_font_style_dto()
-    {
-        return m_objtype == k_imo_font_style_dto;
-    }
-    inline bool is_go_back_fwd()
-    {
-        return m_objtype == k_imo_go_back_fwd;
-    }
+    inline bool is_anonymous_block() { return m_objtype == k_imo_anonymous_block; }
+    inline bool is_articulation_symbol() { return m_objtype == k_imo_articulation_symbol; }
+    inline bool is_articulation_line() { return m_objtype == k_imo_articulation_line; }
+    inline bool is_attachments() { return m_objtype == k_imo_attachments; }
+    inline bool is_barline() { return m_objtype == k_imo_barline; }
+    inline bool is_beam() { return m_objtype == k_imo_beam; }
+    inline bool is_beam_data() { return m_objtype == k_imo_beam_data; }
+    inline bool is_beam_dto() { return m_objtype == k_imo_beam_dto; }
+    inline bool is_bezier_info() { return m_objtype == k_imo_bezier_info; }
+    inline bool is_border_dto() { return m_objtype == k_imo_border_dto; }
+    inline bool is_button() { return m_objtype == k_imo_button; }
+    inline bool is_chord() { return m_objtype == k_imo_chord; }
+    inline bool is_clef() { return m_objtype == k_imo_clef; }
+    inline bool is_color_dto() { return m_objtype == k_imo_color_dto; }
+    inline bool is_content() { return m_objtype == k_imo_content; }
+    inline bool is_control() { return m_objtype >= k_imo_control
+                                      && m_objtype < k_imo_control_end; }
+    inline bool is_cursor_info() { return m_objtype == k_imo_cursor_info; }
+    inline bool is_direction() { return m_objtype == k_imo_direction; }
+    inline bool is_document() { return m_objtype == k_imo_document; }
+    inline bool is_dynamic() { return m_objtype == k_imo_dynamic; }
+    inline bool is_dynamics_mark() { return m_objtype == k_imo_dynamics_mark; }
+    inline bool is_fermata() { return m_objtype == k_imo_fermata; }
+    inline bool is_figured_bass() { return m_objtype == k_imo_figured_bass; }
+    inline bool is_figured_bass_info() { return m_objtype == k_imo_figured_bass_info; }
+    inline bool is_font_style_dto() { return m_objtype == k_imo_font_style_dto; }
+    inline bool is_go_back_fwd() { return m_objtype == k_imo_go_back_fwd; }
     bool is_gap();      ///a rest representing a goFwd element
-    inline bool is_heading()
-    {
-        return m_objtype == k_imo_heading;
-    }
-    inline bool is_image()
-    {
-        return m_objtype == k_imo_image;
-    }
-    inline bool is_inline_wrapper()
-    {
-        return m_objtype == k_imo_inline_wrapper;
-    }
-    inline bool is_instrument()
-    {
-        return m_objtype == k_imo_instrument;
-    }
-    inline bool is_instr_group()
-    {
-        return m_objtype == k_imo_instr_group;
-    }
-    inline bool is_key_signature()
-    {
-        return m_objtype == k_imo_key_signature;
-    }
-    inline bool is_line()
-    {
-        return m_objtype == k_imo_line;
-    }
-    inline bool is_line_style()
-    {
-        return m_objtype == k_imo_line_style;
-    }
-    inline bool is_link()
-    {
-        return m_objtype == k_imo_link;
-    }
-    inline bool is_list()
-    {
-        return m_objtype == k_imo_list;
-    }
-    inline bool is_listitem()
-    {
-        return m_objtype == k_imo_listitem;
-    }
-    inline bool is_lyric()
-    {
-        return m_objtype == k_imo_lyric;
-    }
-    inline bool is_lyrics_text_info()
-    {
-        return m_objtype == k_imo_lyrics_text_info;
-    }
-    inline bool is_metronome_mark()
-    {
-        return m_objtype == k_imo_metronome_mark;
-    }
-    inline bool is_midi_info()
-    {
-        return m_objtype == k_imo_midi_info;
-    }
-    inline bool is_multicolumn()
-    {
-        return m_objtype == k_imo_multicolumn;
-    }
-    inline bool is_music_data()
-    {
-        return m_objtype == k_imo_music_data;
-    }
-    inline bool is_note()
-    {
-        return m_objtype == k_imo_note;
-    }
-    inline bool is_note_rest()
-    {
-        return m_objtype == k_imo_note
-               || m_objtype == k_imo_rest;
-    }
-    inline bool is_option()
-    {
-        return m_objtype == k_imo_option;
-    }
-    inline bool is_ornament()
-    {
-        return m_objtype == k_imo_ornament;
-    }
-    inline bool is_page_info()
-    {
-        return m_objtype == k_imo_page_info;
-    }
-    inline bool is_paragraph()
-    {
-        return m_objtype == k_imo_para;
-    }
-    inline bool is_param_info()
-    {
-        return m_objtype == k_imo_param_info;
-    }
-    inline bool is_point_dto()
-    {
-        return m_objtype == k_imo_point_dto;
-    }
-    inline bool is_rest()
-    {
-        return m_objtype == k_imo_rest;
-    }
-    inline bool is_relations()
-    {
-        return m_objtype == k_imo_relations;
-    }
-    inline bool is_repetition_mark()
-    {
-        return m_objtype == k_imo_text_repetition_mark
-               || m_objtype == k_imo_symbol_repetition_mark;
-    }
-    inline bool is_score()
-    {
-        return m_objtype == k_imo_score;
-    }
-    inline bool is_score_line()
-    {
-        return m_objtype == k_imo_score_line;
-    }
-    inline bool is_score_player()
-    {
-        return m_objtype == k_imo_score_player;
-    }
-    inline bool is_score_text()
-    {
-        return m_objtype == k_imo_score_text;
-    }
-    inline bool is_score_title()
-    {
-        return m_objtype == k_imo_score_title;
-    }
-    inline bool is_size_info()
-    {
-        return m_objtype == k_imo_size_dto;
-    }
-    inline bool is_slur()
-    {
-        return m_objtype == k_imo_slur;
-    }
-    inline bool is_slur_data()
-    {
-        return m_objtype == k_imo_slur_data;
-    }
-    inline bool is_slur_dto()
-    {
-        return m_objtype == k_imo_slur_dto;
-    }
-    inline bool is_sound_change()
-    {
-        return m_objtype == k_imo_sound_change;
-    }
-    inline bool is_sound_info()
-    {
-        return m_objtype == k_imo_sound_info;
-    }
-    inline bool is_spacer()
-    {
-        return m_objtype == k_imo_spacer;
-    }
-    inline bool is_staff_info()
-    {
-        return m_objtype == k_imo_staff_info;
-    }
-    inline bool is_style()
-    {
-        return m_objtype == k_imo_style;
-    }
-    inline bool is_styles()
-    {
-        return m_objtype == k_imo_styles;
-    }
-    inline bool is_symbol_repetition_mark()
-    {
-        return m_objtype == k_imo_symbol_repetition_mark;
-    }
-    inline bool is_system_break()
-    {
-        return m_objtype == k_imo_system_break;
-    }
-    inline bool is_system_info()
-    {
-        return m_objtype == k_imo_system_info;
-    }
-    inline bool is_table()
-    {
-        return m_objtype == k_imo_table;
-    }
-    inline bool is_table_cell()
-    {
-        return m_objtype == k_imo_table_cell;
-    }
-    inline bool is_table_body()
-    {
-        return m_objtype == k_imo_table_body;
-    }
-    inline bool is_table_head()
-    {
-        return m_objtype == k_imo_table_head;
-    }
-    inline bool is_table_row()
-    {
-        return m_objtype == k_imo_table_row;
-    }
-    inline bool is_technical()
-    {
-        return m_objtype == k_imo_technical;
-    }
-    inline bool is_text_info()
-    {
-        return m_objtype == k_imo_text_info;
-    }
-    inline bool is_text_item()
-    {
-        return m_objtype == k_imo_text_item;
-    }
-    inline bool is_text_style()
-    {
-        return m_objtype == k_imo_text_style;
-    }
-    inline bool is_textblock_info()
-    {
-        return m_objtype == k_imo_textblock_info;
-    }
-    inline bool is_text_box()
-    {
-        return m_objtype == k_imo_text_box;
-    }
-    inline bool is_text_repetition_mark()
-    {
-        return m_objtype == k_imo_text_repetition_mark;
-    }
-    inline bool is_tie()
-    {
-        return m_objtype == k_imo_tie;
-    }
-    inline bool is_tie_data()
-    {
-        return m_objtype == k_imo_tie_data;
-    }
-    inline bool is_tie_dto()
-    {
-        return m_objtype == k_imo_tie_dto;
-    }
-    inline bool is_time_signature()
-    {
-        return m_objtype == k_imo_time_signature;
-    }
-    inline bool is_time_modification_dto()
-    {
-        return m_objtype == k_imo_time_modification_dto;
-    }
-    inline bool is_tuplet()
-    {
-        return m_objtype == k_imo_tuplet;
-    }
-    inline bool is_tuplet_dto()
-    {
-        return m_objtype == k_imo_tuplet_dto;
-    }
-    inline bool is_volta_bracket()
-    {
-        return m_objtype == k_imo_volta_bracket;
-    }
-    inline bool is_volta_bracket_dto()
-    {
-        return m_objtype == k_imo_volta_bracket_dto;
-    }
+    inline bool is_heading() { return m_objtype == k_imo_heading; }
+    inline bool is_image() { return m_objtype == k_imo_image; }
+    inline bool is_inline_wrapper() { return m_objtype == k_imo_inline_wrapper; }
+    inline bool is_instrument() { return m_objtype == k_imo_instrument; }
+    inline bool is_instr_group() { return m_objtype == k_imo_instr_group; }
+    inline bool is_key_signature() { return m_objtype == k_imo_key_signature; }
+    inline bool is_line() { return m_objtype == k_imo_line; }
+    inline bool is_line_style() { return m_objtype == k_imo_line_style; }
+    inline bool is_link() { return m_objtype == k_imo_link; }
+    inline bool is_list() { return m_objtype == k_imo_list; }
+    inline bool is_listitem() { return m_objtype == k_imo_listitem; }
+    inline bool is_lyric() { return m_objtype == k_imo_lyric; }
+    inline bool is_lyrics_text_info() { return m_objtype == k_imo_lyrics_text_info; }
+    inline bool is_metronome_mark() { return m_objtype == k_imo_metronome_mark; }
+    inline bool is_measure_info() { return m_objtype == k_imo_measure_info; }
+    inline bool is_midi_info() { return m_objtype == k_imo_midi_info; }
+    inline bool is_multicolumn() { return m_objtype == k_imo_multicolumn; }
+    inline bool is_music_data() { return m_objtype == k_imo_music_data; }
+    inline bool is_note() { return m_objtype == k_imo_note; }
+    inline bool is_note_rest() { return m_objtype == k_imo_note
+               || m_objtype == k_imo_rest; }
+    inline bool is_option() { return m_objtype == k_imo_option; }
+    inline bool is_ornament() { return m_objtype == k_imo_ornament; }
+    inline bool is_page_info() { return m_objtype == k_imo_page_info; }
+    inline bool is_paragraph() { return m_objtype == k_imo_para; }
+    inline bool is_param_info() { return m_objtype == k_imo_param_info; }
+    inline bool is_point_dto() { return m_objtype == k_imo_point_dto; }
+    inline bool is_rest() { return m_objtype == k_imo_rest; }
+    inline bool is_relations() { return m_objtype == k_imo_relations; }
+    inline bool is_repetition_mark() { return m_objtype == k_imo_text_repetition_mark
+               || m_objtype == k_imo_symbol_repetition_mark; }
+    inline bool is_score() { return m_objtype == k_imo_score; }
+    inline bool is_score_line() { return m_objtype == k_imo_score_line; }
+    inline bool is_score_player() { return m_objtype == k_imo_score_player; }
+    inline bool is_score_text() { return m_objtype == k_imo_score_text; }
+    inline bool is_score_title() { return m_objtype == k_imo_score_title; }
+    inline bool is_size_info() { return m_objtype == k_imo_size_dto; }
+    inline bool is_slur() { return m_objtype == k_imo_slur; }
+    inline bool is_slur_data() { return m_objtype == k_imo_slur_data; }
+    inline bool is_slur_dto() { return m_objtype == k_imo_slur_dto; }
+    inline bool is_sound_change() { return m_objtype == k_imo_sound_change; }
+    inline bool is_sound_info() { return m_objtype == k_imo_sound_info; }
+    inline bool is_spacer() { return m_objtype == k_imo_spacer; }
+    inline bool is_staff_info() { return m_objtype == k_imo_staff_info; }
+    inline bool is_style() { return m_objtype == k_imo_style; }
+    inline bool is_styles() { return m_objtype == k_imo_styles; }
+    inline bool is_symbol_repetition_mark() { return m_objtype == k_imo_symbol_repetition_mark; }
+    inline bool is_system_break() { return m_objtype == k_imo_system_break; }
+    inline bool is_system_info() { return m_objtype == k_imo_system_info; }
+    inline bool is_table() { return m_objtype == k_imo_table; }
+    inline bool is_table_cell() { return m_objtype == k_imo_table_cell; }
+    inline bool is_table_body() { return m_objtype == k_imo_table_body; }
+    inline bool is_table_head() { return m_objtype == k_imo_table_head; }
+    inline bool is_table_row() { return m_objtype == k_imo_table_row; }
+    inline bool is_technical() { return m_objtype == k_imo_technical; }
+    inline bool is_text_info() { return m_objtype == k_imo_text_info; }
+    inline bool is_text_item() { return m_objtype == k_imo_text_item; }
+    inline bool is_text_style() { return m_objtype == k_imo_text_style; }
+    inline bool is_textblock_info() { return m_objtype == k_imo_textblock_info; }
+    inline bool is_text_box() { return m_objtype == k_imo_text_box; }
+    inline bool is_text_repetition_mark() { return m_objtype == k_imo_text_repetition_mark; }
+    inline bool is_tie() { return m_objtype == k_imo_tie; }
+    inline bool is_tie_data() { return m_objtype == k_imo_tie_data; }
+    inline bool is_tie_dto() { return m_objtype == k_imo_tie_dto; }
+    inline bool is_time_signature() { return m_objtype == k_imo_time_signature; }
+    inline bool is_time_modification_dto() { return m_objtype == k_imo_time_modification_dto; }
+    inline bool is_tuplet() { return m_objtype == k_imo_tuplet; }
+    inline bool is_tuplet_dto() { return m_objtype == k_imo_tuplet_dto; }
+    inline bool is_volta_bracket() { return m_objtype == k_imo_volta_bracket; }
+    inline bool is_volta_bracket_dto() { return m_objtype == k_imo_volta_bracket_dto; }
 
     //special checkers
-    inline bool is_mouse_over_generator()
-    {
-        return    m_objtype == k_imo_link
+    inline bool is_mouse_over_generator() { return   m_objtype == k_imo_link
                   || m_objtype == k_imo_button
-                  ;
-    }
+                  ; }
 
 protected:
     void visit_children(BaseVisitor& v);
@@ -4020,6 +3690,8 @@ public:
 };
 
 //---------------------------------------------------------------------------------------
+/** %ImoBarline represents a barline for an instrument.
+*/
 class ImoBarline : public ImoStaffObj
 {
 protected:
@@ -4035,8 +3707,8 @@ protected:
     int m_winged;       //indicates whether the barline has winged extensions above and
     //below. The k_winged_none value indicates no wings.
 
-    ImMeasuresTableEntry* m_pMeasure;   //ptr to measure ending with this barline.
-                                        //nullptr when middle barline
+    ImoMeasureInfo* m_pMeasure;   //ptr to info for measure ending with this barline.
+                                  //nullptr when middle barline
 
 
     friend class ImFactory;
@@ -4058,7 +3730,7 @@ public:
     inline bool is_middle() { return m_fMiddle; }
     inline int get_num_repeats() { return m_times; }
     inline int get_winged() { return m_winged; }
-    inline ImMeasuresTableEntry* get_measure() { return m_pMeasure; }
+    inline ImoMeasureInfo* get_measure() { return m_pMeasure; }
 
 
     //setters
@@ -4066,7 +3738,7 @@ public:
     inline void set_middle(bool value) { m_fMiddle = value; }
     inline void set_num_repeats(int times) { m_times = times; }
     inline void set_winged(int wingsType) { m_winged = wingsType; }
-    inline void set_measure(ImMeasuresTableEntry* pEntry) { m_pMeasure = pEntry; }
+    inline void set_measure(ImoMeasureInfo* pEntry) { m_pMeasure = pEntry; }
 
     //overrides: barlines always in staff 0
     void set_staff(int UNUSED(staff)) { m_staff = 0; }
@@ -4125,13 +3797,9 @@ protected:
 public:
     virtual ~ImoTextBox() {}
 
-    inline ImoTextBlockInfo* get_box_info()
-    {
-        return &m_box;
+    inline ImoTextBlockInfo* get_box_info() { return &m_box;
     }
-    inline ImoLineStyle* get_anchor_line_info()
-    {
-        return &m_line;
+    inline ImoLineStyle* get_anchor_line_info() { return &m_line;
     }
     inline bool has_anchor_line()
     {
@@ -5032,9 +4700,7 @@ public:
     {
         return m_text.get_text();
     }
-    inline ImoTextInfo* get_text_info()
-    {
-        return &m_text;
+    inline ImoTextInfo* get_text_info() { return &m_text;
     }
     string& get_language();
     inline void set_language(const string& lang)
@@ -5310,6 +4976,9 @@ public:
 };
 
 //---------------------------------------------------------------------------------------
+/** %ImoInstrument represents the musical content and attributes for an score-part
+    ('instrument', in lomse terminology).
+*/
 class ImoInstrument : public ImoContainerObj
 {
 protected:
@@ -5318,8 +4987,10 @@ protected:
     ImoScoreText    m_abbrev;
     string          m_partId;
     std::list<ImoStaffInfo*> m_staves;
-    int             m_barlineLayout;        //enum EBarlineLayout
+    int             m_barlineLayout;        //from enum EBarlineLayout
     ImMeasuresTable*  m_pMeasures;
+    ImoMeasureInfo* m_pLastMeasure;     //for last measure if not closed or the score
+                                        //has no metric. Otherwise it will be nullptr.
 
     friend class ImFactory;
     ImoInstrument();
@@ -5346,6 +5017,7 @@ public:
     inline const string& get_instr_id() const { return m_partId; }
     inline int get_barline_layout() const { return m_barlineLayout; }
     inline ImMeasuresTable* get_measures_table() const { return m_pMeasures; }
+    inline ImoMeasureInfo* get_las_measure() { return m_pLastMeasure; }
 
     //setters
     ImoStaffInfo* add_staff();
@@ -5356,6 +5028,7 @@ public:
     void replace_staff_info(ImoStaffInfo* pInfo);
     inline void set_instr_id(const string& id) { m_partId = id; }
     inline void set_barline_layout(int value) { m_barlineLayout = value; }
+    inline void set_last_measure(ImoMeasureInfo* pInfo) { m_pLastMeasure = pInfo; }
 
     //info
     inline bool has_name() { return m_name.get_text() != ""; }
@@ -5488,9 +5161,7 @@ public:
         delete m_pStyle;
     }
 
-    inline ImoLineStyle* get_line_info()
-    {
-        return m_pStyle;
+    inline ImoLineStyle* get_line_info() { return m_pStyle;
     }
     inline void set_line_style(ImoLineStyle* pStyle)
     {
@@ -5548,6 +5219,52 @@ public:
 
 protected:
     friend class BlockLevelCreatorApi;
+
+};
+
+//---------------------------------------------------------------------------------------
+/** %ImoMeasureInfo represents the data associated to a measure, such as its
+    displayed number.
+
+    %ImoMeasureInfo objects are not part of the IM tree. Each %ImoMeasureInfo object
+    is directly stored in the ImoBarline object that closes the measure. And
+    in ImoInstrument if last measure is not closed or if the score has no metric.
+*/
+class ImoMeasureInfo : public ImoSimpleObj
+{
+protected:
+    int m_mnxIndex;     //An optional integer index for the measure, as defined in NMX.
+                        //The first measure has an index of 1.
+    string m_number;    //An optional textual number to be displayed for the measure.
+
+    friend class ImFactory;
+    ImoMeasureInfo()
+        : ImoSimpleObj(k_imo_measure_info)
+        , m_mnxIndex(1)
+        , m_number("")
+    {
+    }
+    ImoMeasureInfo(int index, const string& number)
+        : ImoSimpleObj(k_imo_measure_info)
+        , m_mnxIndex(index)
+        , m_number(number)
+    {
+    }
+
+public:
+
+    virtual ~ImoMeasureInfo() {}
+
+    inline int get_index() const { return m_mnxIndex; }
+    inline const string& get_number() { return m_number; }
+
+protected:
+
+    friend class MxlAnalyser;
+    friend class LdpAnalyser;
+    friend class MnxAnalyser;
+    inline void set_index(int index) { m_mnxIndex = index; }
+    inline void set_number(const string& number) { m_number = number; }
 
 };
 
@@ -6270,18 +5987,12 @@ public:
 
     //score layout
     void add_sytem_info(ImoSystemInfo* pSL);
-    inline ImoSystemInfo* get_first_system_info()
-    {
-        return &m_systemInfoFirst;
+    inline ImoSystemInfo* get_first_system_info() { return &m_systemInfoFirst;
     }
-    inline ImoSystemInfo* get_other_system_info()
-    {
-        return &m_systemInfoOther;
+    inline ImoSystemInfo* get_other_system_info() { return &m_systemInfoOther;
     }
     void add_page_info(ImoPageInfo* pPI);
-    inline ImoPageInfo* get_page_info()
-    {
-        return &m_pageInfo;
+    inline ImoPageInfo* get_page_info() { return &m_pageInfo;
     }
     bool has_default_values(ImoSystemInfo* pInfo);
 

--- a/include/lomse_internal_model.h
+++ b/include/lomse_internal_model.h
@@ -3707,8 +3707,8 @@ protected:
     int m_winged;       //indicates whether the barline has winged extensions above and
     //below. The k_winged_none value indicates no wings.
 
-    ImoMeasureInfo* m_pMeasure;   //ptr to info for measure ending with this barline.
-                                  //nullptr when middle barline
+    ImoMeasureInfo* m_pMeasureInfo;     //ptr to info for measure ending with this barline.
+                                        //nullptr when middle barline
 
 
     friend class ImFactory;
@@ -3718,19 +3718,19 @@ protected:
         , m_fMiddle(false)
         , m_times(0)
         , m_winged(k_wings_none)
-        , m_pMeasure(nullptr)
+        , m_pMeasureInfo(nullptr)
     {
     }
 
 public:
-    virtual ~ImoBarline() {}
+    virtual ~ImoBarline();
 
     //getters
     inline int get_type() { return m_barlineType; }
     inline bool is_middle() { return m_fMiddle; }
     inline int get_num_repeats() { return m_times; }
     inline int get_winged() { return m_winged; }
-    inline ImoMeasureInfo* get_measure() { return m_pMeasure; }
+    inline ImoMeasureInfo* get_measure_info() { return m_pMeasureInfo; }
 
 
     //setters
@@ -3738,7 +3738,7 @@ public:
     inline void set_middle(bool value) { m_fMiddle = value; }
     inline void set_num_repeats(int times) { m_times = times; }
     inline void set_winged(int wingsType) { m_winged = wingsType; }
-    inline void set_measure(ImoMeasureInfo* pEntry) { m_pMeasure = pEntry; }
+    inline void set_measure_info(ImoMeasureInfo* pEntry) { m_pMeasureInfo = pEntry; }
 
     //overrides: barlines always in staff 0
     void set_staff(int UNUSED(staff)) { m_staff = 0; }
@@ -4989,8 +4989,8 @@ protected:
     std::list<ImoStaffInfo*> m_staves;
     int             m_barlineLayout;        //from enum EBarlineLayout
     ImMeasuresTable*  m_pMeasures;
-    ImoMeasureInfo* m_pLastMeasure;     //for last measure if not closed or the score
-                                        //has no metric. Otherwise it will be nullptr.
+    ImoMeasureInfo* m_pLastMeasureInfo;     //for last measure if not closed or the score
+                                            //has no metric. Otherwise it will be nullptr.
 
     friend class ImFactory;
     ImoInstrument();
@@ -5017,7 +5017,7 @@ public:
     inline const string& get_instr_id() const { return m_partId; }
     inline int get_barline_layout() const { return m_barlineLayout; }
     inline ImMeasuresTable* get_measures_table() const { return m_pMeasures; }
-    inline ImoMeasureInfo* get_las_measure() { return m_pLastMeasure; }
+    inline ImoMeasureInfo* get_last_measure_info() { return m_pLastMeasureInfo; }
 
     //setters
     ImoStaffInfo* add_staff();
@@ -5028,7 +5028,7 @@ public:
     void replace_staff_info(ImoStaffInfo* pInfo);
     inline void set_instr_id(const string& id) { m_partId = id; }
     inline void set_barline_layout(int value) { m_barlineLayout = value; }
-    inline void set_last_measure(ImoMeasureInfo* pInfo) { m_pLastMeasure = pInfo; }
+    inline void set_last_measure_info(ImoMeasureInfo* pInfo) { m_pLastMeasureInfo = pInfo; }
 
     //info
     inline bool has_name() { return m_name.get_text() != ""; }
@@ -5235,18 +5235,22 @@ class ImoMeasureInfo : public ImoSimpleObj
 protected:
     int m_mnxIndex;     //An optional integer index for the measure, as defined in NMX.
                         //The first measure has an index of 1.
+    int m_count;        //sequential integer index for the measure. The first measure
+                        //is counted as 1, even if anacrusis start.
     string m_number;    //An optional textual number to be displayed for the measure.
 
     friend class ImFactory;
     ImoMeasureInfo()
         : ImoSimpleObj(k_imo_measure_info)
-        , m_mnxIndex(1)
+        , m_mnxIndex(0)
+        , m_count(0)
         , m_number("")
     {
     }
-    ImoMeasureInfo(int index, const string& number)
+    ImoMeasureInfo(int index, int count, const string& number)
         : ImoSimpleObj(k_imo_measure_info)
         , m_mnxIndex(index)
+        , m_count(count)
         , m_number(number)
     {
     }
@@ -5256,16 +5260,18 @@ public:
     virtual ~ImoMeasureInfo() {}
 
     inline int get_index() const { return m_mnxIndex; }
+    inline int get_count() const { return m_count; }
     inline const string& get_number() { return m_number; }
 
 protected:
 
     friend class MxlAnalyser;
     friend class LdpAnalyser;
+    friend class ElementAnalyser;
     friend class MnxAnalyser;
     inline void set_index(int index) { m_mnxIndex = index; }
+    inline void set_count(int value) { m_count = value; }
     inline void set_number(const string& number) { m_number = number; }
-
 };
 
 //---------------------------------------------------------------------------------------

--- a/include/lomse_ldp_analyser.h
+++ b/include/lomse_ldp_analyser.h
@@ -51,7 +51,7 @@ class LdpAnalyser;
 class ImoObj;
 class ImoNote;
 class ImoRest;
-class ImoMeasureInfo;
+class TypeMeasureInfo;
 
 
 //---------------------------------------------------------------------------------------
@@ -214,7 +214,7 @@ protected:
 
     //saved values
     ImoNote* m_pLastNote;
-    ImoMeasureInfo* m_pMeasureInfo;
+    TypeMeasureInfo* m_pMeasureInfo;
 
     //other
     bool    m_fInstrIdRequired;     //Id required in instruments
@@ -324,8 +324,8 @@ public:
     inline bool is_instr_id_required() { return m_fInstrIdRequired; }
 
     //methods for creating measures info
-    inline ImoMeasureInfo* get_measure_info() { return m_pMeasureInfo; }
-    inline void set_measure_info(ImoMeasureInfo* pInfo) { m_pMeasureInfo = pInfo; }
+    inline TypeMeasureInfo* get_measure_info() { return m_pMeasureInfo; }
+    inline void set_measure_info(TypeMeasureInfo* pInfo) { m_pMeasureInfo = pInfo; }
     inline int increment_measures_counter() { return ++m_measuresCounter; }
 
     //static methods for general use

--- a/include/lomse_ldp_analyser.h
+++ b/include/lomse_ldp_analyser.h
@@ -51,6 +51,7 @@ class LdpAnalyser;
 class ImoObj;
 class ImoNote;
 class ImoRest;
+class ImoMeasureInfo;
 
 
 //---------------------------------------------------------------------------------------
@@ -213,13 +214,15 @@ protected:
 
     //saved values
     ImoNote* m_pLastNote;
+    ImoMeasureInfo* m_pMeasureInfo;
 
     //other
     bool    m_fInstrIdRequired;     //Id required in instruments
+    int     m_measuresCounter;
 
     //FIX: for lyrics space
-    friend class InstrumentAnalyser;
     ImoInstrument*  m_pCurInstr;    //current instrument being analysed
+    friend class InstrumentAnalyser;
     LUnits  m_extraMarginSpace;     //extra margin for next instrument
 
 public:
@@ -255,6 +258,9 @@ public:
 
     inline void save_last_note(ImoNote* pNote) { m_pLastNote = pNote; }
     inline ImoNote* get_last_note() { return m_pLastNote; }
+
+    inline void set_current_instrument(ImoInstrument* pInstr) { m_pCurInstr = pInstr; }
+    inline ImoInstrument* get_current_instrument() { return m_pCurInstr; }
 
     //interface for building relations
     void add_relation_info(ImoObj* pDto);
@@ -314,8 +320,13 @@ public:
     inline ImoDocument* get_root_imo_document() { return m_pImoDoc; }
 
     //methods related to analysing instruments
-    void require_instr_id() { m_fInstrIdRequired = true; }
-    bool is_instr_id_required() { return m_fInstrIdRequired; }
+    inline void require_instr_id() { m_fInstrIdRequired = true; }
+    inline bool is_instr_id_required() { return m_fInstrIdRequired; }
+
+    //methods for creating measures info
+    inline ImoMeasureInfo* get_measure_info() { return m_pMeasureInfo; }
+    inline void set_measure_info(ImoMeasureInfo* pInfo) { m_pMeasureInfo = pInfo; }
+    inline int increment_measures_counter() { return ++m_measuresCounter; }
 
     //static methods for general use
     static int ldp_name_to_key_type(const string& value);

--- a/include/lomse_mnx_analyser.h
+++ b/include/lomse_mnx_analyser.h
@@ -272,6 +272,7 @@ protected:
     float           m_divisions;        //fractions of quarter note to use as units for 'duration' values
     string          m_curPartId;        //Part Id being analysed
     string          m_curMeasureNum;    //Num of measure being analysed
+    int             m_measuresCounter;  //counter for measures in current instrument
 
     //current values
     int m_curStaff;
@@ -372,6 +373,10 @@ public:
     inline void save_last_note(ImoNote* pNote) { m_pLastNote = pNote; }
     inline ImoNote* get_last_note() { return m_pLastNote; }
 
+    //for creating measures info
+    inline int increment_measures_counter() { return ++m_measuresCounter; }
+    inline void save_current_measure_num(const string& num) { m_curMeasureNum = num; }
+
     //last barline added to current instrument
     inline void save_last_barline(ImoBarline* pBarline) { m_pLastBarline = pBarline; }
     inline ImoBarline* get_last_barline() { return m_pLastBarline; }
@@ -425,7 +430,6 @@ public:
     //information for reporting errors
     string get_element_info();
     inline void save_current_part_id(const string& id) { m_curPartId = id; }
-    inline void save_current_measure_num(const string& num) { m_curMeasureNum = num; }
     int get_line_number(XmlNode* node);
 
 

--- a/include/lomse_mxl_analyser.h
+++ b/include/lomse_mxl_analyser.h
@@ -249,6 +249,7 @@ protected:
     float           m_divisions;        //fractions of quarter note to use as units for 'duration' values
     string          m_curPartId;        //Part Id being analysed
     string          m_curMeasureNum;    //Num of measure being analysed
+    int             m_measuresCounter;  //counter for measures in current instrument
 
     //inherited values
 //    int m_curStaff;
@@ -353,6 +354,9 @@ public:
     int create_index_for_sound(const string& id);
     ImoMidiInfo* get_latest_midi_info_for(const string& id);
     void set_latest_midi_info_for(const string& id, ImoMidiInfo* pMidi);
+
+    //for creating measures info
+    inline int increment_measures_counter() { return ++m_measuresCounter; }
 
     //interface for building relations
     void add_relation_info(ImoObj* pDto);

--- a/include/lomse_mxl_analyser.h
+++ b/include/lomse_mxl_analyser.h
@@ -357,6 +357,7 @@ public:
 
     //for creating measures info
     inline int increment_measures_counter() { return ++m_measuresCounter; }
+    inline void save_current_measure_num(const string& num) { m_curMeasureNum = num; }
 
     //interface for building relations
     void add_relation_info(ImoObj* pDto);
@@ -395,7 +396,6 @@ public:
     //information for reporting errors
     string get_element_info();
     inline void save_current_part_id(const string& id) { m_curPartId = id; }
-    inline void save_current_measure_num(const string& num) { m_curMeasureNum = num; }
     int get_line_number(XmlNode* node);
 
 

--- a/src/internal_model/lomse_im_factory.cpp
+++ b/src/internal_model/lomse_im_factory.cpp
@@ -91,7 +91,8 @@ ImoObj* ImFactory::inject(int type, Document* pDoc, ImoId id)
         case k_imo_lyric:               pObj = LOMSE_NEW ImoLyric();              break;
         case k_imo_lyrics_text_info:    pObj = LOMSE_NEW ImoLyricsTextInfo();     break;
         case k_imo_metronome_mark:      pObj = LOMSE_NEW ImoMetronomeMark();      break;
-        case k_imo_midi_info:           pObj = LOMSE_NEW ImoMidiInfo();             break;
+        case k_imo_measure_info:        pObj = LOMSE_NEW ImoMeasureInfo();        break;
+        case k_imo_midi_info:           pObj = LOMSE_NEW ImoMidiInfo();           break;
         case k_imo_multicolumn:         pObj = LOMSE_NEW ImoMultiColumn(pDoc);    break;
         case k_imo_music_data:          pObj = LOMSE_NEW ImoMusicData();          break;
         case k_imo_note:                pObj = LOMSE_NEW ImoNote();               break;

--- a/src/internal_model/lomse_im_factory.cpp
+++ b/src/internal_model/lomse_im_factory.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -91,7 +91,6 @@ ImoObj* ImFactory::inject(int type, Document* pDoc, ImoId id)
         case k_imo_lyric:               pObj = LOMSE_NEW ImoLyric();              break;
         case k_imo_lyrics_text_info:    pObj = LOMSE_NEW ImoLyricsTextInfo();     break;
         case k_imo_metronome_mark:      pObj = LOMSE_NEW ImoMetronomeMark();      break;
-        case k_imo_measure_info:        pObj = LOMSE_NEW ImoMeasureInfo();        break;
         case k_imo_midi_info:           pObj = LOMSE_NEW ImoMidiInfo();           break;
         case k_imo_multicolumn:         pObj = LOMSE_NEW ImoMultiColumn(pDoc);    break;
         case k_imo_music_data:          pObj = LOMSE_NEW ImoMusicData();          break;

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -489,6 +489,7 @@ const string& ImoObj::get_name(int type)
         m_TypeToName[k_imo_instr_group] = "instr-group";
         m_TypeToName[k_imo_line_style] = "line-style";
         m_TypeToName[k_imo_lyrics_text_info] = "lyric-text";
+        m_TypeToName[k_imo_measure_info] = "measure-info";
         m_TypeToName[k_imo_midi_info] = "midi-info";
         m_TypeToName[k_imo_option] = "opt";
         m_TypeToName[k_imo_page_info] = "page-info";
@@ -2423,6 +2424,7 @@ ImoInstrument::ImoInstrument()
     , m_partId("")
     , m_barlineLayout(k_isolated)
     , m_pMeasures(nullptr)
+    , m_pLastMeasure(nullptr)
 {
     add_staff();
 //	m_midiChannel = g_pMidi->DefaultVoiceChannel();
@@ -2438,6 +2440,7 @@ ImoInstrument::~ImoInstrument()
     m_staves.clear();
 
     delete m_pMeasures;
+    delete m_pLastMeasure;
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -1544,6 +1544,12 @@ void ImoBlocksContainer::append_content_item(ImoContentObj* pItem)
 //=======================================================================================
 // ImoBarline implementation
 //=======================================================================================
+ImoBarline::~ImoBarline()
+{
+    delete m_pMeasureInfo;
+}
+
+//---------------------------------------------------------------------------------------
 void ImoBarline::set_int_attribute(TIntAttribute attrib, int value)
 {
     //AWARE: override of staff_num (in ImoStaffObj)
@@ -2424,7 +2430,7 @@ ImoInstrument::ImoInstrument()
     , m_partId("")
     , m_barlineLayout(k_isolated)
     , m_pMeasures(nullptr)
-    , m_pLastMeasure(nullptr)
+    , m_pLastMeasureInfo(nullptr)
 {
     add_staff();
 //	m_midiChannel = g_pMidi->DefaultVoiceChannel();
@@ -2440,7 +2446,7 @@ ImoInstrument::~ImoInstrument()
     m_staves.clear();
 
     delete m_pMeasures;
-    delete m_pLastMeasure;
+    delete m_pLastMeasureInfo;
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -489,7 +489,6 @@ const string& ImoObj::get_name(int type)
         m_TypeToName[k_imo_instr_group] = "instr-group";
         m_TypeToName[k_imo_line_style] = "line-style";
         m_TypeToName[k_imo_lyrics_text_info] = "lyric-text";
-        m_TypeToName[k_imo_measure_info] = "measure-info";
         m_TypeToName[k_imo_midi_info] = "midi-info";
         m_TypeToName[k_imo_option] = "opt";
         m_TypeToName[k_imo_page_info] = "page-info";

--- a/src/parser/ldp/lomse_ldp_analyser.cpp
+++ b/src/parser/ldp/lomse_ldp_analyser.cpp
@@ -990,7 +990,7 @@ protected:
 
     void add_measure_info(ImoBarline* pBarline)
     {
-        ImoMeasureInfo* pInfo = m_pAnalyser->get_measure_info();
+        TypeMeasureInfo* pInfo = m_pAnalyser->get_measure_info();
         if (pInfo)  //In Unit Tests it could not exist
         {
             pBarline->set_measure_info(pInfo);
@@ -3604,7 +3604,7 @@ protected:
         ImoInstrument* pInstr = m_pAnalyser->get_current_instrument();
         if (pInstr != nullptr)  //in Unit Tests there could be no instrument
         {
-            ImoMeasureInfo* pInfo = m_pAnalyser->get_measure_info();
+            TypeMeasureInfo* pInfo = m_pAnalyser->get_measure_info();
             pInstr->set_last_measure_info(pInfo);
             m_pAnalyser->set_measure_info(nullptr);
         }
@@ -6321,15 +6321,12 @@ void ElementAnalyser::add_to_model(ImoObj* pImo)
 //---------------------------------------------------------------------------------------
 void ElementAnalyser::create_measure_info_if_necessary()
 {
-    ImoMeasureInfo* pInfo = m_pAnalyser->get_measure_info();
+    TypeMeasureInfo* pInfo = m_pAnalyser->get_measure_info();
     if (pInfo == nullptr)
     {
-        Document* pDoc = m_pAnalyser->get_document_being_analysed();
-        pInfo = static_cast<ImoMeasureInfo*>(
-                    ImFactory::inject(k_imo_measure_info, pDoc) );
+        pInfo = LOMSE_NEW TypeMeasureInfo();
         m_pAnalyser->set_measure_info(pInfo);
-        int count = m_pAnalyser->increment_measures_counter();
-        pInfo->set_count(count);
+        pInfo->count = m_pAnalyser->increment_measures_counter();
     }
 }
 

--- a/src/parser/ldp/lomse_ldp_analyser.cpp
+++ b/src/parser/ldp/lomse_ldp_analyser.cpp
@@ -131,6 +131,7 @@ protected:
 
     //building the model
     void add_to_model(ImoObj* pImo);
+    void create_measure_info_if_necessary();
 
     //auxiliary
     inline ImoId get_node_id() { return m_pAnalysedNode->get_id(); }
@@ -955,6 +956,7 @@ public:
         error_if_more_elements();
 
         add_to_model(pBarline);
+        add_measure_info(pBarline);
     }
 
 protected:
@@ -984,6 +986,16 @@ protected:
         }
 
         return type;
+    }
+
+    void add_measure_info(ImoBarline* pBarline)
+    {
+        ImoMeasureInfo* pInfo = m_pAnalyser->get_measure_info();
+        if (pInfo)  //In Unit Tests it could not exist
+        {
+            pBarline->set_measure_info(pInfo);
+            m_pAnalyser->set_measure_info(nullptr);
+        }
     }
 
 };
@@ -2923,7 +2935,7 @@ public:
         while (analyse_optional(k_staff, pInstrument));
 
         //FIX: For adding space for lyrics
-        m_pAnalyser->m_pCurInstr = pInstrument;
+        m_pAnalyser->set_current_instrument(pInstrument);
         if (!m_pAnalyser->is_instr_id_required())
         {
             pInstrument->reserve_space_for_lyrics(0, m_pAnalyser->m_extraMarginSpace);
@@ -3582,6 +3594,20 @@ public:
         }
 
         add_to_model(pMD);
+        add_last_measure_info_if_required();
+    }
+
+protected:
+
+    void add_last_measure_info_if_required()
+    {
+        ImoInstrument* pInstr = m_pAnalyser->get_current_instrument();
+        if (pInstr != nullptr)  //in Unit Tests there could be no instrument
+        {
+            ImoMeasureInfo* pInfo = m_pAnalyser->get_measure_info();
+            pInstr->set_last_measure_info(pInfo);
+            m_pAnalyser->set_measure_info(nullptr);
+        }
     }
 
 };
@@ -6283,13 +6309,29 @@ void ElementAnalyser::analyse_scoreobj_options(ImoScoreObj* pSO)
 //---------------------------------------------------------------------------------------
 void ElementAnalyser::add_to_model(ImoObj* pImo)
 {
+    if (pImo->is_staffobj())
+        create_measure_info_if_necessary();
+
     int ldpNodeType = m_pAnalysedNode->get_type();
     Linker linker( m_pAnalyser->get_document_being_analysed() );
     ImoObj* pObj = linker.add_child_to_model(m_pAnchor, pImo, ldpNodeType);
     m_pAnalysedNode->set_imo(pObj);
 }
 
-
+//---------------------------------------------------------------------------------------
+void ElementAnalyser::create_measure_info_if_necessary()
+{
+    ImoMeasureInfo* pInfo = m_pAnalyser->get_measure_info();
+    if (pInfo == nullptr)
+    {
+        Document* pDoc = m_pAnalyser->get_document_being_analysed();
+        pInfo = static_cast<ImoMeasureInfo*>(
+                    ImFactory::inject(k_imo_measure_info, pDoc) );
+        m_pAnalyser->set_measure_info(pInfo);
+        int count = m_pAnalyser->increment_measures_counter();
+        pInfo->set_count(count);
+    }
+}
 
 
 //=======================================================================================
@@ -6316,7 +6358,10 @@ LdpAnalyser::LdpAnalyser(ostream& reporter, LibraryScope& libraryScope, Document
     , m_nShowTupletBracket(k_yesno_default)
     , m_nShowTupletNumber(k_yesno_default)
     , m_pLastNote(nullptr)
+    , m_pMeasureInfo(nullptr)
     , m_fInstrIdRequired(false)
+    , m_measuresCounter(0)
+    , m_pCurInstr(nullptr)
     , m_extraMarginSpace(0.0f)
 {
 }
@@ -6336,6 +6381,9 @@ void LdpAnalyser::reset_defaults_for_instrument()
     m_curStaff = 0;
     m_curVoice = 1;
     m_pLastNote = nullptr;
+    m_pMeasureInfo = nullptr;
+    m_pCurInstr = nullptr;
+    m_measuresCounter = 0;
 }
 
 //---------------------------------------------------------------------------------------
@@ -6433,7 +6481,7 @@ void LdpAnalyser::add_marging_space_for_lyrics(ImoNote* pNote, ImoLyric* pLyric)
 
     int iStaff = pNote->get_staff();
     bool fAbove = pLyric->get_placement() == k_placement_above;
-    ImoInstrument* pInstr = m_pCurInstr;
+    ImoInstrument* pInstr = get_current_instrument();
     LUnits space = 400.0f;  //4mm per lyrics line
     if (fAbove)
     {

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -3370,7 +3370,7 @@ public:
         ImoMusicData* pMD = dynamic_cast<ImoMusicData*>(m_pAnchor);
         bool fSomethingAdded = false;
 
-        //attrb: number #REQUIRED
+        //attrb: number CDATA #REQUIRED
         string num = get_optional_string_attribute("number", "");
         if (num.empty())
         {
@@ -3378,6 +3378,17 @@ public:
             return nullptr;
         }
         TypeMeasureInfo* pInfo = create_measure_info(num);
+
+        //attrb: implicit %yes-no; #IMPLIED
+        //TODO
+
+        //attrb: non-controlling %yes-no; #IMPLIED
+        //'non-controlling': a barline not suitable for line breaks or page breaks.
+        //MusicXML uses this concept for dealing with multi-metrics
+        //TODO
+
+        //attrb: width %tenths; #IMPLIED
+        //TODO
 
         // [{<xxxx>|<yyyy>|<zzzz>}*]    alternatives: zero or more
         while (more_children_to_analyse())
@@ -6725,6 +6736,7 @@ MxlAnalyser::MxlAnalyser(ostream& reporter, LibraryScope& libraryScope, Document
     , m_time(0.0)
     , m_maxTime(0.0)
     , m_divisions(1.0f)
+    , m_curMeasureNum("")
     , m_measuresCounter(0)
 {
     //populate the name to enum conversion map

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -3377,7 +3377,7 @@ public:
             error_msg("<measure>: missing mandatory 'number' attribute. <measure> content will be ignored");
             return nullptr;
         }
-        ImoMeasureInfo* pInfo = create_measure_info(num);
+        TypeMeasureInfo* pInfo = create_measure_info(num);
 
         // [{<xxxx>|<yyyy>|<zzzz>}*]    alternatives: zero or more
         while (more_children_to_analyse())
@@ -3422,19 +3422,16 @@ public:
 
 protected:
 
-    ImoMeasureInfo* create_measure_info(const string& num)
+    TypeMeasureInfo* create_measure_info(const string& num)
     {
-        Document* pDoc = m_pAnalyser->get_document_being_analysed();
-        ImoMeasureInfo* pInfo = static_cast<ImoMeasureInfo*>(
-                        ImFactory::inject(k_imo_measure_info, pDoc) );
-        int count = m_pAnalyser->increment_measures_counter();
-        pInfo->set_count(count);
-        pInfo->set_number(num);
+        TypeMeasureInfo* pInfo = LOMSE_NEW TypeMeasureInfo();
+        pInfo->count = m_pAnalyser->increment_measures_counter();
+        pInfo->number = num;
         m_pAnalyser->save_current_measure_num(num);
         return pInfo;
     }
 
-    void add_barline(ImoMeasureInfo* pInfo)
+    void add_barline(TypeMeasureInfo* pInfo)
     {
         advance_timepos_if_required();
 

--- a/src/tests/lomse_test_ldp_analyser.cpp
+++ b/src/tests/lomse_test_ldp_analyser.cpp
@@ -10956,7 +10956,7 @@ SUITE(LdpAnalyserTest)
 
     TEST_FIXTURE(LdpAnalyserTestFixture, measures_001)
     {
-        //@001. Barline has info. No info in instrument
+        //@001. Score ends in barline. MeasuresInfo in Barline but not in Instrument
 
         stringstream errormsg;
         stringstream expected;
@@ -10997,8 +10997,7 @@ SUITE(LdpAnalyserTest)
         ImoMeasureInfo* pInfo = pBarline->get_measure_info();
         CHECK( pInfo != nullptr );
         CHECK( pInfo->get_count() == 1 );
-//        cout << test_name();
-//        cout << ": count=" << pInfo->get_count() << endl;
+//        cout << test_name() << ": count=" << pInfo->get_count() << endl;
 
         delete tree->get_root();
         if (pRoot && !pRoot->is_document()) delete pRoot;
@@ -11006,7 +11005,7 @@ SUITE(LdpAnalyserTest)
 
     TEST_FIXTURE(LdpAnalyserTestFixture, measures_002)
     {
-        //@002. Barline has info. Info in instrument
+        //@002. Score does not end in barline. MeasuresInfo in Barline and Instrument
 
         stringstream errormsg;
         stringstream expected;
@@ -11029,8 +11028,7 @@ SUITE(LdpAnalyserTest)
         ImoMeasureInfo* pInfo = pInstr->get_last_measure_info();
         CHECK( pInfo != nullptr );
         CHECK( pInfo->get_count() == 2 );
-//        cout << test_name();
-//        cout << ": count=" << pInfo->get_count() << endl;
+//        cout << test_name() << ": count=" << pInfo->get_count() << endl;
 
         ImoMusicData* pMusic = pInstr->get_musicdata();
         CHECK( pMusic != nullptr );
@@ -11053,8 +11051,34 @@ SUITE(LdpAnalyserTest)
         pInfo = pBarline->get_measure_info();
         CHECK( pInfo != nullptr );
         CHECK( pInfo->get_count() == 1 );
-//        cout << test_name();
-//        cout << ": count=" << pInfo->get_count() << endl;
+//        cout << test_name() << ": count=" << pInfo->get_count() << endl;
+
+        delete tree->get_root();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, measures_003)
+    {
+        //@003. Empty score. No MeasuresInfo in Instrument
+
+        stringstream errormsg;
+        stringstream expected;
+        Document doc(m_libraryScope);
+        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+        parser.parse_text("(score (vers 2.0)"
+            "(instrument (musicData "
+            ")))"
+        );
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pRoot );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMeasureInfo* pInfo = pInstr->get_last_measure_info();
+        CHECK( pInfo == nullptr );
 
         delete tree->get_root();
         if (pRoot && !pRoot->is_document()) delete pRoot;

--- a/src/tests/lomse_test_ldp_analyser.cpp
+++ b/src/tests/lomse_test_ldp_analyser.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -10994,10 +10994,10 @@ SUITE(LdpAnalyserTest)
         CHECK( pBarline != nullptr );
         CHECK( pBarline->get_type() == k_barline_simple );
         CHECK( pBarline->is_visible() );
-        ImoMeasureInfo* pInfo = pBarline->get_measure_info();
+        TypeMeasureInfo* pInfo = pBarline->get_measure_info();
         CHECK( pInfo != nullptr );
-        CHECK( pInfo->get_count() == 1 );
-//        cout << test_name() << ": count=" << pInfo->get_count() << endl;
+        CHECK( pInfo->count == 1 );
+//        cout << test_name() << ": count=" << pInfo->count << endl;
 
         delete tree->get_root();
         if (pRoot && !pRoot->is_document()) delete pRoot;
@@ -11025,10 +11025,10 @@ SUITE(LdpAnalyserTest)
         CHECK( errormsg.str() == expected.str() );
         ImoScore* pScore = dynamic_cast<ImoScore*>( pRoot );
         ImoInstrument* pInstr = pScore->get_instrument(0);
-        ImoMeasureInfo* pInfo = pInstr->get_last_measure_info();
+        TypeMeasureInfo* pInfo = pInstr->get_last_measure_info();
         CHECK( pInfo != nullptr );
-        CHECK( pInfo->get_count() == 2 );
-//        cout << test_name() << ": count=" << pInfo->get_count() << endl;
+        CHECK( pInfo->count == 2 );
+//        cout << test_name() << ": count=" << pInfo->count << endl;
 
         ImoMusicData* pMusic = pInstr->get_musicdata();
         CHECK( pMusic != nullptr );
@@ -11050,8 +11050,8 @@ SUITE(LdpAnalyserTest)
         CHECK( pBarline->is_visible() );
         pInfo = pBarline->get_measure_info();
         CHECK( pInfo != nullptr );
-        CHECK( pInfo->get_count() == 1 );
-//        cout << test_name() << ": count=" << pInfo->get_count() << endl;
+        CHECK( pInfo->count == 1 );
+//        cout << test_name() << ": count=" << pInfo->count << endl;
 
         delete tree->get_root();
         if (pRoot && !pRoot->is_document()) delete pRoot;
@@ -11077,7 +11077,7 @@ SUITE(LdpAnalyserTest)
         CHECK( errormsg.str() == expected.str() );
         ImoScore* pScore = dynamic_cast<ImoScore*>( pRoot );
         ImoInstrument* pInstr = pScore->get_instrument(0);
-        ImoMeasureInfo* pInfo = pInstr->get_last_measure_info();
+        TypeMeasureInfo* pInfo = pInstr->get_last_measure_info();
         CHECK( pInfo == nullptr );
 
         delete tree->get_root();

--- a/src/tests/lomse_test_ldp_analyser.cpp
+++ b/src/tests/lomse_test_ldp_analyser.cpp
@@ -681,25 +681,10 @@ SUITE(LdpAnalyserTest)
         if (pRoot && !pRoot->is_document()) delete pRoot;
     }
 
-    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Barline_HasId)
+    TEST_FIXTURE(LdpAnalyserTestFixture, barline_012)
     {
-//        stringstream errormsg;
-//        Document doc(m_libraryScope);
-//        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
-//        stringstream expected;
-//        //expected << "Line 0. " << endl;
-//        parser.parse_text("(barline#7 double)");
-//        LdpAnalyser a(errormsg, m_libraryScope, &doc);
-//        ImoObj* pRoot = a.analyse_tree(tree, "string:");
-//        //cout << "[" << errormsg.str() << "]" << endl;
-//        //cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
-//        ImoBarline* pBarline = dynamic_cast<ImoBarline*>( pRoot );
-//        CHECK( pBarline != nullptr );
-//        CHECK( pBarline->get_id() == 7 );
-//
-//        delete tree->get_root();
-//        if (pRoot && !pRoot->is_document()) delete pRoot;
+        //@012. Barline has id
+
         Document doc(m_libraryScope);
         LdpParser parser(cout, m_libraryScope.ldp_factory());
         parser.parse_text("(barline#7 double)");
@@ -10962,6 +10947,114 @@ SUITE(LdpAnalyserTest)
         CHECK( pBody->get_num_items() == 1 );
         pRow = dynamic_cast<ImoTableRow*>( pBody->get_item(0) );
         CHECK( pRow->is_table_row() == true );
+
+        delete tree->get_root();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    //@ measures ------------------------------------------------------------------------
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, measures_001)
+    {
+        //@001. Barline has info. No info in instrument
+
+        stringstream errormsg;
+        stringstream expected;
+        Document doc(m_libraryScope);
+        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+        parser.parse_text("(score (vers 2.0)"
+            "(instrument (musicData "
+            "(clef G)(key D)(time 2 4)(n c4 q)(n e4 q)(barline)"
+            ")))"
+        );
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pRoot );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        CHECK( pInstr->get_last_measure_info() == nullptr );
+        ImoMusicData* pMusic = pInstr->get_musicdata();
+        CHECK( pMusic != nullptr );
+        ImoObj::children_iterator it = pMusic->begin();  //clef
+        CHECK( (*it)->is_clef() );
+        ++it;   //key
+        CHECK( (*it)->is_key_signature() );
+        ++it;   //TS
+        CHECK( (*it)->is_time_signature() );
+        ++it;   //n c4
+        CHECK( (*it)->is_note() );
+        ++it;   //n eq
+        CHECK( (*it)->is_note() );
+        ++it;   //barline
+        CHECK( (*it)->is_barline() );
+        ImoBarline* pBarline = dynamic_cast<ImoBarline*>( *it );
+        CHECK( pBarline != nullptr );
+        CHECK( pBarline->get_type() == k_barline_simple );
+        CHECK( pBarline->is_visible() );
+        ImoMeasureInfo* pInfo = pBarline->get_measure_info();
+        CHECK( pInfo != nullptr );
+        CHECK( pInfo->get_count() == 1 );
+//        cout << test_name();
+//        cout << ": count=" << pInfo->get_count() << endl;
+
+        delete tree->get_root();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, measures_002)
+    {
+        //@002. Barline has info. Info in instrument
+
+        stringstream errormsg;
+        stringstream expected;
+        Document doc(m_libraryScope);
+        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+        parser.parse_text("(score (vers 2.0)"
+            "(instrument (musicData "
+            "(clef G)(key D)(time 2 4)(n c4 q)(n e4 q)(barline)"
+            "(n g4 q)"
+            ")))"
+        );
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pRoot );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMeasureInfo* pInfo = pInstr->get_last_measure_info();
+        CHECK( pInfo != nullptr );
+        CHECK( pInfo->get_count() == 2 );
+//        cout << test_name();
+//        cout << ": count=" << pInfo->get_count() << endl;
+
+        ImoMusicData* pMusic = pInstr->get_musicdata();
+        CHECK( pMusic != nullptr );
+        ImoObj::children_iterator it = pMusic->begin();  //clef
+        CHECK( (*it)->is_clef() );
+        ++it;   //key
+        CHECK( (*it)->is_key_signature() );
+        ++it;   //TS
+        CHECK( (*it)->is_time_signature() );
+        ++it;   //n c4
+        CHECK( (*it)->is_note() );
+        ++it;   //n eq
+        CHECK( (*it)->is_note() );
+        ++it;   //barline
+        CHECK( (*it)->is_barline() );
+        ImoBarline* pBarline = dynamic_cast<ImoBarline*>( *it );
+        CHECK( pBarline != nullptr );
+        CHECK( pBarline->get_type() == k_barline_simple );
+        CHECK( pBarline->is_visible() );
+        pInfo = pBarline->get_measure_info();
+        CHECK( pInfo != nullptr );
+        CHECK( pInfo->get_count() == 1 );
+//        cout << test_name();
+//        cout << ": count=" << pInfo->get_count() << endl;
 
         delete tree->get_root();
         if (pRoot && !pRoot->is_document()) delete pRoot;

--- a/src/tests/lomse_test_mnx_analyser.cpp
+++ b/src/tests/lomse_test_mnx_analyser.cpp
@@ -66,7 +66,7 @@ public:
         : m_libraryScope(cout)
         , m_requestType(k_null_request)
         , m_fRequestReceived(false)
-        , m_pDoc(NULL)
+        , m_pDoc(nullptr)
     {
         m_libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
     }
@@ -123,7 +123,7 @@ SUITE(MnxAnalyserTest)
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
         CHECK( errormsg.str() == expected.str() );
-        CHECK( pRoot != NULL );
+        CHECK( pRoot != nullptr );
         CHECK( pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         CHECK( pDoc->get_num_content_items() == 0 );
@@ -161,7 +161,7 @@ SUITE(MnxAnalyserTest)
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
         CHECK( errormsg.str() == expected.str() );
-        CHECK( pRoot != NULL );
+        CHECK( pRoot != nullptr );
         CHECK( pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         CHECK( doc.is_dirty() == true );
@@ -201,7 +201,7 @@ SUITE(MnxAnalyserTest)
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
 //        CHECK( errormsg.str() == expected.str() );
-//        CHECK( pRoot != NULL );
+//        CHECK( pRoot != nullptr );
 //        CHECK( pRoot->is_document() == true );
 //        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
 //        CHECK( doc.is_dirty() == true );
@@ -212,6 +212,174 @@ SUITE(MnxAnalyserTest)
 //
 //        if (pRoot && !pRoot->is_document()) delete pRoot;
 //    }
+
+
+    //@ measure -------------------------------------------------------------------------
+
+    TEST_FIXTURE(MnxAnalyserTestFixture, measure_01)
+    {
+        //@01. MeasuresInfo in Barline but not in Instrument
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        expected << "Line 0. <cwmnx>: missing mandatory element <global>." << endl;
+        parser.parse_text(
+            "<mnx>"
+            "<head></head>"
+            "<score><cwmnx profile='standard'>"
+                "<part>"
+                    "<part-name>Piano</part-name>"
+                    "<measure>"
+                      "<directions>"
+                        "<staves number='1'/>"
+                        "<clef line='2' sign='G'/>"
+                      "</directions>"
+                      "<sequence staff='1'>"
+                        "<event value='/4'><note pitch='C4'/></event>"
+                        "<event value='/2'><note pitch='E4'/></event>"
+                      "</sequence>"
+                    "</measure>"
+                "</part>"
+            "</cwmnx></score>"
+            "</mnx>");
+        MnxAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot =  a.analyse_tree(tree, "string:");
+
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pRoot != nullptr );
+        CHECK( pRoot->is_document() == true );
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
+        CHECK( pDoc->get_num_content_items() == 1 );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        TypeMeasureInfo* pInfo = pInstr->get_last_measure_info();
+        CHECK( pInfo == nullptr );
+        ImoMusicData* pMD = pInstr->get_musicdata();
+        CHECK( pMD != nullptr );
+
+        CHECK( pMD->get_num_children() == 4 );
+        ImoObj::children_iterator it = pMD->begin();    //clef
+        CHECK( (*it)->is_clef() );
+        ++it;   //note c4
+        CHECK( (*it)->is_note() );
+        ++it;   //note e4
+        CHECK( (*it)->is_note() );
+        ++it;   //barline
+        CHECK( (*it)->is_barline() );
+        ImoBarline* pBarline = dynamic_cast<ImoBarline*>( *it );
+        CHECK( pBarline != nullptr );
+        CHECK( pBarline->get_type() == k_barline_simple );
+        CHECK( pBarline->is_visible() );
+        pInfo = pBarline->get_measure_info();
+        CHECK( pInfo != nullptr );
+        CHECK( pInfo->count == 1 );
+//        cout << test_name() << ": count=" << pInfo->count << endl;
+
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    TEST_FIXTURE(MnxAnalyserTestFixture, measure_02)
+    {
+        //@02. Two measures
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        expected << "Line 0. <cwmnx>: missing mandatory element <global>." << endl;
+        parser.parse_text(
+            "<mnx>"
+            "<head></head>"
+            "<score><cwmnx profile='standard'>"
+                "<part>"
+                    "<part-name>Piano</part-name>"
+                    "<measure number='1'>"
+                      "<directions>"
+                        "<staves number='1'/>"
+                        "<clef line='2' sign='G'/>"
+                      "</directions>"
+                      "<sequence staff='1'>"
+                        "<event value='/4'><note pitch='C4'/></event>"
+                        "<event value='/2'><note pitch='E4'/></event>"
+                      "</sequence>"
+                    "</measure>"
+                    "<measure number='2'>"
+                      "<sequence staff='1'>"
+                        "<event value='/4'><note pitch='C4'/></event>"
+                        "<event value='/2'><note pitch='E4'/></event>"
+                      "</sequence>"
+                    "</measure>"
+                "</part>"
+            "</cwmnx></score>"
+            "</mnx>");
+        MnxAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot =  a.analyse_tree(tree, "string:");
+
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pRoot != nullptr );
+        CHECK( pRoot->is_document() == true );
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        TypeMeasureInfo* pInfo = pInstr->get_last_measure_info();
+        CHECK( pInfo == nullptr );
+        ImoMusicData* pMD = pInstr->get_musicdata();
+        CHECK( pMD != nullptr );
+
+        CHECK( pMD->get_num_children() == 7 );
+        ImoObj::children_iterator it = pMD->begin();    //clef
+        CHECK( (*it)->is_clef() );
+        ++it;   //note c4
+        CHECK( (*it)->is_note() );
+        ++it;   //note e4
+        CHECK( (*it)->is_note() );
+        ++it;   //barline
+        CHECK( (*it)->is_barline() );
+        ImoBarline* pBarline = dynamic_cast<ImoBarline*>( *it );
+        CHECK( pBarline != nullptr );
+        CHECK( pBarline->get_type() == k_barline_simple );
+        CHECK( pBarline->is_visible() );
+        TypeMeasureInfo* pInfo1 = pBarline->get_measure_info();
+        CHECK( pInfo1 != nullptr );
+        CHECK( pInfo1->count == 1 );
+        CHECK( pInfo1->number == "1" );
+//        cout << test_name() << ": count=" << pInfo1->count
+//             << ", number=" << pInfo1->number << endl;
+
+        //measure 2
+        ++it;   //note c4
+        CHECK( (*it)->is_note() );
+        ++it;   //note e4
+        CHECK( (*it)->is_note() );
+        ++it;   //barline
+        CHECK( (*it)->is_barline() );
+        pBarline = dynamic_cast<ImoBarline*>( *it );
+        CHECK( pBarline != nullptr );
+        CHECK( pBarline->get_type() == k_barline_simple );
+        CHECK( pBarline->is_visible() );
+        TypeMeasureInfo* pInfo2 = pBarline->get_measure_info();
+        CHECK( pInfo2 != nullptr );
+        CHECK( pInfo2->count == 2 );
+        CHECK( pInfo2->number == "2" );
+//        cout << test_name() << ": count=" << pInfo2->count
+//             << ", number=" << pInfo2->number << endl;
+
+        CHECK( pInfo1 != pInfo2 );
+
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
 
 
     //@ z. miscellaneous ----------------------------------------------------------------

--- a/src/tests/lomse_test_mxl_analyser.cpp
+++ b/src/tests/lomse_test_mxl_analyser.cpp
@@ -1796,7 +1796,7 @@ SUITE(MxlAnalyserTest)
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
         ImoInstrument* pInstr = pScore->get_instrument(0);
-        ImoMeasureInfo* pInfo = pInstr->get_last_measure_info();
+        TypeMeasureInfo* pInfo = pInstr->get_last_measure_info();
         CHECK( pInfo == nullptr );
         ImoMusicData* pMD = pInstr->get_musicdata();
         CHECK( pMD != nullptr );
@@ -1814,8 +1814,8 @@ SUITE(MxlAnalyserTest)
         CHECK( pBarline->is_visible() );
         pInfo = pBarline->get_measure_info();
         CHECK( pInfo != nullptr );
-        CHECK( pInfo->get_count() == 1 );
-//        cout << test_name() << ": count=" << pInfo->get_count() << endl;
+        CHECK( pInfo->count == 1 );
+//        cout << test_name() << ": count=" << pInfo->count << endl;
 
         a.do_not_delete_instruments_in_destructor();
         if (pRoot && !pRoot->is_document()) delete pRoot;
@@ -1859,7 +1859,7 @@ SUITE(MxlAnalyserTest)
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
         ImoInstrument* pInstr = pScore->get_instrument(0);
-        ImoMeasureInfo* pInfo = pInstr->get_last_measure_info();
+        TypeMeasureInfo* pInfo = pInstr->get_last_measure_info();
         CHECK( pInfo == nullptr );
         ImoMusicData* pMD = pInstr->get_musicdata();
         CHECK( pMD != nullptr );
@@ -1875,12 +1875,12 @@ SUITE(MxlAnalyserTest)
         CHECK( pBarline != nullptr );
         CHECK( pBarline->get_type() == k_barline_simple );
         CHECK( pBarline->is_visible() );
-        ImoMeasureInfo* pInfo1 = pBarline->get_measure_info();
+        TypeMeasureInfo* pInfo1 = pBarline->get_measure_info();
         CHECK( pInfo1 != nullptr );
-        CHECK( pInfo1->get_count() == 1 );
-        CHECK( pInfo1->get_number() == "1" );
-//        cout << test_name() << ": count=" << pInfo1->get_count()
-//             << ", number=" << pInfo1->get_number() << endl;
+        CHECK( pInfo1->count == 1 );
+        CHECK( pInfo1->number == "1" );
+//        cout << test_name() << ": count=" << pInfo1->count
+//             << ", number=" << pInfo1->number << endl;
 
         //measure 2
         ++it;   //note a4
@@ -1893,12 +1893,12 @@ SUITE(MxlAnalyserTest)
         CHECK( pBarline != nullptr );
         CHECK( pBarline->get_type() == k_barline_simple );
         CHECK( pBarline->is_visible() );
-        ImoMeasureInfo* pInfo2 = pBarline->get_measure_info();
+        TypeMeasureInfo* pInfo2 = pBarline->get_measure_info();
         CHECK( pInfo2 != nullptr );
-        CHECK( pInfo2->get_count() == 2 );
-        CHECK( pInfo2->get_number() == "2" );
-//        cout << test_name() << ": count=" << pInfo2->get_count()
-//             << ", number=" << pInfo2->get_number() << endl;
+        CHECK( pInfo2->count == 2 );
+        CHECK( pInfo2->number == "2" );
+//        cout << test_name() << ": count=" << pInfo2->count
+//             << ", number=" << pInfo2->number << endl;
 
         CHECK( pInfo1 != pInfo2 );
 

--- a/src/tests/lomse_test_mxl_analyser.cpp
+++ b/src/tests/lomse_test_mxl_analyser.cpp
@@ -1762,6 +1762,151 @@ SUITE(MxlAnalyserTest)
     }
 
 
+    //@ measure -------------------------------------------------------------------------
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, measure_01)
+    {
+        //@01. MeasuresInfo in Barline but not in Instrument
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        parser.parse_text(
+            "<score-partwise version='3.0'><part-list>"
+            "<score-part id='P1'><part-name>Music</part-name></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "<note><pitch><step>A</step><octave>3</octave></pitch>"
+                "<duration>4</duration><type>16th</type></note>"
+            "<note><chord/><pitch><step>C</step><octave>4</octave></pitch>"
+                "<duration>4</duration><type>16th</type></note>"
+            "</measure>"
+            "</part></score-partwise>"
+        );
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot =  a.analyse_tree(tree, "string:");
+
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pRoot != nullptr);
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMeasureInfo* pInfo = pInstr->get_last_measure_info();
+        CHECK( pInfo == nullptr );
+        ImoMusicData* pMD = pInstr->get_musicdata();
+        CHECK( pMD != nullptr );
+
+        CHECK( pMD->get_num_children() == 3 );
+        ImoObj::children_iterator it = pMD->begin();    //note a4
+        CHECK( (*it)->is_note() );
+        ++it;   //note c3
+        CHECK( (*it)->is_note() );
+        ++it;   //barline
+        CHECK( (*it)->is_barline() );
+        ImoBarline* pBarline = dynamic_cast<ImoBarline*>( *it );
+        CHECK( pBarline != nullptr );
+        CHECK( pBarline->get_type() == k_barline_simple );
+        CHECK( pBarline->is_visible() );
+        pInfo = pBarline->get_measure_info();
+        CHECK( pInfo != nullptr );
+        CHECK( pInfo->get_count() == 1 );
+//        cout << test_name() << ": count=" << pInfo->get_count() << endl;
+
+        a.do_not_delete_instruments_in_destructor();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, measure_02)
+    {
+        //@02. Two measures
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        parser.parse_text(
+            "<score-partwise version='3.0'><part-list>"
+            "<score-part id='P1'><part-name>Music</part-name></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "<note><pitch><step>A</step><octave>3</octave></pitch>"
+                "<duration>4</duration><type>16th</type></note>"
+            "<note><chord/><pitch><step>C</step><octave>4</octave></pitch>"
+                "<duration>4</duration><type>16th</type></note>"
+            "</measure>"
+            "<measure number='2'>"
+            "<note><pitch><step>A</step><octave>3</octave></pitch>"
+                "<duration>4</duration><type>16th</type></note>"
+            "<note><chord/><pitch><step>C</step><octave>4</octave></pitch>"
+                "<duration>4</duration><type>16th</type></note>"
+            "</measure>"
+            "</part></score-partwise>"
+        );
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot =  a.analyse_tree(tree, "string:");
+
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pRoot != nullptr);
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMeasureInfo* pInfo = pInstr->get_last_measure_info();
+        CHECK( pInfo == nullptr );
+        ImoMusicData* pMD = pInstr->get_musicdata();
+        CHECK( pMD != nullptr );
+
+        CHECK( pMD->get_num_children() == 6 );
+        ImoObj::children_iterator it = pMD->begin();    //measure 1: note a4
+        CHECK( (*it)->is_note() );
+        ++it;   //note c3
+        CHECK( (*it)->is_note() );
+        ++it;   //barline
+        CHECK( (*it)->is_barline() );
+        ImoBarline* pBarline = dynamic_cast<ImoBarline*>( *it );
+        CHECK( pBarline != nullptr );
+        CHECK( pBarline->get_type() == k_barline_simple );
+        CHECK( pBarline->is_visible() );
+        ImoMeasureInfo* pInfo1 = pBarline->get_measure_info();
+        CHECK( pInfo1 != nullptr );
+        CHECK( pInfo1->get_count() == 1 );
+        CHECK( pInfo1->get_number() == "1" );
+//        cout << test_name() << ": count=" << pInfo1->get_count()
+//             << ", number=" << pInfo1->get_number() << endl;
+
+        //measure 2
+        ++it;   //note a4
+        CHECK( (*it)->is_note() );
+        ++it;   //note c3
+        CHECK( (*it)->is_note() );
+        ++it;   //barline
+        CHECK( (*it)->is_barline() );
+        pBarline = dynamic_cast<ImoBarline*>( *it );
+        CHECK( pBarline != nullptr );
+        CHECK( pBarline->get_type() == k_barline_simple );
+        CHECK( pBarline->is_visible() );
+        ImoMeasureInfo* pInfo2 = pBarline->get_measure_info();
+        CHECK( pInfo2 != nullptr );
+        CHECK( pInfo2->get_count() == 2 );
+        CHECK( pInfo2->get_number() == "2" );
+//        cout << test_name() << ": count=" << pInfo2->get_count()
+//             << ", number=" << pInfo2->get_number() << endl;
+
+        CHECK( pInfo1 != pInfo2 );
+
+        a.do_not_delete_instruments_in_destructor();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+
     //@ midi-device -----------------------------------------------------------------
 
     TEST_FIXTURE(MxlAnalyserTestFixture, midi_device_01)


### PR DESCRIPTION
Until now, the internal model didn't store information about measure attributes, such as the displayed measure number.

This PR introduces changes in the internal model for capturing attributes related to measures. All importers now parse and store this information. The API documentation has been updated.
