### PR TITLE
MusicXML: import metronome directions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ##### COMPATIBLE CHANGES
 
+- MusicXML importer now accepts metronome directions.
 - The algorithm for auto-scroll has been improved.
 - During playback, when the time signature changes, metronome clicks
   interval is now adjusted for maintaining notes duration equivalence.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Read [Contributing][] for information about how to contribute.
 ~~~~
 # download lomse repository
 cd <projects-path>
-git clone -b master --single-branch https.//github.com/lenmus/lomse.git
+git clone -b master --single-branch https://github.com/lenmus/lomse.git
 
 # create folder for building and move there
 mkdir build

--- a/include/lomse_glyphs.h
+++ b/include/lomse_glyphs.h
@@ -225,6 +225,7 @@ enum EGlyphIndex
     k_glyph_cut_time,
 
     //Metronome marks
+    k_glyph_small_longa_note,
     k_glyph_small_whole_note,
     k_glyph_small_half_note,
     k_glyph_small_quarter_note,
@@ -419,6 +420,9 @@ enum EGlyphIndex
     k_glyph_belltree,                       // Belltree
     k_glyph_table_single_handbell,          // Table single handbell
     k_glyph_table_pair_of_handbells,        // Table pair of handbells
+
+    //Electronic music pictograms (U+EB10 - U+EB5F)
+    k_glyph_error,          // stop play button
 
 };
 

--- a/include/lomse_interactor.h
+++ b/include/lomse_interactor.h
@@ -245,7 +245,7 @@ public:
             {
                 spInteractor->set_operating_mode(Interactor::k_mode_playback);
 
-                SpEventPlayCtrl pEv = boost::static_pointer_cast<EventPlayCtrl>(pEvent);
+                SpEventPlayCtrl pEv = static_pointer_cast<EventPlayCtrl>(pEvent);
                 ImoScore* pScore = pEv->get_score();
                 ScorePlayer* pPlayer  = m_appScope.get_score_player();
                 PlayerGui* pPlayerGui = pEv->get_player();

--- a/include/lomse_internal_model.h
+++ b/include/lomse_internal_model.h
@@ -118,7 +118,6 @@ class ImoSimpleObj;
 class ImoSlurDto;
 class ImoSoundInfo;
 class ImoSounds;
-class ImoSpacer;
 class ImoStaffInfo;
 class ImoStaffObj;
 class ImoStyle;
@@ -624,7 +623,6 @@ enum EImoObjType
     k_imo_note,             ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Note
     k_imo_rest,             ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Rest
     k_imo_sound_change,     ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Playback parameters
-    k_imo_spacer,           ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Spacer
     k_imo_system_break,     ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; System break
     k_imo_time_signature,   ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Time signature
     k_imo_staffobj_last,
@@ -1417,7 +1415,7 @@ public:
     inline bool is_slur_dto() { return m_objtype == k_imo_slur_dto; }
     inline bool is_sound_change() { return m_objtype == k_imo_sound_change; }
     inline bool is_sound_info() { return m_objtype == k_imo_sound_info; }
-    inline bool is_spacer() { return m_objtype == k_imo_spacer; }
+    inline bool is_spacer() { return m_objtype == k_imo_direction; }
     inline bool is_staff_info() { return m_objtype == k_imo_staff_info; }
     inline bool is_style() { return m_objtype == k_imo_style; }
     inline bool is_styles() { return m_objtype == k_imo_styles; }
@@ -4154,6 +4152,9 @@ public:
 };
 
 //---------------------------------------------------------------------------------------
+/** ImoDirection represents a discrete instruction in the score that applies to
+    notated events.
+*/
 class ImoDirection : public ImoStaffObj
 {
 protected:
@@ -4182,50 +4183,20 @@ public:
     virtual ~ImoDirection() {}
 
     //getters
-    inline Tenths get_width()
-    {
-        return m_space;
-    }
-    inline int get_placement()
-    {
-        return m_placement;
-    }
-    inline int get_display_repeat()
-    {
-        return m_displayRepeat;
-    }
-    inline int get_sound_repeat()
-    {
-        return m_soundRepeat;
-    }
+    inline Tenths get_width() { return m_space; }
+    inline int get_placement() { return m_placement; }
+    inline int get_display_repeat() { return m_displayRepeat; }
+    inline int get_sound_repeat() { return m_soundRepeat; }
 
     //setters
-    inline void set_width(Tenths space)
-    {
-        m_space = space;
-    }
-    inline void set_placement(int placement)
-    {
-        m_placement = placement;
-    }
-    inline void set_display_repeat(int repeat)
-    {
-        m_displayRepeat = repeat;
-    }
-    inline void set_sound_repeat(int repeat)
-    {
-        m_soundRepeat = repeat;
-    }
+    inline void set_width(Tenths space) { m_space = space; }
+    inline void set_placement(int placement) { m_placement = placement; }
+    inline void set_display_repeat(int repeat) { m_displayRepeat = repeat; }
+    inline void set_sound_repeat(int repeat) { m_soundRepeat = repeat; }
 
     //info
-    inline bool is_display_repeat()
-    {
-        return m_displayRepeat != k_repeat_none;
-    }
-    inline bool is_sound_repeat()
-    {
-        return m_soundRepeat != k_repeat_none;
-    }
+    inline bool is_display_repeat() { return m_displayRepeat != k_repeat_none; }
+    inline bool is_sound_repeat() { return m_soundRepeat != k_repeat_none; }
 };
 
 ////---------------------------------------------------------------------------------------
@@ -5189,7 +5160,7 @@ public:
     ImoClef* add_clef(int type, int nStaff=1, bool fVisible=true);
     ImoKeySignature* add_key_signature(int type, bool fVisible=true);
     ImoTimeSignature* add_time_signature(int top, int bottom, bool fVisible=true);
-    ImoSpacer* add_spacer(Tenths space);
+    ImoDirection* add_spacer(Tenths space);
     ImoObj* add_object(const string& ldpsource);
     void add_staff_objects(const string& ldpsource);
 
@@ -5923,32 +5894,6 @@ public:
     inline void set_height(Tenths h)
     {
         m_size.height = h;
-    }
-
-};
-
-//---------------------------------------------------------------------------------------
-class ImoSpacer : public ImoStaffObj
-{
-protected:
-    Tenths  m_space;
-
-    friend class ImFactory;
-    ImoSpacer() : ImoStaffObj(k_imo_spacer), m_space(0.0f) {}
-
-public:
-    virtual ~ImoSpacer() {}
-
-    //getters
-    inline Tenths get_width()
-    {
-        return m_space;
-    }
-
-    //setters
-    inline void set_width(Tenths space)
-    {
-        m_space = space;
     }
 
 };

--- a/include/lomse_internal_model.h
+++ b/include/lomse_internal_model.h
@@ -621,7 +621,6 @@ enum EImoObjType
     k_imo_figured_bass,     ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Figured bass mark
     k_imo_go_back_fwd,      ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; GoBackFwd
     k_imo_key_signature,    ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Key signature
-    k_imo_metronome_mark,   ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Metronome mark
     k_imo_note,             ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Note
     k_imo_rest,             ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Rest
     k_imo_sound_change,     ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Playback parameters
@@ -634,6 +633,7 @@ enum EImoObjType
     k_imo_auxobj,               ///< &nbsp;&nbsp;&nbsp;&nbsp; <b>Auxiliary object. Any of the following:</b>
     k_imo_dynamics_mark,    ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Dynamics mark
     k_imo_fermata,          ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Fermata
+    k_imo_metronome_mark,   ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Metronome mark
     k_imo_ornament,         ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Ornament
     k_imo_symbol_repetition_mark,   ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Symbol for repetition mark
     k_imo_technical,        ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Technical mark
@@ -5371,7 +5371,7 @@ protected:
 };
 
 //---------------------------------------------------------------------------------------
-class ImoMetronomeMark : public ImoStaffObj
+class ImoMetronomeMark : public ImoAuxObj
 {
 protected:
     int     m_markType;
@@ -5384,7 +5384,7 @@ protected:
 
     friend class ImFactory;
     ImoMetronomeMark()
-        : ImoStaffObj(k_imo_metronome_mark), m_markType(k_value)
+        : ImoAuxObj(k_imo_metronome_mark), m_markType(k_value)
         , m_ticksPerMinute(60), m_leftNoteType(0), m_leftDots(0)
         , m_rightNoteType(0), m_rightDots(0), m_fParenthesis(false)
     {}

--- a/include/lomse_ldp_elements.h
+++ b/include/lomse_ldp_elements.h
@@ -65,6 +65,7 @@ enum ELdpElement
     //staffobjs
     k_barline,
     k_clef,
+    k_direction,
     k_figuredBass,
     k_goBack,
     k_goFwd,

--- a/include/lomse_logger.h
+++ b/include/lomse_logger.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -141,20 +141,33 @@ public:
     void log_error(const string& file, int line, const string& prettyFunction,
                    const char* fmtstr, ...) PRINTF_SYNTAX(5);
     void log_error(const string& file, int line, const string& prettyFunction,
-                   const string& msg)
-        { log_error(file, line, prettyFunction, "%s", msg.c_str()); }
+                   const string& msg);
+
     void log_warn(const string& file, int line, const string& prettyFunction,
                   const char* fmtstr, ...) PRINTF_SYNTAX(5);
+    void log_warn(const string& file, int line, const string& prettyFunction,
+                  const string& msg);
+
     void log_info(const string& file, int line, const string& prettyFunction,
                   const char* fmtstr, ...) PRINTF_SYNTAX(5);
+    void log_info(const string& file, int line, const string& prettyFunction,
+                  const string& msg);
+
     void log_debug(const string& file, int line, const string& prettyFunction,
                    uint_least32_t area, const char* fmtstr, ...) PRINTF_SYNTAX(6);
+    void log_debug(const string& file, int line, const string& prettyFunction,
+                   uint_least32_t area, const string& msg);
+
     void log_trace(const string& file, int line, const string& prettyFunction,
                    uint_least32_t area, const char* fmtstr, ...) PRINTF_SYNTAX(6);
+    void log_trace(const string& file, int line, const string& prettyFunction,
+                   uint_least32_t area, const string& msg);
 
 protected:
     void log_message(const string& file, int line, const string& prettyFunction,
                      const string& prefix, const char* fmtstr, va_list args);
+    void log_message(const string& file, int line, const string& prettyFunction,
+                     const string& prefix, const string& msg);
     string format(const char* fmtstr, va_list args);
 };
 

--- a/include/lomse_metronome.h
+++ b/include/lomse_metronome.h
@@ -30,13 +30,16 @@
 #ifndef __LOMSE_METRONOME_H__        //to avoid nested includes
 #define __LOMSE_METRONOME_H__
 
+#include "lomse_document.h"         //EBeatDuration
+#include "lomse_internal_model.h"   //ENoteDuration
 
 
 namespace lomse
 {
 
 //---------------------------------------------------------------------------------------
-// Abstract class defining the interface for any Metronome
+/** Abstract class defining the interface for any Metronome
+*/
 class Metronome
 {
 protected:
@@ -44,10 +47,15 @@ protected:
     long        m_nInterval;    //metronome period: milliseconds between beats
     bool        m_fMuted;       //metronome sound is muted
     bool        m_fRunning;     //true if start() invoked
+    int         m_beatType;
+    TimeUnits   m_beatDuration;
+
 
     Metronome(long nMM)
         : m_fMuted(false)
         , m_fRunning(false)
+        , m_beatType(k_beat_implied)
+        , m_beatDuration(k_duration_quarter)
     {
         set_mm(nMM);
     }
@@ -67,11 +75,21 @@ public:
         m_nMM = (long)((60000.0 / (float)milliseconds)+ 0.5);;
     }
 
+    //setting beat type
+    inline void set_beat_type(int type, TimeUnits duration=0.0)
+    {
+        m_beatType = type;
+        m_beatDuration = duration;
+    }
+
+
     // accessors
     inline long get_mm() { return m_nMM; }
     inline long get_interval() { return m_nInterval; }
     inline bool is_muted() { return m_fMuted; }
     inline bool is_running() { return m_fRunning; }
+    inline int get_beat_type() { return m_beatType; }
+    inline TimeUnits get_beat_duration() { return m_beatDuration; }
 
     // commands
     virtual void start() = 0;

--- a/include/lomse_score_utilities.h
+++ b/include/lomse_score_utilities.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -91,6 +91,11 @@ class ImoTimeSignature;
     //returns the step (0..6, 0=Do, 1=Re, 3=Mi, ... , 6=Si) for the root note in
     //the Key signature. For example, if keyType is A sharp minor it returns 5 (step A)
     int get_step_for_root_note(EKeySignature keyType);
+
+    //-----------------------------------------------------------------------------------
+    //returns the step (0..6, 0=Do, 1=Re, 3=Mi, ... , 6=Si) for the leading note in
+    //the Key signature. For example, if keyType is A sharp minor it returns 4 (step G)
+    int get_step_for_leading_note(EKeySignature keyType);
 
     //-----------------------------------------------------------------------------------
     extern bool is_major_key(EKeySignature keyType);

--- a/include/lomse_staffobjs_table.h
+++ b/include/lomse_staffobjs_table.h
@@ -48,7 +48,7 @@ class ImoObj;
 class ImoStaffObj;
 class ImoGoBackFwd;
 class ImoAuxObj;
-class ImoSpacer;
+class ImoDirection;
 class ImoScore;
 class ImoTimeSignature;
 class ImoGoBackFwd;
@@ -356,7 +356,7 @@ private:
     void update_measure(ImoStaffObj* pSO);
     void update_time_counter(ImoGoBackFwd* pGBF);
     void add_entry_for_staffobj(ImoObj* pImo, int nInstr);
-    ImoSpacer* anchor_object(ImoAuxObj* pImo);
+    ImoDirection* anchor_object(ImoAuxObj* pImo);
     void delete_node(ImoGoBackFwd* pGBF, ImoMusicData* pMusicData);
     void prepare_for_next_instrument();
 

--- a/src/exporters/lomse_ldp_exporter.cpp
+++ b/src/exporters/lomse_ldp_exporter.cpp
@@ -1719,7 +1719,7 @@ public:
         start_element("metronome", m_pImo->get_id());
         add_marks();
         add_parenthesis();
-        source_for_staffobj_options(m_pImo);
+        //source_for_auxobj_options(m_pImo);    //TODO
         end_element(k_in_same_line);
         return m_source.str();
     }

--- a/src/exporters/lomse_lmd_exporter.cpp
+++ b/src/exporters/lomse_lmd_exporter.cpp
@@ -1515,12 +1515,12 @@ protected:
 class SpacerLmdGenerator : public LmdGenerator
 {
 protected:
-    ImoSpacer* m_pObj;
+    ImoDirection* m_pObj;
 
 public:
     SpacerLmdGenerator(ImoObj* pImo, LmdExporter* pExporter) : LmdGenerator(pExporter)
     {
-        m_pObj = static_cast<ImoSpacer*>(pImo);
+        m_pObj = static_cast<ImoDirection*>(pImo);
     }
 
     string generate_source()
@@ -1921,7 +1921,7 @@ LmdGenerator* LmdExporter::new_generator(ImoObj* pImo)
         case k_imo_para:            return LOMSE_NEW ParagraphLmdGenerator(pImo, this);
         case k_imo_rest:            return LOMSE_NEW RestLmdGenerator(pImo, this);
         case k_imo_score:           return LOMSE_NEW ScoreLmdGenerator(pImo, this);
-        case k_imo_spacer:          return LOMSE_NEW SpacerLmdGenerator(pImo, this);
+        case k_imo_direction:          return LOMSE_NEW SpacerLmdGenerator(pImo, this);
         case k_imo_style:           return LOMSE_NEW DefineStyleLmdGenerator(pImo, this);
         case k_imo_styles:          return LOMSE_NEW StylesLmdGenerator(pImo, this);
         default:

--- a/src/exporters/lomse_mnx_exporter.cpp
+++ b/src/exporters/lomse_mnx_exporter.cpp
@@ -1302,12 +1302,12 @@ protected:
 class SpacerMnxGenerator : public MnxGenerator
 {
 protected:
-    ImoSpacer* m_pObj;
+    ImoDirection* m_pObj;
 
 public:
     SpacerMnxGenerator(ImoObj* pImo, MnxExporter* pExporter) : MnxGenerator(pExporter)
     {
-        m_pObj = static_cast<ImoSpacer*>(pImo);
+        m_pObj = static_cast<ImoDirection*>(pImo);
     }
 
     string generate_source()
@@ -1714,7 +1714,7 @@ MnxGenerator* MnxExporter::new_generator(ImoObj* pImo)
         case k_imo_note:            return LOMSE_NEW NoteMnxGenerator(pImo, this);
         case k_imo_rest:            return LOMSE_NEW RestMnxGenerator(pImo, this);
         case k_imo_score:           return LOMSE_NEW ScoreMnxGenerator(pImo, this);
-        case k_imo_spacer:          return LOMSE_NEW SpacerMnxGenerator(pImo, this);
+        case k_imo_direction:          return LOMSE_NEW SpacerMnxGenerator(pImo, this);
         case k_imo_style:           return LOMSE_NEW DefineStyleMnxGenerator(pImo, this);
         case k_imo_styles:          return LOMSE_NEW StylesMnxGenerator(pImo, this);
         default:

--- a/src/graphic_model/engravers/lomse_engrouters.cpp
+++ b/src/graphic_model/engravers/lomse_engrouters.cpp
@@ -82,7 +82,7 @@ Engrouter* EngroutersCreator::create_next_engrouter(LUnits maxSpace, bool fFirst
         return nullptr;
     }
 
-    LOMSE_LOG_DEBUG(Logger::k_layout, "");
+    LOMSE_LOG_DEBUG(Logger::k_layout, string(""));
     Engrouter* pEngr = nullptr;
     if (!is_there_a_pending_engrouter())
     {

--- a/src/graphic_model/engravers/lomse_metronome_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_metronome_engraver.cpp
@@ -188,6 +188,8 @@ int MetronomeMarkEngraver::select_glyph(int noteType)
 {
     switch (noteType)
 	{
+        case k_longa:
+            return k_glyph_small_longa_note;
         case k_whole:
             return k_glyph_small_whole_note;
         case k_half:
@@ -208,10 +210,9 @@ int MetronomeMarkEngraver::select_glyph(int noteType)
             return k_glyph_small_256th_note;
         default:
         {
-            stringstream msg;
-            msg << "[MetronomeMarkEngraver::select_glyph] invalid note type " << noteType;
-            LOMSE_LOG_ERROR(msg.str());
-            throw runtime_error(msg.str());
+            LOMSE_LOG_ERROR(
+                "[MetronomeMarkEngraver::select_glyph] invalid note type %d", noteType);
+            return k_glyph_error;
         }
     }
 }

--- a/src/graphic_model/layouters/lomse_blocks_container_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_blocks_container_layouter.cpp
@@ -57,7 +57,7 @@ ContentLayouter::ContentLayouter(ImoContentObj* pItem, Layouter* pParent,
 //---------------------------------------------------------------------------------------
 void ContentLayouter::layout_in_box()
 {
-    LOMSE_LOG_DEBUG(Logger::k_layout, "");
+    LOMSE_LOG_DEBUG(Logger::k_layout, string(""));
 
     set_cursor_and_available_space();
 
@@ -105,7 +105,7 @@ MultiColumnLayouter::~MultiColumnLayouter()
 //---------------------------------------------------------------------------------------
 void MultiColumnLayouter::layout_in_box()
 {
-    LOMSE_LOG_DEBUG(Logger::k_layout, "");
+    LOMSE_LOG_DEBUG(Logger::k_layout, string(""));
 
     set_cursor_and_available_space();
 
@@ -240,7 +240,7 @@ BlocksContainerLayouter::BlocksContainerLayouter(ImoContentObj* pImo, Layouter* 
 //---------------------------------------------------------------------------------------
 void BlocksContainerLayouter::layout_in_box()
 {
-    LOMSE_LOG_DEBUG(Logger::k_layout, "");
+    LOMSE_LOG_DEBUG(Logger::k_layout, string(""));
 
     set_cursor_and_available_space();
 

--- a/src/graphic_model/layouters/lomse_inlines_container_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_inlines_container_layouter.cpp
@@ -94,7 +94,7 @@ void InlinesContainerLayouter::get_indent_and_bullet_info()
 //---------------------------------------------------------------------------------------
 void InlinesContainerLayouter::layout_in_box()
 {
-    LOMSE_LOG_DEBUG(Logger::k_layout, "");
+    LOMSE_LOG_DEBUG(Logger::k_layout, string(""));
 
     //AWARE: This method is invoked to layout a page. If there are more pages to
     //layout, it will be invoked more times. Therefore, this method must not initialize
@@ -131,7 +131,7 @@ void InlinesContainerLayouter::layout_in_box()
 //---------------------------------------------------------------------------------------
 void InlinesContainerLayouter::prepare_line()
 {
-    LOMSE_LOG_DEBUG(Logger::k_layout, "");
+    LOMSE_LOG_DEBUG(Logger::k_layout, string(""));
 
     set_line_pos_and_width();
     initialize_line_references();
@@ -245,7 +245,7 @@ void InlinesContainerLayouter::set_line_pos_and_width()
 //---------------------------------------------------------------------------------------
 void InlinesContainerLayouter::add_line()
 {
-    LOMSE_LOG_DEBUG(Logger::k_layout, "");
+    LOMSE_LOG_DEBUG(Logger::k_layout, string(""));
 
     m_pageCursor.x = m_xLineStart;
     LUnits left = m_pageCursor.x;       //save left margin
@@ -285,7 +285,7 @@ void InlinesContainerLayouter::add_line()
 //---------------------------------------------------------------------------------------
 void InlinesContainerLayouter::advance_current_line_space(LUnits left)
 {
-    LOMSE_LOG_DEBUG(Logger::k_layout, "");
+    LOMSE_LOG_DEBUG(Logger::k_layout, string(""));
 
     m_pageCursor.x = left;
     m_pageCursor.y += m_lineRefs.lineHeight;
@@ -297,7 +297,7 @@ void InlinesContainerLayouter::advance_current_line_space(LUnits left)
 //---------------------------------------------------------------------------------------
 void InlinesContainerLayouter::add_engrouter_to_line(Engrouter* pEngrouter)
 {
-    LOMSE_LOG_DEBUG(Logger::k_layout, "");
+    LOMSE_LOG_DEBUG(Logger::k_layout, string(""));
 
     //add engrouter to the list of engrouters for current line.
     m_engrouters.push_back( pEngrouter );

--- a/src/graphic_model/layouters/lomse_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_layouter.cpp
@@ -74,7 +74,7 @@ Layouter::Layouter(LibraryScope& libraryScope)
 //---------------------------------------------------------------------------------------
 GmoBox* Layouter::start_new_page()
 {
-    LOMSE_LOG_DEBUG(Logger::k_layout, "");
+    LOMSE_LOG_DEBUG(Logger::k_layout, string(""));
 
     GmoBox* pParentBox = m_pParentLayouter->start_new_page();
 

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -1057,13 +1057,6 @@ GmoShape* ShapesCreator::create_staffobj_shape(ImoStaffObj* pSO, int iInstr, int
             //TODO
             return create_invisible_shape(pSO, iInstr, iStaff, pos, 0.0f);
         }
-        case k_imo_metronome_mark:
-        {
-            ImoMetronomeMark* pImo = static_cast<ImoMetronomeMark*>(pSO);
-            MetronomeMarkEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr, iStaff);
-            Color color = pImo->get_color();
-            return engrv.create_shape(pImo, pos, color);
-        }
         case k_imo_sound_change:
         default:
             return create_invisible_shape(pSO, iInstr, iStaff, pos, 0.0f);
@@ -1103,6 +1096,13 @@ GmoShape* ShapesCreator::create_auxobj_shape(ImoAuxObj* pAO, int iInstr, int iSt
             FermataEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr, iStaff);
             Color color = pImo->get_color();
             return engrv.create_shape(pImo, pos, color, pParentShape);
+        }
+        case k_imo_metronome_mark:
+        {
+            ImoMetronomeMark* pImo = static_cast<ImoMetronomeMark*>(pAO);
+            MetronomeMarkEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr, iStaff);
+            Color color = pImo->get_color();
+            return engrv.create_shape(pImo, pos, color);
         }
         case k_imo_ornament:
         {

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -134,7 +134,7 @@ void ScoreLayouter::prepare_to_start_layout()
 //---------------------------------------------------------------------------------------
 void ScoreLayouter::layout_in_box()
 {
-    LOMSE_LOG_DEBUG(Logger::k_layout, "");
+    LOMSE_LOG_DEBUG(Logger::k_layout, string(""));
 
     //AWARE: This method is invoked to layout a page. If there are more pages to
     //layout, it will be invoked more times. Therefore, this method must not initialize

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -1045,17 +1045,12 @@ GmoShape* ShapesCreator::create_staffobj_shape(ImoStaffObj* pSO, int iInstr, int
             Color color = pImo->get_color();
             return engrv.create_shape(pImo, pos, color);
         }
-        case k_imo_spacer:
+        case k_imo_direction:
         {
-            ImoSpacer* pImo = static_cast<ImoSpacer*>(pSO);
+            ImoDirection* pImo = static_cast<ImoDirection*>(pSO);
             LUnits space = m_pScoreMeter->tenths_to_logical(pImo->get_width(),
                                                             iInstr, iStaff);
             return create_invisible_shape(pSO, iInstr, iStaff, pos, space);
-        }
-        case k_imo_direction:
-        {
-            //TODO
-            return create_invisible_shape(pSO, iInstr, iStaff, pos, 0.0f);
         }
         case k_imo_sound_change:
         default:

--- a/src/graphic_model/layouters/lomse_spacing_algorithm_gourlay.cpp
+++ b/src/graphic_model/layouters/lomse_spacing_algorithm_gourlay.cpp
@@ -158,7 +158,6 @@ void SpAlgGourlay::include_object(ColStaffObjsEntry* pCurEntry, int iCol, int UN
             case k_imo_clef:
             case k_imo_key_signature:
             case k_imo_time_signature:
-            case k_imo_spacer:
             case k_imo_direction:
             case k_imo_metronome_mark:
             case k_imo_go_back_fwd:

--- a/src/graphic_model/layouters/lomse_table_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_table_layouter.cpp
@@ -93,7 +93,7 @@ void TableLayouter::create_sections_layouters()
 //---------------------------------------------------------------------------------------
 void TableLayouter::layout_in_box()
 {
-    LOMSE_LOG_DEBUG(Logger::k_layout, "");
+    LOMSE_LOG_DEBUG(Logger::k_layout, string(""));
 
     //AWARE: This method is invoked to layout a page. If there are more pages to
     //layout, it will be invoked more times. Therefore, this method must not initialize
@@ -311,7 +311,7 @@ void TableSectionLayouter::prepare_to_start_layout()
 //---------------------------------------------------------------------------------------
 void TableSectionLayouter::layout_in_box()
 {
-    LOMSE_LOG_DEBUG(Logger::k_layout, "");
+    LOMSE_LOG_DEBUG(Logger::k_layout, string(""));
 }
 
 //---------------------------------------------------------------------------------------
@@ -319,7 +319,7 @@ void TableSectionLayouter::create_main_box(GmoBox* UNUSED(pParentBox),
                                            UPoint UNUSED(pos), LUnits UNUSED(width),
                                            LUnits UNUSED(height))
 {
-    LOMSE_LOG_DEBUG(Logger::k_layout, "");
+    LOMSE_LOG_DEBUG(Logger::k_layout, string(""));
 }
 
 //---------------------------------------------------------------------------------------
@@ -530,7 +530,7 @@ TableRowLayouter::~TableRowLayouter()
 //---------------------------------------------------------------------------------------
 void TableRowLayouter::layout_in_box()
 {
-    LOMSE_LOG_DEBUG(Logger::k_layout, "");
+    LOMSE_LOG_DEBUG(Logger::k_layout, string(""));
 
     set_cursor_and_available_space();
     LUnits yPos = m_pageCursor.y;

--- a/src/graphic_model/lomse_glyphs.cpp
+++ b/src/graphic_model/lomse_glyphs.cpp
@@ -200,6 +200,7 @@ const GlyphData m_glyphs_smufl[] =
     GlyphData(0xE08B),  // CUT_TIME
 
 //Metronome marks (U+ECA0 - U+ECBF)
+    GlyphData(0xECA0),  // small longa note
     GlyphData(0xECA2),  // small whole note
     GlyphData(0xECA3),  // small half note up
     GlyphData(0xECA5),  // small quarter note up
@@ -396,6 +397,8 @@ const GlyphData m_glyphs_smufl[] =
     GlyphData(0xE820),  // Table single handbell
     GlyphData(0xE821),  // Table pair of handbells
 
+//Electronic music pictograms (U+EB10 - U+EB5F)
+    GlyphData(0xEB1D),  // stop button, used for errors
 };
 
 

--- a/src/internal_model/lomse_im_factory.cpp
+++ b/src/internal_model/lomse_im_factory.cpp
@@ -113,7 +113,6 @@ ImoObj* ImFactory::inject(int type, Document* pDoc, ImoId id)
         case k_imo_sound_change:        pObj = LOMSE_NEW ImoSoundChange();        break;
         case k_imo_sound_info:          pObj = LOMSE_NEW ImoSoundInfo();          break;
         case k_imo_sounds:              pObj = LOMSE_NEW ImoSounds();             break;
-        case k_imo_spacer:              pObj = LOMSE_NEW ImoSpacer();             break;
         case k_imo_staff_info:          pObj = LOMSE_NEW ImoStaffInfo();          break;
         case k_imo_style:               pObj = LOMSE_NEW ImoStyle();              break;
         case k_imo_styles:              pObj = LOMSE_NEW ImoStyles(pDoc);         break;

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -438,16 +438,14 @@ const string& ImoObj::get_name(int type)
         // ImoStaffObj (A)
         m_TypeToName[k_imo_barline] = "barline";
         m_TypeToName[k_imo_clef] = "clef";
+        m_TypeToName[k_imo_direction] = "direction";
+        m_TypeToName[k_imo_figured_bass] = "figured-bass";
+        m_TypeToName[k_imo_go_back_fwd] = "go-back-fwd";
         m_TypeToName[k_imo_key_signature] = "key-signature";
-        m_TypeToName[k_imo_time_signature] = "time-signature";
         m_TypeToName[k_imo_note] = "note";
         m_TypeToName[k_imo_rest] = "rest";
-        m_TypeToName[k_imo_go_back_fwd] = "go-back-fwd";
-        m_TypeToName[k_imo_metronome_mark] = "metronome-mark";
         m_TypeToName[k_imo_system_break] = "system-break";
-        m_TypeToName[k_imo_spacer] = "spacer";
-        m_TypeToName[k_imo_figured_bass] = "figured-bass";
-        m_TypeToName[k_imo_direction] = "direction";
+        m_TypeToName[k_imo_time_signature] = "time-signature";
 
         // ImoBlocksContainer (A)
         m_TypeToName[k_imo_content] = "content";
@@ -467,21 +465,20 @@ const string& ImoObj::get_name(int type)
         m_TypeToName[k_imo_para] = "paragraph";
 
         // ImoInlineLevelObj
+        m_TypeToName[k_imo_button] = "buttom";
+        m_TypeToName[k_imo_control] = "control";
         m_TypeToName[k_imo_image] = "image";
         m_TypeToName[k_imo_score_player] = "score-player";
-        m_TypeToName[k_imo_control] = "control";
-        m_TypeToName[k_imo_button] = "buttom";
         m_TypeToName[k_imo_text_item] = "text";
 
         // ImoBoxInline (A)
-        m_TypeToName[k_imo_inline_wrapper] = "wrapper";
         m_TypeToName[k_imo_link] = "link";
+        m_TypeToName[k_imo_inline_wrapper] = "wrapper";
 
         // ImoDto, ImoSimpleObj (A)
         m_TypeToName[k_imo_beam_dto] = "beam";
         m_TypeToName[k_imo_bezier_info] = "bezier";
         m_TypeToName[k_imo_border_dto] = "border";
-        m_TypeToName[k_imo_textblock_info] = "textblock";
         m_TypeToName[k_imo_color_dto] = "color";
         m_TypeToName[k_imo_cursor_info] = "cursor";
         m_TypeToName[k_imo_figured_bass_info] = "figured-bass";
@@ -501,6 +498,7 @@ const string& ImoObj::get_name(int type)
         m_TypeToName[k_imo_staff_info] = "staff-info";
         m_TypeToName[k_imo_style] = "style";
         m_TypeToName[k_imo_system_info] = "system-info";
+        m_TypeToName[k_imo_textblock_info] = "textblock";
         m_TypeToName[k_imo_text_info] = "text-info";
         m_TypeToName[k_imo_text_style] = "text-style";
         m_TypeToName[k_imo_tie_dto] = "tie-dto";
@@ -536,6 +534,7 @@ const string& ImoObj::get_name(int type)
         m_TypeToName[k_imo_dynamics_mark] = "dynamics-mark";
         m_TypeToName[k_imo_fermata] = "fermata";
         m_TypeToName[k_imo_line] = "line";
+        m_TypeToName[k_imo_metronome_mark] = "metronome-mark";
         m_TypeToName[k_imo_ornament] = "ornament";
         m_TypeToName[k_imo_score_text] = "score-text";
         m_TypeToName[k_imo_score_line] = "score-line";
@@ -2589,10 +2588,11 @@ ImoKeySignature* ImoInstrument::add_key_signature(int type, bool fVisible)
 }
 
 //---------------------------------------------------------------------------------------
-ImoSpacer* ImoInstrument::add_spacer(Tenths space)
+ImoDirection* ImoInstrument::add_spacer(Tenths space)
 {
     ImoMusicData* pMD = get_musicdata();
-    ImoSpacer* pImo = static_cast<ImoSpacer*>( ImFactory::inject(k_imo_spacer, m_pDoc) );
+    ImoDirection* pImo =
+            static_cast<ImoDirection*>( ImFactory::inject(k_imo_direction, m_pDoc) );
     pImo->set_width(space);
     pMD->append_child_imo(pImo);
     return pImo;

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -1964,7 +1964,9 @@ void ImoContentObj::add_attachment(Document* pDoc, ImoAuxObj* pAO)
 ImoAuxObj* ImoContentObj::get_attachment(int i)
 {
     ImoAttachments* pAuxObjs = get_attachments();
-    return static_cast<ImoAuxObj*>( pAuxObjs->get_item(i) );
+    if (pAuxObjs)
+        return static_cast<ImoAuxObj*>( pAuxObjs->get_item(i) );
+    return nullptr;
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/internal_model/lomse_score_utilities.cpp
+++ b/src/internal_model/lomse_score_utilities.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -305,6 +305,13 @@ int get_step_for_root_note(EKeySignature keyType)
             throw runtime_error(ss.str());
         }
     }
+}
+
+//---------------------------------------------------------------------------------------
+int get_step_for_leading_note(EKeySignature keyType)
+{
+    int nRoot = get_step_for_root_note(keyType);
+    return (nRoot == 0 ? 6 : nRoot-1);      //scale degree seven
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/internal_model/lomse_staffobjs_table.cpp
+++ b/src/internal_model/lomse_staffobjs_table.cpp
@@ -191,7 +191,7 @@ bool ColStaffObjs::is_lower_entry(ColStaffObjsEntry* b, ColStaffObjsEntry* a)
         if ((pA->is_direction() || pA->is_sound_change())
             && (pB->is_clef() || pB->is_time_signature() || pB->is_key_signature()))
         {
-            return (a->line() != b->line());    //move clef/key/time before 'A' object
+            return true;    //(a->line() != b->line());    //move clef/key/time before 'A' object
         }
 
 ////        //clef in other staff can not go after key or time signature
@@ -538,10 +538,11 @@ void ColStaffObjsBuilderEngine1x::update_time_counter(ImoGoBackFwd* pGBF)
 }
 
 //---------------------------------------------------------------------------------------
-ImoSpacer* ColStaffObjsBuilderEngine1x::anchor_object(ImoAuxObj* pAux)
+ImoDirection* ColStaffObjsBuilderEngine1x::anchor_object(ImoAuxObj* pAux)
 {
     Document* pDoc = m_pImScore->get_the_document();
-    ImoSpacer* pAnchor = static_cast<ImoSpacer*>(ImFactory::inject(k_imo_spacer, pDoc));
+    ImoDirection* pAnchor =
+            static_cast<ImoDirection*>(ImFactory::inject(k_imo_direction, pDoc));
     pAnchor->add_attachment(pDoc, pAux);
     return pAnchor;
 }

--- a/src/module/lomse_injectors.cpp
+++ b/src/module/lomse_injectors.cpp
@@ -198,7 +198,7 @@ int LibraryScope::get_pixel_format() const
 //---------------------------------------------------------------------------------------
 void LibraryScope::post_event(SpEventInfo pEvent)
 {
-    LOMSE_LOG_DEBUG(Logger::k_events, "");
+    LOMSE_LOG_DEBUG(Logger::k_events, string(""));
     m_pDoorway->post_event(pEvent);
 }
 

--- a/src/module/lomse_logger.cpp
+++ b/src/module/lomse_logger.cpp
@@ -60,6 +60,13 @@ Logger::~Logger()
 void Logger::log_message(const string& file, int line, const string& prettyFunction,
                          const string& prefix, const char* fmtstr, va_list args)
 {
+    log_message(file, line, prettyFunction, prefix, format(fmtstr, args));
+}
+
+//---------------------------------------------------------------------------------------
+void Logger::log_message(const string& file, int line, const string& prettyFunction,
+                         const string& prefix, const string& msg)
+{
     size_t end = prettyFunction.rfind("(");
     size_t begin = prettyFunction.substr(0,end).rfind(" ") + 1;
     end -= begin;
@@ -67,8 +74,6 @@ void Logger::log_message(const string& file, int line, const string& prettyFunct
     size_t fileStartLinux = file.rfind("/") + 1;
     size_t fileStartWindows = file.rfind("\\") + 1;
     size_t fileStart = max(fileStartLinux, fileStartWindows);
-
-    string msg = format(fmtstr, args);
 
     dbgLogger << file.substr(fileStart) << ", line " << line << ". " << prefix << "["
             << prettyFunction.substr(begin,end) << "] " << msg << endl;
@@ -85,6 +90,13 @@ void Logger::log_error(const string& file, int line, const string& prettyFunctio
 }
 
 //---------------------------------------------------------------------------------------
+void Logger::log_error(const string& file, int line, const string& prettyFunction,
+                       const string& msg)
+{
+    log_message(file, line, prettyFunction, "ERROR: ", msg);
+}
+
+//---------------------------------------------------------------------------------------
 void Logger::log_warn(const string& file, int line, const string& prettyFunction,
                       const char* fmtstr, ...)
 {
@@ -95,6 +107,13 @@ void Logger::log_warn(const string& file, int line, const string& prettyFunction
 }
 
 //---------------------------------------------------------------------------------------
+void Logger::log_warn(const string& file, int line, const string& prettyFunction,
+                      const string& msg)
+{
+    log_message(file, line, prettyFunction, "WARNING: ", msg);
+}
+
+//---------------------------------------------------------------------------------------
 void Logger::log_info(const string& file, int line, const string& prettyFunction,
                       const char* fmtstr, ...)
 {
@@ -102,6 +121,13 @@ void Logger::log_info(const string& file, int line, const string& prettyFunction
     va_start(args, fmtstr);
     log_message(file, line, prettyFunction, "INFO: ", fmtstr, args);
     va_end(args);
+}
+
+//---------------------------------------------------------------------------------------
+void Logger::log_info(const string& file, int line, const string& prettyFunction,
+                      const string& msg)
+{
+    log_message(file, line, prettyFunction, "INFO: ", msg);
 }
 
 //---------------------------------------------------------------------------------------
@@ -118,6 +144,16 @@ void Logger::log_debug(const string& file, int line, const string& prettyFunctio
 }
 
 //---------------------------------------------------------------------------------------
+void Logger::log_debug(const string& file, int line, const string& prettyFunction,
+                       uint_least32_t area, const string& msg)
+{
+    if ((m_mode == k_debug_mode || m_mode == k_trace_mode) && ((m_areas & area) != 0))
+    {
+        log_message(file, line, prettyFunction, "DEBUG: ", msg);
+    }
+}
+
+//---------------------------------------------------------------------------------------
 void Logger::log_trace(const string& file, int line, const string& prettyFunction,
                        uint_least32_t area, const char* fmtstr, ...)
 {
@@ -127,6 +163,16 @@ void Logger::log_trace(const string& file, int line, const string& prettyFunctio
         va_start(args, fmtstr);
         log_message(file, line, prettyFunction, "TRACE: ", fmtstr, args);
         va_end(args);
+    }
+}
+
+//---------------------------------------------------------------------------------------
+void Logger::log_trace(const string& file, int line, const string& prettyFunction,
+                       uint_least32_t area, const string& msg)
+{
+    if (m_mode == k_trace_mode && ((m_areas & area) != 0))
+    {
+        log_message(file, line, prettyFunction, "TRACE: ", msg);
     }
 }
 

--- a/src/module/lomse_pitch.cpp
+++ b/src/module/lomse_pitch.cpp
@@ -201,7 +201,7 @@ EAccidentals FPitch::accidentals()
 //---------------------------------------------------------------------------------------
 string FPitch::to_abs_ldp_name()
 {
-    // The absolute LDP none name is returned
+    // The absolute LDP note name is returned
     // If note is invalid (more than two accidentals) returns empty string
 
     string sAnswer;
@@ -665,7 +665,7 @@ string DiatonicPitch::get_ldp_name()
         return m_sNoteName[step()] + m_sOctave[octave()];
     else
     {
-        LOMSE_LOG_ERROR("Operation on non-valid DiatonicPitch");
+        LOMSE_LOG_ERROR("Operation on non-valid DiatonicPitch %d", m_dp);
         return "*";
         //throw runtime_error("Operation on non-valid DiatonicPitch");
     }

--- a/src/mvc/lomse_graphic_view.cpp
+++ b/src/mvc/lomse_graphic_view.cpp
@@ -250,14 +250,14 @@ void GraphicView::add_handler(int iHandler, GmoObj* pOwnerGmo)
 //---------------------------------------------------------------------------------------
 void GraphicView::new_viewport(Pixels x, Pixels y)
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
     do_change_viewport(x, y);
 }
 
 //---------------------------------------------------------------------------------------
 void GraphicView::do_change_viewport(Pixels x, Pixels y)
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
     std::lock_guard<std::mutex> lock(m_viewportMutex);
 
     m_vxOrg = x;
@@ -314,7 +314,7 @@ void GraphicView::do_move_tempo_line_and_change_viewport(ImoId scoreId, TimeUnit
 //---------------------------------------------------------------------------------------
 bool GraphicView::determine_page_system_and_position_for(ImoId scoreId, TimeUnits timepos)
 {
-    LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_score_player, "");
+    LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_score_player, string(""));
 
     //returns true if no errors
     //updates variables m_iScrollPage, m_pScrollSystem and m_xScrollLeft;
@@ -477,7 +477,7 @@ void GraphicView::do_change_viewport()
 //---------------------------------------------------------------------------------------
 void GraphicView::change_viewport_to(ImoId scoreId, TimeUnits timepos)
 {
-    LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_score_player, "");
+    LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_score_player, string(""));
 
     determine_scroll_position_for(scoreId, timepos);
     do_change_viewport();
@@ -486,7 +486,7 @@ void GraphicView::change_viewport_to(ImoId scoreId, TimeUnits timepos)
 //---------------------------------------------------------------------------------------
 void GraphicView::determine_scroll_position_for(ImoId scoreId, TimeUnits timepos)
 {
-    LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_score_player, "");
+    LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_score_player, string(""));
 
     if (!determine_page_system_and_position_for(scoreId, timepos))
         return;
@@ -557,7 +557,7 @@ void GraphicView::do_determine_new_scroll_position()
 //---------------------------------------------------------------------------------------
 void GraphicView::redraw_bitmap() //, RepaintOptions& opt)
 {
-    LOMSE_LOG_DEBUG(Logger::k_render, "");
+    LOMSE_LOG_DEBUG(Logger::k_render, string(""));
 
     draw_all();
 }
@@ -631,7 +631,7 @@ void GraphicView::draw_all()
 {
     if (m_pRenderBuf)
     {
-        LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+        LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
         //render graphical model
         m_pInteractor->timing_start_measurements();
@@ -649,7 +649,7 @@ void GraphicView::draw_all()
 //---------------------------------------------------------------------------------------
 void GraphicView::draw_caret()
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     m_pInteractor->timing_start_measurements();
     layout_caret();
@@ -662,7 +662,7 @@ void GraphicView::draw_caret()
 //---------------------------------------------------------------------------------------
 void GraphicView::draw_time_grid()
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     m_pInteractor->timing_start_measurements();
     layout_time_grid();
@@ -736,7 +736,7 @@ void GraphicView::print_page(int page, VPoint viewport)
 //---------------------------------------------------------------------------------------
 void GraphicView::draw_graphic_model()
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     m_options.background_color = m_backgroundColor;
     m_options.page_border_flag = true;
@@ -758,7 +758,7 @@ void GraphicView::draw_graphic_model()
 //---------------------------------------------------------------------------------------
 void GraphicView::draw_all_visual_effects()
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     layout_caret();
     layout_time_grid();
@@ -769,7 +769,7 @@ void GraphicView::draw_all_visual_effects()
 //---------------------------------------------------------------------------------------
 void GraphicView::draw_selection_rectangle()
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     m_pInteractor->timing_start_measurements();
     m_pOverlaysGenerator->update_visual_effect(m_pSelRect, m_pDrawer);
@@ -779,7 +779,7 @@ void GraphicView::draw_selection_rectangle()
 //---------------------------------------------------------------------------------------
 void GraphicView::draw_visual_tracking()
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     m_pInteractor->timing_start_measurements();
     if (m_trackingEffect & k_tracking_highlight_notes)
@@ -792,7 +792,7 @@ void GraphicView::draw_visual_tracking()
 //---------------------------------------------------------------------------------------
 void GraphicView::draw_dragged_image()
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     m_pInteractor->timing_start_measurements();
     m_pOverlaysGenerator->update_visual_effect(m_pDragImg, m_pDrawer);
@@ -802,7 +802,7 @@ void GraphicView::draw_dragged_image()
 //---------------------------------------------------------------------------------------
 void GraphicView::draw_handler(Handler* pHandler)
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     m_pInteractor->timing_start_measurements();
     m_pOverlaysGenerator->update_visual_effect(pHandler, m_pDrawer);
@@ -812,7 +812,7 @@ void GraphicView::draw_handler(Handler* pHandler)
 //---------------------------------------------------------------------------------------
 void GraphicView::draw_selected_objects()
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     m_pInteractor->timing_start_measurements();
     layout_selection_highlight();
@@ -935,7 +935,7 @@ void GraphicView::update_selection_rectangle(LUnits x2, LUnits y2)
 //---------------------------------------------------------------------------------------
 void GraphicView::zoom_in(Pixels x, Pixels y)
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     double rx(x);
     double ry(y);
@@ -955,7 +955,7 @@ void GraphicView::zoom_in(Pixels x, Pixels y)
 //---------------------------------------------------------------------------------------
 void GraphicView::zoom_out(Pixels x, Pixels y)
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     double rx(x);
     double ry(y);

--- a/src/mvc/lomse_interactor.cpp
+++ b/src/mvc/lomse_interactor.cpp
@@ -153,7 +153,7 @@ void Interactor::create_graphic_model()
     //of the requirements. The Interactor is the owner of the View.
 
 
-    LOMSE_LOG_DEBUG(Logger::k_render, "");
+    LOMSE_LOG_DEBUG(Logger::k_render, string(""));
 
     if (SpDocument spDoc = m_wpDoc.lock())
     {
@@ -268,7 +268,7 @@ void Interactor::delete_graphic_model()
 //---------------------------------------------------------------------------------------
 void Interactor::on_mouse_button_down(Pixels x, Pixels y, unsigned flags)
 {
-    LOMSE_LOG_DEBUG(Logger::k_events, "");
+    LOMSE_LOG_DEBUG(Logger::k_events, string(""));
     m_pTask->process_event( Event((flags & k_mouse_left ? Event::k_mouse_left_down
                                                         : Event::k_mouse_right_down),
                                   x, y, flags) );
@@ -277,7 +277,7 @@ void Interactor::on_mouse_button_down(Pixels x, Pixels y, unsigned flags)
 //---------------------------------------------------------------------------------------
 void Interactor::on_mouse_move(Pixels x, Pixels y, unsigned flags)
 {
-    LOMSE_LOG_TRACE(Logger::k_events, "");
+    LOMSE_LOG_TRACE(Logger::k_events, string(""));
     m_pTask->process_event( Event(Event::k_mouse_move, x, y, flags) );
 }
 
@@ -332,7 +332,7 @@ bool Interactor::is_in_selection(GmoObj* pGmo)
 void Interactor::task_action_select_object_and_show_contextual_menu(
                                                     Pixels x, Pixels y, unsigned flags)
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     if (SpDocument spDoc = m_wpDoc.lock())
     {
@@ -366,7 +366,7 @@ void Interactor::task_action_select_object_and_show_contextual_menu(
 //---------------------------------------------------------------------------------------
 void Interactor::task_action_click_at_screen_point(Pixels x, Pixels y, unsigned flags)
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     //mouse left click when in selection mode
 
@@ -531,7 +531,7 @@ void Interactor::task_action_mouse_in_out(Pixels x, Pixels y,
 ////---------------------------------------------------------------------------------------
 //void Interactor::task_action_start_move_drag(Pixels x, Pixels y, bool fLeftButton)
 //{
-//    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+//    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 //
 //    // Edition mode: mouse click down at point (x, y). Decide what to do.
 //
@@ -604,7 +604,7 @@ void Interactor::task_action_mouse_in_out(Pixels x, Pixels y,
 //---------------------------------------------------------------------------------------
 void Interactor::task_action_move_drag_image(Pixels x, Pixels y)
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     GraphicView* pGView = dynamic_cast<GraphicView*>(m_pView);
     if (pGView)
@@ -618,7 +618,7 @@ void Interactor::task_action_move_drag_image(Pixels x, Pixels y)
 //---------------------------------------------------------------------------------------
 void Interactor::task_action_insert_object_at_point(Pixels x, Pixels y, unsigned flags)
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     //invoked only from TaskDataEntry: mouse left click when in data entry mode
 
@@ -769,7 +769,7 @@ void Interactor::task_action_select_objects_in_screen_rectangle(Pixels x1, Pixel
                                                                 Pixels x2, Pixels y2,
                                                                 unsigned flags)
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     //invoked only from TaskSelection
 
@@ -801,7 +801,7 @@ void Interactor::task_action_select_objects_in_screen_rectangle(Pixels x1, Pixel
 void Interactor::task_action_decide_on_switching_task(Pixels x, Pixels y,
                                                       unsigned UNUSED(flags))
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     // Edition mode: mouse left click at point (x, y). Decide what to do.
 
@@ -869,7 +869,7 @@ void Interactor::task_action_move_object(Pixels UNUSED(x), Pixels UNUSED(y))
 //---------------------------------------------------------------------------------------
 void Interactor::task_action_move_handler(Pixels x, Pixels y)
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     UPoint pos = screen_point_to_model_point(x, y);
     m_pCurHandler->move_to(pos);
@@ -886,7 +886,7 @@ void Interactor::task_action_move_handler(Pixels x, Pixels y)
 void Interactor::task_action_move_handler_end_point(Pixels xFinal, Pixels yFinal,
                                                     Pixels xTotalShift, Pixels yTotalShift)
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     task_action_move_handler(xFinal, yFinal);
 
@@ -920,7 +920,7 @@ void Interactor::task_action_move_handler_end_point(Pixels xFinal, Pixels yFinal
 //---------------------------------------------------------------------------------------
 void Interactor::task_action_drag_the_view(Pixels x, Pixels y)
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     new_viewport(x, y);
 }
@@ -943,7 +943,7 @@ void Interactor::restore_selection()
 //---------------------------------------------------------------------------------------
 void Interactor::redraw_bitmap()
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     if (SpDocument spDoc = m_wpDoc.lock())
     {
@@ -960,7 +960,7 @@ void Interactor::redraw_bitmap()
 //---------------------------------------------------------------------------------------
 void Interactor::request_window_update()
 {
-    LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_mvc, string(""));
 
     SpInteractor sp = get_shared_ptr_from_this();
     WpInteractor wpIntor(sp);
@@ -987,7 +987,7 @@ void Interactor::force_redraw()
 //---------------------------------------------------------------------------------------
 void Interactor::do_force_redraw()
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     redraw_bitmap();
     request_window_update();
@@ -996,7 +996,7 @@ void Interactor::do_force_redraw()
 //---------------------------------------------------------------------------------------
 void Interactor::new_viewport(Pixels x, Pixels y, bool fForceRedraw)
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     m_fViewParamsChanged = true;
     GraphicView* pGView = dynamic_cast<GraphicView*>(m_pView);
@@ -1046,7 +1046,7 @@ void Interactor::request_viewport_change(Pixels x, Pixels y)
 {
     //AWARE: This code is executed in the sound thread
 
-    LOMSE_LOG_DEBUG(lomse::Logger::k_events | lomse::Logger::k_score_player, "");
+    LOMSE_LOG_DEBUG(lomse::Logger::k_events | lomse::Logger::k_score_player, string(""));
 
     SpInteractor sp = get_shared_ptr_from_this();
     WpInteractor wpIntor(sp);
@@ -1301,7 +1301,7 @@ void Interactor::remove_highlight_from_object(ImoStaffObj* pSO)
 //---------------------------------------------------------------------------------------
 void Interactor::change_viewport_if_necessary(ImoId id)
 {
-    LOMSE_LOG_DEBUG(lomse::Logger::k_events | lomse::Logger::k_score_player, "");
+    LOMSE_LOG_DEBUG(lomse::Logger::k_events | lomse::Logger::k_score_player, string(""));
     GraphicView* pGView = dynamic_cast<GraphicView*>(m_pView);
     if (pGView)
         pGView->change_viewport_if_necessary(id);
@@ -1345,7 +1345,7 @@ int Interactor::page_at_screen_point(double x, double y)
 //---------------------------------------------------------------------------------------
 void Interactor::zoom_in(Pixels x, Pixels y, bool fForceRedraw)
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     m_fViewParamsChanged = true;
     GraphicView* pGView = dynamic_cast<GraphicView*>(m_pView);
@@ -1360,7 +1360,7 @@ void Interactor::zoom_in(Pixels x, Pixels y, bool fForceRedraw)
 //---------------------------------------------------------------------------------------
 void Interactor::zoom_out(Pixels x, Pixels y, bool fForceRedraw)
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, "");
+    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
 
     m_fViewParamsChanged = true;
     GraphicView* pGView = dynamic_cast<GraphicView*>(m_pView);
@@ -1619,7 +1619,7 @@ void Interactor::on_end_of_play_event(ImoScore* pScore, PlayerGui* pPlayCtrl)
     //avoid raising questions on users about the contradiction of having to invoke
     // "send_end_of_play_event" when an end of play event is received!!
 
-    LOMSE_LOG_DEBUG(Logger::k_events, "");
+    LOMSE_LOG_DEBUG(Logger::k_events, string(""));
 
     if (SpDocument spDoc = m_wpDoc.lock())
     {

--- a/src/parser/ldp/lomse_ldp_analyser.cpp
+++ b/src/parser/ldp/lomse_ldp_analyser.cpp
@@ -3499,14 +3499,13 @@ protected:
 //@--------------------------------------------------------------------------------------
 //@ <metronome> = (metronome { <NoteType><TicksPerMinute> | <NoteType><NoteType> |
 //@                            <TicksPerMinute> }
-//@                          [parenthesis][<staffObjOptions>*] )
+//@                          [parenthesis]<printOptions>* )
 //@
 //@ examples:
 //@    (metronome q 80)                -->  quarter_note_sign = 80
 //@    (metronome q q.)                -->  quarter_note_sign = dotted_quarter_note_sign
 //@    (metronome 80)                  -->  m.m. = 80
 //@    (metronome q 80 parenthesis)    -->  (quarter_note_sign = 80)
-//@    (metronome 120 noVisible)       -->  nothing displayed
 
 class MetronomeAnalyser : public ElementAnalyser
 {
@@ -3577,8 +3576,8 @@ public:
                 error_invalid_param();
         }
 
-        // [<staffObjOptions>*]
-        analyse_scoreobj_options(pMtr);       //TODO: Needed?
+        // <printOptions>*
+        analyse_scoreobj_options(pMtr);
 
         error_if_more_elements();
 
@@ -3587,13 +3586,17 @@ public:
 };
 
 //@--------------------------------------------------------------------------------------
-//@ <musicData> = (musicData [{<note>|<rest>|<barline>|<chord>|<clef>|<figuredBass>|
-//@                            <graphic>|<key>|<line>|<metronome>|<newSystem>|<spacer>|
-//@                            <text>|<time>|<goFwd>|<goBack>}*] )
+//@ <musicData> = (musicData [{<note>|<rest>|<barline>|<chord>|<clef>|<direction>|
+//@                            <figuredBass>|<key>|<metronome>|<newSystem>|<spacer>|
+//@                            <time>|<goFwd>|<goBack>|<graphic>|<line>|<text>}*] )
 //@
 //@ <graphic>, <line> and <text> elements are accepted for compatibility with 1.5.
 //@ From 1.6 these elements will no longer be possible. They must go attached to an
 //@ spacer or other staffobj
+//@
+//@ <metronome> element is accepted for backwards compatibility with 2.0. But in
+//@ future <metronome> element will not be possible here. It must go attached to a
+//@ <direction> element.
 
 
 class MusicDataAnalyser : public ElementAnalyser
@@ -4949,7 +4952,7 @@ protected:
 };
 
 //@--------------------------------------------------------------------------------------
-//@ ImoSpacer StaffObj
+//@ ImoDirection StaffObj
 //@ <spacer> = (spacer <width> <staffobjOptions>* <soAttachments>*)
 //@
 //@ width in Tenths
@@ -4964,8 +4967,8 @@ public:
     void do_analysis()
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
-        ImoSpacer* pSpacer = static_cast<ImoSpacer*>(
-                    ImFactory::inject(k_imo_spacer, pDoc, get_node_id()) );
+        ImoDirection* pSpacer = static_cast<ImoDirection*>(
+                    ImFactory::inject(k_imo_direction, pDoc, get_node_id()) );
 
         // <width>
         if (get_optional(k_number))
@@ -7012,10 +7015,10 @@ ElementAnalyser* LdpAnalyser::new_analyser(ELdpElement type, ImoObj* pAnchor)
         case k_color:           return LOMSE_NEW ColorAnalyser(this, m_reporter, m_libraryScope);
         case k_cursor:          return LOMSE_NEW CursorAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_defineStyle:     return LOMSE_NEW DefineStyleAnalyser(this, m_reporter, m_libraryScope, pAnchor);
-        case k_endPoint:        return LOMSE_NEW PointAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_direction:       return LOMSE_NEW DirectionAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_dynamic:         return LOMSE_NEW DynamicAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_dynamics_mark:   return LOMSE_NEW DynamicsAnalyser(this, m_reporter, m_libraryScope, pAnchor);
+        case k_endPoint:        return LOMSE_NEW PointAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_fermata:         return LOMSE_NEW FermataAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_figuredBass:     return LOMSE_NEW FiguredBassAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_font:            return LOMSE_NEW FontAnalyser(this, m_reporter, m_libraryScope, pAnchor);

--- a/src/parser/lmd/lomse_lmd_analyser.cpp
+++ b/src/parser/lmd/lomse_lmd_analyser.cpp
@@ -4349,7 +4349,7 @@ protected:
 };
 
 //@--------------------------------------------------------------------------------------
-//@ ImoSpacer StaffObj
+//@ ImoDirection StaffObj
 //@ <spacer> = (spacer <width>[<staffobjOptions>*][<attachments>*])     width in Tenths
 
 class SpacerLmdAnalyser : public LmdElementAnalyser
@@ -4362,8 +4362,8 @@ public:
     ImoObj* do_analysis()
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
-        ImoSpacer* pSpacer = static_cast<ImoSpacer*>(
-                                    ImFactory::inject(k_imo_spacer, pDoc) );
+        ImoDirection* pSpacer = static_cast<ImoDirection*>(
+                                    ImFactory::inject(k_imo_direction, pDoc) );
 
         // <width>
         if (get_optional(k_number))

--- a/src/parser/lomse_ldp_factory.cpp
+++ b/src/parser/lomse_ldp_factory.cpp
@@ -103,6 +103,7 @@ LdpFactory::LdpFactory()
     m_TypeToName[k_defineStyle] = "defineStyle";
     m_TypeToName[k_doit] = "doit";
     m_TypeToName[k_down] = "down";
+    m_TypeToName[k_direction] = "dir";
     m_TypeToName[k_displayBracket] = "displayBracket";
     m_TypeToName[k_displayNumber] = "displayNumber";
     m_TypeToName[k_duration] = "duration";
@@ -307,11 +308,12 @@ LdpFactory::LdpFactory()
     m_NameToFunctor["ctrol2-y"] = LOMSE_NEW LdpElementFunctor<k_ctrol2_y>;
     m_NameToFunctor["cursor"] = LOMSE_NEW LdpElementFunctor<k_cursor>;
     m_NameToFunctor["defineStyle"] = LOMSE_NEW LdpElementFunctor<k_defineStyle>;
+    m_NameToFunctor["dir"] = LOMSE_NEW LdpElementFunctor<k_direction>;
+    m_NameToFunctor["displayBracket"] = LOMSE_NEW LdpElementFunctor<k_displayBracket>;
+    m_NameToFunctor["displayNumber"] = LOMSE_NEW LdpElementFunctor<k_displayNumber>;
     m_NameToFunctor["doit"] = LOMSE_NEW LdpElementFunctor<k_doit>;
     m_NameToFunctor["down"] = LOMSE_NEW LdpElementFunctor<k_down>;
     m_NameToFunctor["duration"] = LOMSE_NEW LdpElementFunctor<k_duration>;
-    m_NameToFunctor["displayBracket"] = LOMSE_NEW LdpElementFunctor<k_displayBracket>;
-    m_NameToFunctor["displayNumber"] = LOMSE_NEW LdpElementFunctor<k_displayNumber>;
     m_NameToFunctor["dx"] = LOMSE_NEW LdpElementFunctor<k_dx>;
     m_NameToFunctor["dy"] = LOMSE_NEW LdpElementFunctor<k_dy>;
     m_NameToFunctor["dyn"] = LOMSE_NEW LdpElementFunctor<k_dynamics_mark>;

--- a/src/parser/lomse_linker.cpp
+++ b/src/parser/lomse_linker.cpp
@@ -386,9 +386,9 @@ ImoObj* Linker::add_text(ImoScoreText* pText)
         //in musicData; they must go attached to an spacer.
         if (m_pParent->is_music_data())
         {
-            //musicData: create anchor (ImoSpacer) and attach to it
-            ImoSpacer* pSpacer = static_cast<ImoSpacer*>(
-                                        ImFactory::inject(k_imo_spacer, m_pDoc) );
+            //musicData: create anchor (ImoDirection) and attach to it
+            ImoDirection* pSpacer = static_cast<ImoDirection*>(
+                                        ImFactory::inject(k_imo_direction, m_pDoc) );
             pSpacer->add_attachment(m_pDoc, pText);
             add_staffobj(pSpacer);
             return pText;
@@ -547,9 +547,9 @@ ImoObj* Linker::add_attachment(ImoAuxObj* pAuxObj)
         //be explicitly defined in LDP source.
         else if (m_pParent && m_pParent->is_music_data())
         {
-            //auxObj in musicData: create anchor (ImoSpacer) and attach to it
-            ImoSpacer* pSpacer = static_cast<ImoSpacer*>(
-                                        ImFactory::inject(k_imo_spacer, m_pDoc) );
+            //auxObj in musicData: create anchor (ImoDirection) and attach to it
+            ImoDirection* pSpacer = static_cast<ImoDirection*>(
+                                        ImFactory::inject(k_imo_direction, m_pDoc) );
             pSpacer->add_attachment(m_pDoc, pAuxObj);
             add_staffobj(pSpacer);
         }

--- a/src/parser/lomse_linker.cpp
+++ b/src/parser/lomse_linker.cpp
@@ -525,31 +525,51 @@ ImoObj* Linker::add_staffobj(ImoStaffObj* pSO)
 //---------------------------------------------------------------------------------------
 ImoObj* Linker::add_attachment(ImoAuxObj* pAuxObj)
 {
-    if (m_pParent && m_pParent->is_contentobj())
+    if (m_pParent && m_pParent->is_staffobj())
     {
-        ImoContentObj* pContentObj = static_cast<ImoContentObj*>(m_pParent);
-        pContentObj->add_attachment(m_pDoc, pAuxObj);
+        ImoStaffObj* pSO = static_cast<ImoStaffObj*>(m_pParent);
+        pSO->add_attachment(m_pDoc, pAuxObj);
     }
-#if LOMSE_COMPATIBILITY_LDP_1_5
-    //backwards compatibility with 1.5
-    //Until v.1.5 included, it was ok to include AuxObj in a musicData element, and
-    //the parser will create an anchor object for it. Since v1.6 the anchor object *must*
-    //be explicitly defined in LDP source.
     else if (m_pParent && m_pParent->is_music_data())
     {
-        if (pAuxObj->is_score_line())
+        if (pAuxObj->is_metronome_mark())
+        {
+            //metronome mark in musicData: create anchor (ImoDirection) and attach to it
+            ImoDirection* pDirection = static_cast<ImoDirection*>(
+                                            ImFactory::inject(k_imo_direction, m_pDoc) );
+            pDirection->add_attachment(m_pDoc, pAuxObj);
+            add_staffobj(pDirection);
+        }
+        #if LOMSE_COMPATIBILITY_LDP_1_5
+        //backwards compatibility with 1.5
+        //Until v.1.5 included, it was ok to include AuxObj in a musicData element, and
+        //the parser will create an anchor object for it. Since v1.6 the anchor object *must*
+        //be explicitly defined in LDP source.
+        else if (m_pParent && m_pParent->is_music_data())
         {
             //auxObj in musicData: create anchor (ImoSpacer) and attach to it
             ImoSpacer* pSpacer = static_cast<ImoSpacer*>(
                                         ImFactory::inject(k_imo_spacer, m_pDoc) );
             pSpacer->add_attachment(m_pDoc, pAuxObj);
             add_staffobj(pSpacer);
-            return nullptr;
         }
+        #endif  //LOMSE_COMPATIBILITY_LDP_1_5
         else
-            return pAuxObj;
+        {
+            LOMSE_LOG_ERROR("Invalid child for MusicData: %s",
+                            pAuxObj->get_name().c_str());
+        }
     }
-#endif  //LOMSE_COMPATIBILITY_LDP_1_5
+    else
+    {
+        if (m_pParent)
+            LOMSE_LOG_ERROR("Invalid parent %s for object %s",
+                            m_pParent->get_name().c_str(),
+                            pAuxObj->get_name().c_str());
+        else
+            LOMSE_LOG_ERROR("No parent (nullptr) for object %s",
+                            pAuxObj->get_name().c_str());
+    }
 
     return pAuxObj;
 }

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -3553,10 +3553,7 @@ public:
 
     ImoObj* do_analysis()
     {
-        ImoDirection* pDirection = nullptr;
-        if (m_pAnchor && m_pAnchor->is_direction())
-            pDirection = static_cast<ImoDirection*>(m_pAnchor);
-        else
+        if (m_pAnchor == nullptr || !m_pAnchor->is_direction())
         {
             LOMSE_LOG_ERROR("pAnchor is nullptr or it is not ImoDirection");
             error_msg("<direction-type> <measure> is not child of <direction>. Ignored.");
@@ -3623,7 +3620,6 @@ public:
             //TODO: examples needed, for understanding and unit tests
         }
 
-        //pDirection->add_attachment(pDoc, pMtr);
         add_to_model(pMtr);
         return pMtr;
     }

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -1051,6 +1051,51 @@ protected:
 //        return size;
 //    }
 
+    //-----------------------------------------------------------------------------------
+    // Auxiliary methods
+    //-----------------------------------------------------------------------------------
+
+    int to_note_type(const string& type)
+    {
+        int noteType = k_unknown_notetype;
+
+        if (type == "quarter")
+            noteType = k_quarter;
+        else if (type == "eighth")
+            noteType = k_eighth;
+        else if (type == "16th")
+            noteType = k_16th;
+        else if (type == "half")
+            noteType = k_half;
+        else if (type == "32nd")
+            noteType = k_32nd;
+        else if (type == "64th")
+            noteType = k_64th;
+        else if (type == "whole")
+            noteType = k_whole;
+        else if (type == "long")
+            noteType = k_longa;
+        else if (type == "128th")
+            noteType = k_128th;
+        else if (type == "256th")
+            noteType = k_256th;
+        else if (type == "breve")
+            noteType = k_breve;
+//        else if (type == "512th")
+//            noteType = k_512th;
+//        else if (type == "1024th")
+//            noteType = k_1024th;
+//        else if (type == "maxima")
+//            noteType = k_maxima;
+        else
+        {
+            error_msg2(
+                "Invalid or not supported <type> value '" + type + "'. Replaced by 'eighth'.");
+            noteType = k_eighth;
+        }
+        return noteType;
+    }
+
 };
 
 
@@ -3485,6 +3530,20 @@ protected:
 
 //@--------------------------------------------------------------------------------------
 //@ <metronome>
+//@ <!ELEMENT metronome
+//@ 	((beat-unit, beat-unit-dot*,
+//@      (per-minute | (beat-unit, beat-unit-dot*))) |
+//@ 	(metronome-note+, (metronome-relation, metronome-note+)?))>
+//@ <!ATTLIST metronome
+//@     %print-style;
+//@     parentheses %yes-no; #IMPLIED
+//@ >
+//@ <!ELEMENT beat-unit (#PCDATA)>
+//@ <!ELEMENT beat-unit-dot EMPTY>
+//@ <!ELEMENT per-minute (#PCDATA)>
+//@ <!ATTLIST per-minute
+//@     %font;
+//@ >
 class MetronomeMxlAnalyser : public MxlElementAnalyser
 {
 public:
@@ -3494,9 +3553,89 @@ public:
 
     ImoObj* do_analysis()
     {
-		//TODO
-        return nullptr;
+        ImoDirection* pDirection = nullptr;
+        if (m_pAnchor && m_pAnchor->is_direction())
+            pDirection = static_cast<ImoDirection*>(m_pAnchor);
+        else
+        {
+            LOMSE_LOG_ERROR("pAnchor is nullptr or it is not ImoDirection");
+            error_msg("<direction-type> <measure> is not child of <direction>. Ignored.");
+            return nullptr;
+        }
+
+        Document* pDoc = m_pAnalyser->get_document_being_analysed();
+        ImoMetronomeMark* pMtr = static_cast<ImoMetronomeMark*>(
+                    ImFactory::inject(k_imo_metronome_mark, pDoc) );
+
+        //attrb: %print-style;
+            //TODO
+
+        //attrb: parentheses %yes-no; #IMPLIED
+            //TODO
+
+
+        //elements
+
+        if (get_optional("beat-unit"))
+        {
+            // (beat-unit, beat-unit-dot*, (per-minute | (beat-unit, beat-unit-dot*))
+
+            int noteType = get_beat_unit();
+            pMtr->set_left_note_type(noteType);
+
+            int dots = 0;
+            while (get_optional("beat-unit-dot"))
+                ++dots;
+            pMtr->set_left_dots(dots);
+
+            if (get_optional("per-minute"))
+            {
+                // case 1: (beat-unit, beat-unit-dot*) = per-minute
+                pMtr->set_ticks_per_minute( get_child_value_integer(60) );
+                pMtr->set_mark_type(ImoMetronomeMark::k_note_value);
+            }
+            else if (get_optional("beat-unit"))
+            {
+                // case 2: (beat-unit, beat-unit-dot*) = (beat-unit, beat-unit-dot*)
+                int noteType = get_beat_unit();
+                pMtr->set_right_note_type(noteType);
+
+                int dots = 0;
+                while (get_optional("beat-unit-dot"))
+                    ++dots;
+                pMtr->set_right_dots(dots);
+                pMtr->set_mark_type(ImoMetronomeMark::k_note_note);
+            }
+            else
+            {
+                error_msg2(
+                        "Error in metronome parameters. Replaced by '(metronome 60)'.");
+                pMtr->set_ticks_per_minute(60);
+                pMtr->set_mark_type(ImoMetronomeMark::k_value);
+                add_to_model(pMtr);
+                return pMtr;
+            }
+        }
+        else if (get_optional("metronome-note"))
+        {
+            // (metronome-note+, (metronome-relation, metronome-note+)?)
+
+            //TODO: examples needed, for understanding and unit tests
+        }
+
+        //pDirection->add_attachment(pDoc, pMtr);
+        add_to_model(pMtr);
+        return pMtr;
     }
+
+protected:
+
+    int get_beat_unit()
+    {
+        return to_note_type( m_childToAnalyse.value() );
+    }
+
+
 };
 
 //@--------------------------------------------------------------------------------------
@@ -4042,7 +4181,7 @@ protected:
         int noteType = k_unknown_notetype;
         TimeUnits units = m_pAnalyser->duration_to_timepos(duration);
         if (!type.empty())
-            noteType = get_note_type(type);
+            noteType = to_note_type(type);
         else if (pNR->is_rest() && static_cast<ImoRest*>(pNR)->is_full_measure())
         {
             dots = 0;
@@ -4076,49 +4215,6 @@ protected:
         }
 
         pNR->set_type_dots_duration(noteType, dots, units);
-    }
-
-    //----------------------------------------------------------------------------------
-    int get_note_type(const string& type)
-    {
-        int noteType = k_unknown_notetype;
-
-        if (type == "quarter")
-            noteType = k_quarter;
-        else if (type == "eighth")
-            noteType = k_eighth;
-        else if (type == "16th")
-            noteType = k_16th;
-        else if (type == "half")
-            noteType = k_half;
-        else if (type == "32nd")
-            noteType = k_32nd;
-        else if (type == "64th")
-            noteType = k_64th;
-        else if (type == "whole")
-            noteType = k_whole;
-        else if (type == "long")
-            noteType = k_longa;
-        else if (type == "128th")
-            noteType = k_128th;
-        else if (type == "256th")
-            noteType = k_256th;
-        else if (type == "breve")
-            noteType = k_breve;
-//        else if (type == "512th")
-//            noteType = k_512th;
-//        else if (type == "1024th")
-//            noteType = k_1024th;
-//        else if (type == "maxima")
-//            noteType = k_maxima;
-        else
-        {
-            //report_msg(m_pAnalyser->get_line_number(&m_analysedNode),
-            error_msg2(
-                "Invalid or not supported <type> value '" + type + "'. Replaced by 'eighth'.");
-            noteType = k_eighth;
-        }
-        return noteType;
     }
 
     //----------------------------------------------------------------------------------
@@ -7285,7 +7381,7 @@ MxlElementAnalyser* MxlAnalyser::new_analyser(const string& name, ImoObj* pAncho
         case k_mxl_tag_key:                  return LOMSE_NEW KeyMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_mxl_tag_lyric:                return LOMSE_NEW LyricMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_mxl_tag_measure:              return LOMSE_NEW MeasureMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
-//        case k_mxl_tag_metronome:            return LOMSE_NEW MetronomeMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
+        case k_mxl_tag_metronome:            return LOMSE_NEW MetronomeMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_mxl_tag_midi_device:          return LOMSE_NEW MidiDeviceMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_mxl_tag_midi_instrument:      return LOMSE_NEW MidiInstrumentMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_mxl_tag_notations:            return LOMSE_NEW NotationsMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);

--- a/src/sound/lomse_score_player.cpp
+++ b/src/sound/lomse_score_player.cpp
@@ -341,6 +341,9 @@ void ScorePlayer::do_play(int nEvStart, int nEvEnd, bool fVisualTracking,
     Document* pDoc = m_pScore->get_the_document();
     m_beatDuration = pDoc->get_beat_duration();
     m_beatType = pDoc->get_beat_type();
+    LOMSE_LOG_DEBUG(Logger::k_score_player,
+                    "beat: m_beatType=%d, m_beatDuration=%f",
+                    m_beatType, m_beatDuration);
 
     //default beat and metronome information. It is going to be properly set
     //when a SoundEvent::k_RhythmChange event is found (a time signature object). So these

--- a/src/tests/lomse_test_ldp_analyser.cpp
+++ b/src/tests/lomse_test_ldp_analyser.cpp
@@ -3943,9 +3943,9 @@ SUITE(LdpAnalyserTest)
 
     //@ metronome -----------------------------------------------------------------------
 
-    TEST_FIXTURE(LdpAnalyserTestFixture, metronome_0)
+    TEST_FIXTURE(LdpAnalyserTestFixture, metronome_00)
     {
-        //@00. metronome, note value
+        //@00. metronome, note = value
 
         stringstream errormsg;
         Document doc(m_libraryScope);
@@ -3967,13 +3967,381 @@ SUITE(LdpAnalyserTest)
         CHECK( pMusic != nullptr );
         ImoObj::children_iterator it = pMusic->begin();
 
-        ImoMetronomeMark* pImo = static_cast<ImoMetronomeMark*>(*it);
+        ImoDirection* pDir = static_cast<ImoDirection*>(*it);
+        ImoMetronomeMark* pImo = static_cast<ImoMetronomeMark*>(pDir->get_attachment(0));
+
         CHECK( pImo->get_ticks_per_minute() == 55 );
         CHECK( pImo->get_mark_type() == ImoMetronomeMark::k_note_value );
 
         delete tree->get_root();
         if (pRoot && !pRoot->is_document()) delete pRoot;
     }
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, metronome_01)
+    {
+        //@01. metronome, just value
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+        stringstream expected;
+        //expected << "" << endl;
+        parser.parse_text("(metronome 88)");
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+        //cout << "[" << errormsg.str() << "]" << endl;
+        //cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pRoot);
+        CHECK( pMM != nullptr );
+        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
+        CHECK( pMM->get_ticks_per_minute() == 88 );
+        CHECK( pMM->is_visible() == true );
+        CHECK( pMM->has_parenthesis() == false );
+
+        delete tree->get_root();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, metronome_02)
+    {
+        //@02. metronome has id
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+        stringstream expected;
+        //expected << "" << endl;
+        parser.parse_text("(metronome#10 88)");
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pRoot);
+        CHECK( pMM->get_id() == 10L );
+
+        delete tree->get_root();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Metronome_Error)
+    {
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+        stringstream expected;
+        expected << "Line 0. Missing metronome parameters. Replaced by '(metronome 60)'." << endl;
+        parser.parse_text("(metronome)");
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+        //cout << "[" << errormsg.str() << "]" << endl;
+        //cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pRoot);
+        CHECK( pMM != nullptr );
+        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
+        CHECK( pMM->get_ticks_per_minute() == 60 );
+        CHECK( pMM->is_visible() == true );
+        CHECK( pMM->has_parenthesis() == false );
+
+        delete tree->get_root();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Metronome_NoteValue)
+    {
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+        stringstream expected;
+        //expected << "" << endl;
+        parser.parse_text("(metronome e. 77)");
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+        //cout << "[" << errormsg.str() << "]" << endl;
+        //cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pRoot);
+        CHECK( pMM != nullptr );
+        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_note_value );
+        CHECK( pMM->get_ticks_per_minute() == 77 );
+        CHECK( pMM->get_left_note_type() == k_eighth );
+        CHECK( pMM->get_left_dots() == 1 );
+        CHECK( pMM->is_visible() == true );
+        CHECK( pMM->has_parenthesis() == false );
+
+        delete tree->get_root();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Metronome_NoteNote)
+    {
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+        stringstream expected;
+        //expected << "" << endl;
+        parser.parse_text("(metronome e. s)");
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+        //cout << "[" << errormsg.str() << "]" << endl;
+        //cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pRoot);
+        CHECK( pMM != nullptr );
+        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_note_note );
+        CHECK( pMM->get_left_note_type() == k_eighth );
+        CHECK( pMM->get_left_dots() == 1 );
+        CHECK( pMM->get_right_note_type() == k_16th );
+        CHECK( pMM->get_right_dots() == 0 );
+        CHECK( pMM->is_visible() == true );
+        CHECK( pMM->has_parenthesis() == false );
+
+        delete tree->get_root();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Metronome_Error2)
+    {
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+        stringstream expected;
+        expected << "Line 0. Error in metronome parameters. Replaced by '(metronome 60)'." << endl;
+        parser.parse_text("(metronome e. \"s\")");
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+        //cout << "[" << errormsg.str() << "]" << endl;
+        //cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pRoot);
+        CHECK( pMM != nullptr );
+        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
+        CHECK( pMM->get_ticks_per_minute() == 60 );
+        CHECK( pMM->is_visible() == true );
+        CHECK( pMM->has_parenthesis() == false );
+
+        delete tree->get_root();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Metronome_LocationX)
+    {
+        Document doc(m_libraryScope);
+        LdpParser parser(cout, m_libraryScope.ldp_factory());
+        parser.parse_text("(metronome 88 (dx 70))");
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(cout, m_libraryScope, &doc);
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+        ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pRoot);
+        CHECK( pMM != nullptr );
+        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
+        CHECK( pMM->get_ticks_per_minute() == 88 );
+        CHECK( pMM->is_visible() );
+        CHECK( pMM->get_user_location_x() == 70.0f );
+        CHECK( pMM->get_user_location_y() == 0.0f );
+        CHECK( pMM->is_visible() == true );
+        CHECK( pMM->has_parenthesis() == false );
+
+        delete tree->get_root();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Metronome_NoVisible)
+    {
+        Document doc(m_libraryScope);
+        LdpParser parser(cout, m_libraryScope.ldp_factory());
+        parser.parse_text("(metronome 88 noVisible)");
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(cout, m_libraryScope, &doc);
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+        ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pRoot);
+        CHECK( pMM != nullptr );
+        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
+        CHECK( pMM->get_ticks_per_minute() == 88 );
+        CHECK( pMM->get_user_location_x() == 0.0f );
+        CHECK( pMM->get_user_location_y() == 0.0f );
+        CHECK( pMM->is_visible() == false );
+        CHECK( pMM->has_parenthesis() == false );
+
+        delete tree->get_root();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Metronome_Parenthesis)
+    {
+        Document doc(m_libraryScope);
+        LdpParser parser(cout, m_libraryScope.ldp_factory());
+        parser.parse_text("(metronome 88 parenthesis (visible no))");
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(cout, m_libraryScope, &doc);
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+        ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pRoot);
+        CHECK( pMM != nullptr );
+        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
+        CHECK( pMM->get_ticks_per_minute() == 88 );
+        CHECK( pMM->get_user_location_x() == 0.0f );
+        CHECK( pMM->get_user_location_y() == 0.0f );
+        CHECK( pMM->is_visible() == false );
+        CHECK( pMM->has_parenthesis() == true );
+
+        delete tree->get_root();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Metronome_Ordering)
+    {
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+        stringstream expected;
+        //expected << "Line 0. ?" << endl;
+        parser.parse_text("(metronome 88 parenthesis (dx 7) noVisible)");
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+        //cout << "[" << errormsg.str() << "]" << endl;
+        //cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pRoot);
+        CHECK( pMM != nullptr );
+        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
+        CHECK( pMM->get_ticks_per_minute() == 88 );
+        CHECK( pMM->is_visible() == false );
+        CHECK( pMM->has_parenthesis() == true );
+        CHECK( pMM->get_user_location_x() == 7.0f );
+        CHECK( pMM->get_user_location_y() == 0.0f );
+
+        delete tree->get_root();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Metronome_Error3)
+    {
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+        stringstream expected;
+        expected << "Line 0. Element 'label:parentesis' unknown or not possible here. Ignored." << endl;
+        parser.parse_text("(metronome 88 parentesis (dx 7))");
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+
+        ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pRoot);
+        CHECK( pMM != nullptr );
+        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
+        CHECK( pMM->get_ticks_per_minute() == 88 );
+        CHECK( pMM->is_visible() == true );
+        CHECK( pMM->has_parenthesis() == false );
+        CHECK( pMM->get_user_location_x() == 7.0f );
+        CHECK( pMM->get_user_location_y() == 0.0f );
+
+        delete tree->get_root();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, metronome_12)
+    {
+        //@12. metronome directly attached to MusicData
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+        stringstream expected;
+        //expected << "Line 0. Element 'label:parentesis' unknown or not possible here. Ignored." << endl;
+        parser.parse_text("(musicData (metronome 88 (dx 7)))");
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+
+        ImoMusicData* pMusic = dynamic_cast<ImoMusicData*>( pRoot );
+        CHECK( pMusic != nullptr );
+        ImoObj::children_iterator it = pMusic->begin();
+        ImoDirection* pDir = dynamic_cast<ImoDirection*>( *it );
+        ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pDir->get_attachment(0));
+        CHECK( pMM != nullptr );
+        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
+        CHECK( pMM->get_ticks_per_minute() == 88 );
+        CHECK( pMM->is_visible() == true );
+        CHECK( pMM->has_parenthesis() == false );
+        CHECK( pMM->get_user_location_x() == 7.0f );
+        CHECK( pMM->get_user_location_y() == 0.0f );
+
+        delete tree->get_root();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, metronome_13)
+    {
+        //@13. attached to direction
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+        stringstream expected;
+        //expected << "Line 0. " << endl;
+        parser.parse_text("(dir (metronome 60))");
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+
+        ImoDirection* pDir = dynamic_cast<ImoDirection*>( pRoot );
+        CHECK( pDir != nullptr );
+        ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pDir->get_attachment(0));
+        CHECK( pMM != nullptr );
+        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
+        CHECK( pMM->get_ticks_per_minute() == 60 );
+
+        delete tree->get_root();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, metronome_14)
+    {
+        //@14. Error: metronome attached to spacer
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+        stringstream expected;
+        expected <<
+            "Line 0. Element 'metronome' unknown or not possible here. Ignored." << endl;
+        parser.parse_text("(spacer 10 (metronome 60))");
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+
+        ImoSpacer* pSp = dynamic_cast<ImoSpacer*>( pRoot );
+        CHECK( pSp != nullptr );
+        CHECK( pSp->get_width() == 10.0f );
+        CHECK( pSp->get_staff() == 0 );
+        CHECK( pSp && pSp->get_attachment(0) == nullptr );
+
+        delete tree->get_root();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
 
     //@ time signature -------------------------------------------------------------------
 
@@ -4418,278 +4786,6 @@ SUITE(LdpAnalyserTest)
         if (pRoot && !pRoot->is_document()) delete pRoot;
     }
 
-    // metronome ------------------------------------------------------------------------
-
-    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Metronome_Value)
-    {
-        stringstream errormsg;
-        Document doc(m_libraryScope);
-        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
-        stringstream expected;
-        //expected << "" << endl;
-        parser.parse_text("(metronome 88)");
-        LdpTree* tree = parser.get_ldp_tree();
-        LdpAnalyser a(errormsg, m_libraryScope, &doc);
-        ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
-        CHECK( pRoot->is_metronome_mark() == true );
-        ImoMetronomeMark* pMM = dynamic_cast<ImoMetronomeMark*>( pRoot );
-        CHECK( pMM != nullptr );
-        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
-        CHECK( pMM->get_ticks_per_minute() == 88 );
-        CHECK( pMM->is_visible() == true );
-        CHECK( pMM->has_parenthesis() == false );
-
-        delete tree->get_root();
-        if (pRoot && !pRoot->is_document()) delete pRoot;
-    }
-
-    TEST_FIXTURE(LdpAnalyserTestFixture, id_in_metronome)
-    {
-        stringstream errormsg;
-        Document doc(m_libraryScope);
-        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
-        stringstream expected;
-        //expected << "" << endl;
-        parser.parse_text("(metronome#10 88)");
-        LdpTree* tree = parser.get_ldp_tree();
-        LdpAnalyser a(errormsg, m_libraryScope, &doc);
-        ImoObj* pRoot = a.analyse_tree(tree, "string:");
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
-        CHECK( pRoot->is_metronome_mark() == true );
-        ImoObj* pImo = pRoot;
-        CHECK( pImo->get_id() == 10L );
-
-        delete tree->get_root();
-        if (pRoot && !pRoot->is_document()) delete pRoot;
-    }
-
-    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Metronome_Error)
-    {
-        stringstream errormsg;
-        Document doc(m_libraryScope);
-        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
-        stringstream expected;
-        expected << "Line 0. Missing metronome parameters. Replaced by '(metronome 60)'." << endl;
-        parser.parse_text("(metronome)");
-        LdpTree* tree = parser.get_ldp_tree();
-        LdpAnalyser a(errormsg, m_libraryScope, &doc);
-        ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
-        ImoMetronomeMark* pMM = dynamic_cast<ImoMetronomeMark*>( pRoot );
-        CHECK( pMM != nullptr );
-        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
-        CHECK( pMM->get_ticks_per_minute() == 60 );
-        CHECK( pMM->is_visible() == true );
-        CHECK( pMM->has_parenthesis() == false );
-
-        delete tree->get_root();
-        if (pRoot && !pRoot->is_document()) delete pRoot;
-    }
-
-    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Metronome_NoteValue)
-    {
-        stringstream errormsg;
-        Document doc(m_libraryScope);
-        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
-        stringstream expected;
-        //expected << "" << endl;
-        parser.parse_text("(metronome e. 77)");
-        LdpTree* tree = parser.get_ldp_tree();
-        LdpAnalyser a(errormsg, m_libraryScope, &doc);
-        ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
-        ImoMetronomeMark* pMM = dynamic_cast<ImoMetronomeMark*>( pRoot );
-        CHECK( pMM != nullptr );
-        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_note_value );
-        CHECK( pMM->get_ticks_per_minute() == 77 );
-        CHECK( pMM->get_left_note_type() == k_eighth );
-        CHECK( pMM->get_left_dots() == 1 );
-        CHECK( pMM->is_visible() == true );
-        CHECK( pMM->has_parenthesis() == false );
-
-        delete tree->get_root();
-        if (pRoot && !pRoot->is_document()) delete pRoot;
-    }
-
-    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Metronome_NoteNote)
-    {
-        stringstream errormsg;
-        Document doc(m_libraryScope);
-        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
-        stringstream expected;
-        //expected << "" << endl;
-        parser.parse_text("(metronome e. s)");
-        LdpTree* tree = parser.get_ldp_tree();
-        LdpAnalyser a(errormsg, m_libraryScope, &doc);
-        ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
-        ImoMetronomeMark* pMM = dynamic_cast<ImoMetronomeMark*>( pRoot );
-        CHECK( pMM != nullptr );
-        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_note_note );
-        CHECK( pMM->get_left_note_type() == k_eighth );
-        CHECK( pMM->get_left_dots() == 1 );
-        CHECK( pMM->get_right_note_type() == k_16th );
-        CHECK( pMM->get_right_dots() == 0 );
-        CHECK( pMM->is_visible() == true );
-        CHECK( pMM->has_parenthesis() == false );
-
-        delete tree->get_root();
-        if (pRoot && !pRoot->is_document()) delete pRoot;
-    }
-
-    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Metronome_Error2)
-    {
-        stringstream errormsg;
-        Document doc(m_libraryScope);
-        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
-        stringstream expected;
-        expected << "Line 0. Error in metronome parameters. Replaced by '(metronome 60)'." << endl;
-        parser.parse_text("(metronome e. \"s\")");
-        LdpTree* tree = parser.get_ldp_tree();
-        LdpAnalyser a(errormsg, m_libraryScope, &doc);
-        ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
-        ImoMetronomeMark* pMM = dynamic_cast<ImoMetronomeMark*>( pRoot );
-        CHECK( pMM != nullptr );
-        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
-        CHECK( pMM->get_ticks_per_minute() == 60 );
-        CHECK( pMM->is_visible() == true );
-        CHECK( pMM->has_parenthesis() == false );
-
-        delete tree->get_root();
-        if (pRoot && !pRoot->is_document()) delete pRoot;
-    }
-
-    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Metronome_LocationX)
-    {
-        Document doc(m_libraryScope);
-        LdpParser parser(cout, m_libraryScope.ldp_factory());
-        parser.parse_text("(metronome 88 (dx 70))");
-        LdpTree* tree = parser.get_ldp_tree();
-        LdpAnalyser a(cout, m_libraryScope, &doc);
-        ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        ImoMetronomeMark* pMM = dynamic_cast<ImoMetronomeMark*>( pRoot );
-        CHECK( pMM != nullptr );
-        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
-        CHECK( pMM->get_ticks_per_minute() == 88 );
-        CHECK( pMM->is_visible() );
-        CHECK( pMM->get_user_location_x() == 70.0f );
-        CHECK( pMM->get_user_location_y() == 0.0f );
-        CHECK( pMM->is_visible() == true );
-        CHECK( pMM->has_parenthesis() == false );
-
-        delete tree->get_root();
-        if (pRoot && !pRoot->is_document()) delete pRoot;
-    }
-
-    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Metronome_NoVisible)
-    {
-        Document doc(m_libraryScope);
-        LdpParser parser(cout, m_libraryScope.ldp_factory());
-        parser.parse_text("(metronome 88 noVisible)");
-        LdpTree* tree = parser.get_ldp_tree();
-        LdpAnalyser a(cout, m_libraryScope, &doc);
-        ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        ImoMetronomeMark* pMM = dynamic_cast<ImoMetronomeMark*>( pRoot );
-        CHECK( pMM != nullptr );
-        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
-        CHECK( pMM->get_ticks_per_minute() == 88 );
-        CHECK( pMM->get_user_location_x() == 0.0f );
-        CHECK( pMM->get_user_location_y() == 0.0f );
-        CHECK( pMM->is_visible() == false );
-        CHECK( pMM->has_parenthesis() == false );
-
-        delete tree->get_root();
-        if (pRoot && !pRoot->is_document()) delete pRoot;
-    }
-
-    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Metronome_Parenthesis)
-    {
-        Document doc(m_libraryScope);
-        LdpParser parser(cout, m_libraryScope.ldp_factory());
-        parser.parse_text("(metronome 88 parenthesis (visible no))");
-        LdpTree* tree = parser.get_ldp_tree();
-        LdpAnalyser a(cout, m_libraryScope, &doc);
-        ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        ImoMetronomeMark* pMM = dynamic_cast<ImoMetronomeMark*>( pRoot );
-        CHECK( pMM != nullptr );
-        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
-        CHECK( pMM->get_ticks_per_minute() == 88 );
-        CHECK( pMM->get_user_location_x() == 0.0f );
-        CHECK( pMM->get_user_location_y() == 0.0f );
-        CHECK( pMM->is_visible() == false );
-        CHECK( pMM->has_parenthesis() == true );
-
-        delete tree->get_root();
-        if (pRoot && !pRoot->is_document()) delete pRoot;
-    }
-
-    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Metronome_Ordering)
-    {
-        stringstream errormsg;
-        Document doc(m_libraryScope);
-        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
-        stringstream expected;
-        //expected << "Line 0. ?" << endl;
-        parser.parse_text("(metronome 88 parenthesis (dx 7) noVisible)");
-        LdpTree* tree = parser.get_ldp_tree();
-        LdpAnalyser a(errormsg, m_libraryScope, &doc);
-        ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
-        ImoMetronomeMark* pMM = dynamic_cast<ImoMetronomeMark*>( pRoot );
-        CHECK( pMM != nullptr );
-        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
-        CHECK( pMM->get_ticks_per_minute() == 88 );
-        CHECK( pMM->is_visible() == false );
-        CHECK( pMM->has_parenthesis() == true );
-        CHECK( pMM->get_user_location_x() == 7.0f );
-        CHECK( pMM->get_user_location_y() == 0.0f );
-
-        delete tree->get_root();
-        if (pRoot && !pRoot->is_document()) delete pRoot;
-    }
-
-    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_Metronome_Error3)
-    {
-        stringstream errormsg;
-        Document doc(m_libraryScope);
-        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
-        stringstream expected;
-        expected << "Line 0. Element 'label:parentesis' unknown or not possible here. Ignored." << endl;
-        parser.parse_text("(metronome 88 parentesis (dx 7))");
-        LdpTree* tree = parser.get_ldp_tree();
-        LdpAnalyser a(errormsg, m_libraryScope, &doc);
-        ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
-        ImoMetronomeMark* pMM = dynamic_cast<ImoMetronomeMark*>( pRoot );
-        CHECK( pMM != nullptr );
-        CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
-        CHECK( pMM->get_ticks_per_minute() == 88 );
-        CHECK( pMM->is_visible() == true );
-        CHECK( pMM->has_parenthesis() == false );
-        CHECK( pMM->get_user_location_x() == 7.0f );
-        CHECK( pMM->get_user_location_y() == 0.0f );
-
-        delete tree->get_root();
-        if (pRoot && !pRoot->is_document()) delete pRoot;
-    }
 
     // opt ------------------------------------------------------------------------------
 

--- a/src/tests/lomse_test_ldp_analyser.cpp
+++ b/src/tests/lomse_test_ldp_analyser.cpp
@@ -4332,7 +4332,7 @@ SUITE(LdpAnalyserTest)
 //        cout << "[" << expected.str() << "]" << endl;
         CHECK( errormsg.str() == expected.str() );
 
-        ImoSpacer* pSp = dynamic_cast<ImoSpacer*>( pRoot );
+        ImoDirection* pSp = dynamic_cast<ImoDirection*>( pRoot );
         CHECK( pSp != nullptr );
         CHECK( pSp->get_width() == 10.0f );
         CHECK( pSp->get_staff() == 0 );
@@ -5111,7 +5111,7 @@ SUITE(LdpAnalyserTest)
         //cout << "[" << expected.str() << "]" << endl;
         CHECK( errormsg.str() == expected.str() );
         CHECK( pRoot->is_spacer() == true );
-        ImoSpacer* pSp = dynamic_cast<ImoSpacer*>( pRoot );
+        ImoDirection* pSp = dynamic_cast<ImoDirection*>( pRoot );
         CHECK( pSp != nullptr );
         CHECK( pSp->get_width() == 70.5f );
         CHECK( pSp->get_staff() == 0 );
@@ -5175,7 +5175,7 @@ SUITE(LdpAnalyserTest)
         //cout << "[" << errormsg.str() << "]" << endl;
         //cout << "[" << expected.str() << "]" << endl;
         CHECK( errormsg.str() == expected.str() );
-        ImoSpacer* pSp = dynamic_cast<ImoSpacer*>( pRoot );
+        ImoDirection* pSp = dynamic_cast<ImoDirection*>( pRoot );
         CHECK( pSp != nullptr );
         CHECK( pSp->get_width() == 70.5f );
         CHECK( pSp->get_staff() == 2 );
@@ -5198,7 +5198,7 @@ SUITE(LdpAnalyserTest)
         //cout << "[" << errormsg.str() << "]" << endl;
         //cout << "[" << expected.str() << "]" << endl;
         CHECK( errormsg.str() == expected.str() );
-        ImoSpacer* pSp = dynamic_cast<ImoSpacer*>( pRoot );
+        ImoDirection* pSp = dynamic_cast<ImoDirection*>( pRoot );
         CHECK( pSp != nullptr );
         CHECK( pSp->get_width() == 70.5f );
         CHECK( pSp->get_staff() == 0 );
@@ -5221,7 +5221,7 @@ SUITE(LdpAnalyserTest)
         //cout << "[" << errormsg.str() << "]" << endl;
         //cout << "[" << expected.str() << "]" << endl;
         CHECK( errormsg.str() == expected.str() );
-        ImoSpacer* pSp = dynamic_cast<ImoSpacer*>( pRoot );
+        ImoDirection* pSp = dynamic_cast<ImoDirection*>( pRoot );
         CHECK( pSp != nullptr );
         CHECK( pSp->get_width() == 70.5f );
         CHECK( pSp->get_staff() == 0 );
@@ -5244,7 +5244,7 @@ SUITE(LdpAnalyserTest)
         //cout << "[" << errormsg.str() << "]" << endl;
         //cout << "[" << expected.str() << "]" << endl;
         CHECK( errormsg.str() == expected.str() );
-        ImoSpacer* pSp = dynamic_cast<ImoSpacer*>( pRoot );
+        ImoDirection* pSp = dynamic_cast<ImoDirection*>( pRoot );
         CHECK( pSp != nullptr );
         CHECK( pSp->get_width() == 70.0f );
         CHECK( pSp->get_staff() == 0 );
@@ -5268,7 +5268,7 @@ SUITE(LdpAnalyserTest)
         //cout << "[" << errormsg.str() << "]" << endl;
         //cout << "[" << expected.str() << "]" << endl;
         CHECK( errormsg.str() == expected.str() );
-        ImoSpacer* pSp = dynamic_cast<ImoSpacer*>( pRoot );
+        ImoDirection* pSp = dynamic_cast<ImoDirection*>( pRoot );
         CHECK( pSp != nullptr );
         CHECK( pSp->get_width() == 70.0f );
         CHECK( pSp->get_staff() == 0 );
@@ -5292,7 +5292,7 @@ SUITE(LdpAnalyserTest)
         //cout << "[" << errormsg.str() << "]" << endl;
         //cout << "[" << expected.str() << "]" << endl;
         CHECK( errormsg.str() == expected.str() );
-        ImoSpacer* pSp = dynamic_cast<ImoSpacer*>( pRoot );
+        ImoDirection* pSp = dynamic_cast<ImoDirection*>( pRoot );
         CHECK( pSp != nullptr );
         CHECK( pSp->get_width() == 70.0f );
         CHECK( pSp->get_staff() == 0 );
@@ -10514,7 +10514,7 @@ SUITE(LdpAnalyserTest)
         CHECK( pNote != nullptr );
 
         ++it;
-        ImoSpacer* pSpacer = dynamic_cast<ImoSpacer*>( *it );
+        ImoDirection* pSpacer = dynamic_cast<ImoDirection*>( *it );
         CHECK( pSpacer != nullptr );
         ImoAttachments* pAuxObjs = pSpacer->get_attachments();
         CHECK( pAuxObjs != nullptr );

--- a/src/tests/lomse_test_staffobjs_table.cpp
+++ b/src/tests/lomse_test_staffobjs_table.cpp
@@ -348,7 +348,7 @@ SUITE(ColStaffObjsBuilderTest)
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(key C)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n f4 q v1 p1)" );
-        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(spacer 0 p1 (text \"Hello world\"))" );
+        CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(dir 0 p1 (text \"Hello world\"))" );
         CHECK_ENTRY0(it, 0,    0,      0,  64,     0, "(barline simple)" );
         CHECK( pTable->min_note_duration() == 64.0 );
     }
@@ -525,6 +525,86 @@ SUITE(ColStaffObjsBuilderTest)
         CHECK_ENTRY0(it, 0,	    0,	    0,	128,	0,	"(barline simple)" );
         CHECK_ENTRY0(it, 1,	    0,	    0,	128,	2,	"(barline simple)" );
         CHECK( pTable->min_note_duration() == 32.0 );
+    }
+
+    TEST_FIXTURE(ColStaffObjsBuilderTestFixture, builder_13)
+    {
+        //@13. Direction in prolog is re-ordered after prolog
+
+        ImoScore* pScore = create_score(    //unit test score 02033
+            "(score (vers 2.1)"
+            "(instrument P1"
+            "(musicData (clef G) (dir (metronome e 40))"
+            "(key a)(time 3 8)(n e5 s v1 (beam 45 ++))"
+            "(n +d5 s v1 (beam 45 --))"
+            "(barline simple)"
+            "))"
+            "(instrument P2 (musicData"
+            "(clef F4)(key a)(time 3 8)"
+            "(r e v1)(barline simple)"
+            ")))"
+        );
+        ColStaffObjsBuilder builder;
+        ColStaffObjs* pTable = builder.build(pScore);
+
+        CHECK( pTable->num_lines() == 2 );
+        CHECK( pTable->num_entries() == 12 );
+        CHECK( pTable->is_anacrusis_start() == true );
+
+//        cout << test_name() << endl;
+//        cout << pTable->dump();
+//
+        ColStaffObjsIterator it = pTable->begin();
+        //              instr, staff, meas. time, line, scr
+        CHECK_ENTRY0(it, 0,     0,	    0,	0,	    0,	"(clef G p1)" );
+        CHECK_ENTRY0(it, 0,	    0,	    0,	0,	    0,	"(key a)" );
+        CHECK_ENTRY0(it, 0,	    0,	    0,	0,	    0,	"(time 3 8)" );
+        CHECK_ENTRY0(it, 1,	    0,	    0,	0,	    1,	"(clef F4 p1)" );
+        CHECK_ENTRY0(it, 1,	    0,	    0,	0,	    1,	"(key a)" );
+        CHECK_ENTRY0(it, 1,	    0,	    0,	0,	    1,	"(time 3 8)" );
+        CHECK_ENTRY0(it, 0,	    0,	    0,	0,	    0,	"(dir 0 p1 (metronome e 40))" );
+        CHECK_ENTRY0(it, 0,	    0,	    0,	0,	    0,	"(n e5 s v1 p1 (beam 31 ++))" );
+        CHECK( pTable->min_note_duration() == 16.0 );
+    }
+
+    TEST_FIXTURE(ColStaffObjsBuilderTestFixture, builder_14)
+    {
+        //@14. Direction before prolog is re-ordered
+
+        ImoScore* pScore = create_score(    //unit test score 02034
+            "(score (vers 2.1)"
+            "(instrument P1"
+            "(musicData (dir (metronome e 40))(clef G)"
+            "(key a)(time 3 8)(n e5 s v1 (beam 45 ++))"
+            "(n +d5 s v1 (beam 45 --))"
+            "(barline simple)"
+            "))"
+            "(instrument P2 (musicData"
+            "(clef F4)(key a)(time 3 8)"
+            "(r e v1)(barline simple)"
+            ")))"
+        );
+        ColStaffObjsBuilder builder;
+        ColStaffObjs* pTable = builder.build(pScore);
+
+        CHECK( pTable->num_lines() == 2 );
+        CHECK( pTable->num_entries() == 12 );
+        CHECK( pTable->is_anacrusis_start() == true );
+
+//        cout << test_name() << endl;
+//        cout << pTable->dump();
+//
+        ColStaffObjsIterator it = pTable->begin();
+        //              instr, staff, meas. time, line, scr
+        CHECK_ENTRY0(it, 0,     0,	    0,	0,	    0,	"(clef G p1)" );
+        CHECK_ENTRY0(it, 0,	    0,	    0,	0,	    0,	"(key a)" );
+        CHECK_ENTRY0(it, 0,	    0,	    0,	0,	    0,	"(time 3 8)" );
+        CHECK_ENTRY0(it, 1,	    0,	    0,	0,	    1,	"(clef F4 p1)" );
+        CHECK_ENTRY0(it, 1,	    0,	    0,	0,	    1,	"(key a)" );
+        CHECK_ENTRY0(it, 1,	    0,	    0,	0,	    1,	"(time 3 8)" );
+        CHECK_ENTRY0(it, 0,	    0,	    0,	0,	    0,	"(dir 0 p1 (metronome e 40))" );
+        CHECK_ENTRY0(it, 0,	    0,	    0,	0,	    0,	"(n e5 s v1 p1 (beam 31 ++))" );
+        CHECK( pTable->min_note_duration() == 16.0 );
     }
 
     // ColStaffObjsBuilderEngine1x ------------------------------------------------------
@@ -946,7 +1026,7 @@ SUITE(ColStaffObjsBuilderTest)
         CHECK( is_equal_time((*it)->time(), 64.0f) );
         CHECK( (*it)->line() == 0 );
         CHECK( (*it)->staff() == 0 );
-        ImoSpacer* pAnchor = dynamic_cast<ImoSpacer*>( (*it)->imo_object() );
+        ImoDirection* pAnchor = dynamic_cast<ImoDirection*>( (*it)->imo_object() );
         CHECK( pAnchor != nullptr );
         ++it;
         //CHECK( (*it)->to_string() == "(barline )" );

--- a/test-scores/02033-direction-in-prolog.lms
+++ b/test-scores/02033-direction-in-prolog.lms
@@ -1,0 +1,23 @@
+(score (vers 2.1)
+	(instrument P1
+		(musicData
+			(clef G)
+			(dir (metronome e 40))
+			(key a)
+			(time 3 8)
+			(n e5 s v1 (beam 45 ++))
+			(n +d5 s v1 (beam 45 --))
+			(barline simple)
+		)
+	)
+	(instrument P2
+		(musicData
+			(clef F4)
+			(key a)
+			(time 3 8)
+			(r e v1)
+			(barline simple)
+		)
+	)
+)
+

--- a/test-scores/02034-direction-at-start.lms
+++ b/test-scores/02034-direction-at-start.lms
@@ -1,0 +1,23 @@
+(score (vers 2.1)
+	(instrument P1
+		(musicData
+			(dir (metronome e 40))
+			(clef G)
+			(key a)
+			(time 3 8)
+			(n e5 s v1 (beam 45 ++))
+			(n +d5 s v1 (beam 45 --))
+			(barline simple)
+		)
+	)
+	(instrument P2
+		(musicData
+			(clef F4)
+			(key a)
+			(time 3 8)
+			(r e v1)
+			(barline simple)
+		)
+	)
+)
+


### PR DESCRIPTION
This PR is, mainly, for supporting MusicXML metronome marks.  It improves the MusicXML support for importing the most common metronome construct used in most MusicXML files. But it does not add support for the alternative construct, used only for more complex metronome specifications. To support it I need to find sample MusicXML files using it.

This PR also includes a few additional changes:

- A long time ago, when metronome marks were supported in LDP, they were modelled by _ImoMetronomeMark_ objects, derived from _ImoStaffObj_. This decision was not the best one and several facts point to the need to reconsider it and to model _ImoMetronomeMark_ as an _ImoAuxObj_ attached to an _ImoDirection_. This PR does it.

- _ImoDirection_ was introduced time ago when importing things from MusicXML, but now there was a conflict with _ImoSpacer_ as, somehow, both do the same function. Therefore, _ImoSpacer_ has been removed and replaced by _ImoDirection_.

In addition, a few minor unrelated changes are included in this PR, such as removing compiler warnings due to logger class.
