### PR TITLE
Support Octave-shift lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ##### COMPATIBLE CHANGES
 
+- Added support to render octave-shift lines. MusicXML importer now also imports them.
 - Added support to render crescendo/diminuendo wedges (hairpins). The MusicXML importer
   now also imports the wedges.
 - Added methods in `Interactor` to add/remove visual application markings. Created the

--- a/add-sources.cmake
+++ b/add-sources.cmake
@@ -94,6 +94,7 @@ set(GRAPHIC_MODEL_FILES
     ${LOMSE_SRC_DIR}/graphic_model/engravers/lomse_lyric_engraver.cpp
     ${LOMSE_SRC_DIR}/graphic_model/engravers/lomse_metronome_engraver.cpp
     ${LOMSE_SRC_DIR}/graphic_model/engravers/lomse_note_engraver.cpp
+    ${LOMSE_SRC_DIR}/graphic_model/engravers/lomse_octave_shift_engraver.cpp
     ${LOMSE_SRC_DIR}/graphic_model/engravers/lomse_ornament_engraver.cpp
     ${LOMSE_SRC_DIR}/graphic_model/engravers/lomse_rest_engraver.cpp
     ${LOMSE_SRC_DIR}/graphic_model/engravers/lomse_slur_engraver.cpp

--- a/add-sources.cmake
+++ b/add-sources.cmake
@@ -63,6 +63,7 @@ set(GRAPHIC_MODEL_FILES
     ${LOMSE_SRC_DIR}/graphic_model/lomse_shape_brace_bracket.cpp
     ${LOMSE_SRC_DIR}/graphic_model/lomse_shape_line.cpp
     ${LOMSE_SRC_DIR}/graphic_model/lomse_shape_note.cpp
+    ${LOMSE_SRC_DIR}/graphic_model/lomse_shape_octave_shift.cpp
     ${LOMSE_SRC_DIR}/graphic_model/lomse_shape_staff.cpp
     ${LOMSE_SRC_DIR}/graphic_model/lomse_shape_text.cpp
     ${LOMSE_SRC_DIR}/graphic_model/lomse_shape_tie.cpp

--- a/include/lomse_engraving_options.h
+++ b/include/lomse_engraving_options.h
@@ -107,7 +107,10 @@ namespace lomse
 #define LOMSE_WEDGE_LINE_THICKNESS      1.5f    //line thickness for wedges/hairpins
 #define LOMSE_WEDGE_NIENTE_RADIUS       4.0f    //radius for niente circles in wedges
 
-
+//octave-shift lines
+#define LOMSE_OCTAVE_SHIFT_LINE_THICKNESS  1.0f //thickness for octave-shift lines
+#define LOMSE_OCTAVE_SHIFT_SPACE_TO_LINE   2.0f //space from numeral glyph to line start
+#define LOMSE_OCTAVE_SHIFT_LINE_SHIFT      3.0f //vertical line shift to compensate glyph baseline
 
 }   //namespace lomse
 

--- a/include/lomse_glyphs.h
+++ b/include/lomse_glyphs.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -243,9 +243,6 @@ enum EGlyphIndex
     k_glyph_coda,
     k_glyph_segno,
 
-    //Octaves (U+E510 - U+E51F)
-    k_glyph_octava,
-
     //Figured bass. Numbers and other symbols
     k_glyph_figured_bass_0,                   //number 0
     k_glyph_figured_bass_1,                   //number 1
@@ -328,6 +325,24 @@ enum EGlyphIndex
     k_glyph_tremolo_3,     // Combining tremolo 3
     k_glyph_tremolo_4,     // Combining tremolo 4
     k_glyph_tremolo_5,     // Combining tremolo 5
+
+    //Octaves (U+E510 - U+E51F)
+    k_glyph_ottava,                 //Ottava: 8
+    k_glyph_ottavaAlta,             //Ottava alta: 8va ('va' at top)
+    k_glyph_ottavaBassa,            //Ottava bassa: 8va ('va' at bottom)
+    k_glyph_ottavaBassaBa,          //Ottava bassa: 8ba
+    k_glyph_quindicesima,           //Quindicesima: 15
+    k_glyph_quindicesimaAlta,       //Quindicesima alta: 15ma ('ma' at top)
+    k_glyph_quindicesimaBassa,      //Quindicesima bassa: 15ma ('ma' at bottom)
+    k_glyph_ventiduesima,           //Ventiduesima: 22
+    k_glyph_ventiduesimaAlta,       //Ventiduesima alta: 22ma ('ma' at top)
+    k_glyph_ventiduesimaBassa,      //Ventiduesima bassa: 22ma ('ma' at bottom)
+    k_glyph_octaveParensLeft,       //Left parenthesis for octave signs
+    k_glyph_octaveParensRight,      //Right parenthesis for octave signs
+    k_glyph_ottavaBassaVb,          //Ottava bassa: 8vb
+    k_glyph_quindicesimaBassaMb,    //Quindicesima bassa: 15mb
+    k_glyph_ventiduesimaBassaMb,    //Ventiduesima bassa: 22mb
+    k_glyph_octaveBassa,            //'bassa' word
 
     //Brass techniques (U+E5D0 –U+E5EF)
     k_glyph_brass_scoop,                        //Scoop

--- a/include/lomse_gm_basic.h
+++ b/include/lomse_gm_basic.h
@@ -173,7 +173,7 @@ public:
                 k_shape_invisible, k_shape_key_signature, k_shape_lyrics,
                 k_shape_metronome_glyph, k_shape_metronome_mark,
                 k_shape_line, k_shape_note, k_shape_notehead,
-                k_shape_ornament,
+                k_shape_octave_shift, k_shape_octave_glyph, k_shape_ornament,
                 k_shape_rectangle, k_shape_rest, k_shape_rest_glyph,
                 k_shape_slur, k_shape_squared_bracket,
                 k_shape_stem, k_shape_staff,
@@ -237,6 +237,8 @@ public:
     inline bool is_shape_metronome_mark() { return m_objtype == k_shape_metronome_mark; }
     inline bool is_shape_note() { return m_objtype == k_shape_note; }
     inline bool is_shape_notehead() { return m_objtype == k_shape_notehead; }
+    inline bool is_shape_octave_shift() { return m_objtype == k_shape_octave_shift; }
+    inline bool is_shape_octave_num() { return m_objtype == k_shape_octave_glyph; }
     inline bool is_shape_ornament() { return m_objtype == k_shape_ornament; }
     inline bool is_shape_rectangle() { return m_objtype == k_shape_rectangle; }
     inline bool is_shape_rest() { return m_objtype == k_shape_rest; }

--- a/include/lomse_internal_model.h
+++ b/include/lomse_internal_model.h
@@ -592,6 +592,7 @@ enum EImoObjType
     k_imo_color_dto,
     k_imo_font_style_dto,
     k_imo_point_dto,
+    k_imo_octave_shift_dto,
     k_imo_size_dto,
     k_imo_slur_dto,
     k_imo_tie_dto,
@@ -709,6 +710,7 @@ enum EImoObjType
     k_imo_relobj,           ///< &nbsp;&nbsp;&nbsp;&nbsp; <b>Relation objects. Any of the following:</b>
     k_imo_beam,             ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Beam
     k_imo_chord,            ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Chord
+    k_imo_octave_shift,     ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Octave-shift line
     k_imo_slur,             ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Slur
     k_imo_tie,              ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Tie
     k_imo_tuplet,           ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Tuplet
@@ -1445,6 +1447,8 @@ public:
     inline bool is_note() { return m_objtype == k_imo_note; }
     inline bool is_note_rest() { return m_objtype == k_imo_note
                || m_objtype == k_imo_rest; }
+    inline bool is_octave_shift() { return m_objtype == k_imo_octave_shift; }
+    inline bool is_octave_shift_dto() { return m_objtype == k_imo_octave_shift_dto; }
     inline bool is_option() { return m_objtype == k_imo_option; }
     inline bool is_ornament() { return m_objtype == k_imo_ornament; }
     inline bool is_page_info() { return m_objtype == k_imo_page_info; }
@@ -7386,6 +7390,104 @@ public:
 
 
 //---------------------------------------------------------------------------------------
+// Represents an octave-shift line
+class ImoOctaveShift : public ImoRelObj
+{
+protected:
+//    Tenths  m_startSpread;
+//    Tenths  m_endSpread;
+//    bool    m_fNiente;
+    int     m_steps;
+    int     m_octaveShiftNum;
+
+    friend class ImFactory;
+    ImoOctaveShift(int num=0)
+        : ImoRelObj(k_imo_octave_shift)
+//        , m_startSpread(0.0f)
+//        , m_endSpread(0.0f)
+//        , m_fNiente(false)
+        , m_steps(0)
+        , m_octaveShiftNum(num)
+    {
+    }
+
+public:
+    virtual ~ImoOctaveShift() {}
+
+    //setters
+//    inline void set_start_spread(Tenths value) { m_startSpread = value; }
+//    inline void set_end_spread(Tenths value) { m_endSpread = value; }
+//    inline void set_niente(bool value) { m_fNiente = value; }
+    inline void set_shift_steps(int value) { m_steps = value; }
+    inline void set_octave_shift_number(int value) { m_octaveShiftNum = value; }
+
+    //getters
+//    inline Tenths get_start_spread() { return m_startSpread; }
+//    inline Tenths get_end_spread() { return m_endSpread; }
+//    inline bool is_niente() { return m_fNiente; }
+    inline int get_shift_steps() { return m_steps; }
+    inline int get_octave_shift_number() { return m_octaveShiftNum; }
+
+    void reorganize_after_object_deletion();
+};
+
+// raw info about a pending wedge
+//---------------------------------------------------------------------------------------
+class ImoOctaveShiftDto : public ImoSimpleObj
+{
+protected:
+//    Tenths m_spread;
+//    bool m_fNiente;
+    bool m_fStart;
+    int m_steps;
+    int m_octaveShiftNum;
+    ImoDirection* m_pDirection;
+    Color m_color;
+    int m_lineNum;
+
+public:
+    ImoOctaveShiftDto()
+        : ImoSimpleObj(k_imo_octave_shift_dto)
+//        , m_spread(0.0f)
+//        , m_fNiente(false)
+        , m_fStart(true)
+        , m_steps(0)
+        , m_octaveShiftNum(0)
+        , m_pDirection(nullptr)
+        , m_color(Color(0,0,0))
+        , m_lineNum(0)
+    {
+    }
+    virtual ~ImoOctaveShiftDto() {}
+
+    //setters
+    inline void set_line_number(int value) { m_lineNum = value; }
+//    inline void set_spread(Tenths value) { m_spread = value; }
+//    inline void set_niente(bool value) { m_fNiente = value; }
+    inline void set_staffobj(ImoDirection* pDirection) { m_pDirection = pDirection; }
+    inline void set_shift_steps(int value) { m_steps = value; }
+    inline void set_start(bool value) { m_fStart = value; }
+    inline void set_octave_shift_number(int value) { m_octaveShiftNum = value; }
+    inline void set_color(Color value) { m_color = value; }
+
+    //getters
+    inline int get_line_number() { return m_lineNum; }
+//    inline Tenths get_spread() { return m_spread; }
+//    inline bool is_niente() { return m_fNiente; }
+    inline int get_shift_steps() { return m_steps; }
+    inline bool is_start() { return m_fStart; }
+    inline int get_octave_shift_number() { return m_octaveShiftNum; }
+    inline Color get_color() { return m_color; }
+
+    //required by RelationBuilder
+    inline int get_item_number() { return get_octave_shift_number(); }
+    bool is_start_of_relation() { return is_start(); }
+    bool is_end_of_relation() { return !is_start(); }
+    inline ImoDirection* get_staffobj() { return m_pDirection; }
+};
+
+
+//---------------------------------------------------------------------------------------
 class ImoVoltaBracket : public ImoRelObj
 {
 protected:
@@ -7603,7 +7705,7 @@ protected:
     bool    m_fNiente;
     bool    m_fCrescendo;
     int     m_wedgeNum;
-    Color   m_color;
+//    Color   m_color;
 
     friend class ImFactory;
     ImoWedge(int num=0)
@@ -7625,7 +7727,7 @@ public:
     inline void set_niente(bool value) { m_fNiente = value; }
     inline void set_crescendo(bool value) { m_fCrescendo = value; }
     inline void set_wedge_number(int value) { m_wedgeNum = value; }
-    inline void set_color(Color value) { m_color = value; }
+//    inline void set_color(Color value) { m_color = value; }
 
     //getters
     inline Tenths get_start_spread() { return m_startSpread; }
@@ -7633,27 +7735,10 @@ public:
     inline bool is_niente() { return m_fNiente; }
     inline bool is_crescendo() { return m_fCrescendo; }
     inline int get_wedge_number() { return m_wedgeNum; }
-    inline Color get_color() { return m_color; }
+//    inline Color get_color() { return m_color; }
 
     void reorganize_after_object_deletion();
 };
-
-////---------------------------------------------------------------------------------------
-//class ImoWedgeData : public ImoRelDataObj
-//{
-//protected:
-////    bool    m_fStart;
-////    int     m_wedgeNum;
-////    int     m_orientation;
-////    ImoBezierInfo* m_pBezier;
-//
-//    friend class ImFactory;
-//    ImoWedgeData(ImoWedgeDto* pDto);
-//
-//public:
-//    virtual ~ImoWedgeData();
-//
-//};
 
 // raw info about a pending wedge
 //---------------------------------------------------------------------------------------

--- a/include/lomse_internal_model.h
+++ b/include/lomse_internal_model.h
@@ -7394,18 +7394,12 @@ public:
 class ImoOctaveShift : public ImoRelObj
 {
 protected:
-//    Tenths  m_startSpread;
-//    Tenths  m_endSpread;
-//    bool    m_fNiente;
     int     m_steps;
     int     m_octaveShiftNum;
 
     friend class ImFactory;
     ImoOctaveShift(int num=0)
         : ImoRelObj(k_imo_octave_shift)
-//        , m_startSpread(0.0f)
-//        , m_endSpread(0.0f)
-//        , m_fNiente(false)
         , m_steps(0)
         , m_octaveShiftNum(num)
     {
@@ -7415,75 +7409,65 @@ public:
     virtual ~ImoOctaveShift() {}
 
     //setters
-//    inline void set_start_spread(Tenths value) { m_startSpread = value; }
-//    inline void set_end_spread(Tenths value) { m_endSpread = value; }
-//    inline void set_niente(bool value) { m_fNiente = value; }
     inline void set_shift_steps(int value) { m_steps = value; }
     inline void set_octave_shift_number(int value) { m_octaveShiftNum = value; }
 
     //getters
-//    inline Tenths get_start_spread() { return m_startSpread; }
-//    inline Tenths get_end_spread() { return m_endSpread; }
-//    inline bool is_niente() { return m_fNiente; }
     inline int get_shift_steps() { return m_steps; }
     inline int get_octave_shift_number() { return m_octaveShiftNum; }
 
     void reorganize_after_object_deletion();
 };
 
-// raw info about a pending wedge
 //---------------------------------------------------------------------------------------
+// raw info about a pending octave-shift line
 class ImoOctaveShiftDto : public ImoSimpleObj
 {
 protected:
-//    Tenths m_spread;
-//    bool m_fNiente;
     bool m_fStart;
     int m_steps;
     int m_octaveShiftNum;
-    ImoDirection* m_pDirection;
+    ImoNote* m_pNote;
     Color m_color;
     int m_lineNum;
+    int m_iStaff;
 
 public:
     ImoOctaveShiftDto()
         : ImoSimpleObj(k_imo_octave_shift_dto)
-//        , m_spread(0.0f)
-//        , m_fNiente(false)
         , m_fStart(true)
         , m_steps(0)
         , m_octaveShiftNum(0)
-        , m_pDirection(nullptr)
+        , m_pNote(nullptr)
         , m_color(Color(0,0,0))
         , m_lineNum(0)
+        , m_iStaff(0)
     {
     }
     virtual ~ImoOctaveShiftDto() {}
 
     //setters
     inline void set_line_number(int value) { m_lineNum = value; }
-//    inline void set_spread(Tenths value) { m_spread = value; }
-//    inline void set_niente(bool value) { m_fNiente = value; }
-    inline void set_staffobj(ImoDirection* pDirection) { m_pDirection = pDirection; }
+    inline void set_staffobj(ImoNote* pNote) { m_pNote = pNote; }
     inline void set_shift_steps(int value) { m_steps = value; }
     inline void set_start(bool value) { m_fStart = value; }
     inline void set_octave_shift_number(int value) { m_octaveShiftNum = value; }
     inline void set_color(Color value) { m_color = value; }
+    inline void set_staff(int value) { m_iStaff = value; }
 
     //getters
     inline int get_line_number() { return m_lineNum; }
-//    inline Tenths get_spread() { return m_spread; }
-//    inline bool is_niente() { return m_fNiente; }
     inline int get_shift_steps() { return m_steps; }
     inline bool is_start() { return m_fStart; }
     inline int get_octave_shift_number() { return m_octaveShiftNum; }
     inline Color get_color() { return m_color; }
+    inline int get_staff() { return m_iStaff; }
 
     //required by RelationBuilder
     inline int get_item_number() { return get_octave_shift_number(); }
     bool is_start_of_relation() { return is_start(); }
     bool is_end_of_relation() { return !is_start(); }
-    inline ImoDirection* get_staffobj() { return m_pDirection; }
+    inline ImoNote* get_staffobj() { return m_pNote; }
 };
 
 

--- a/include/lomse_mxl_analyser.h
+++ b/include/lomse_mxl_analyser.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -135,22 +135,34 @@ public:
 
 
 //---------------------------------------------------------------------------------------
-// helper class to save volta bracket dto items, match them and build the volta brackets
+// helper class to save wedge dto items, match them and build the wedges
 class MxlWedgesBuilder : public RelationBuilder<ImoWedgeDto, MxlAnalyser>
 {
-protected:
-    ImoWedgeDto* m_pFirstWedge;        //ptr to 1st wedge of current repetition set
-
 public:
     MxlWedgesBuilder(ostream& reporter, MxlAnalyser* pAnalyser)
         : RelationBuilder<ImoWedgeDto, MxlAnalyser>(
                 reporter, pAnalyser, "wedge", "Wedge")
-        , m_pFirstWedge(nullptr)
     {
     }
     virtual ~MxlWedgesBuilder() {}
 
     void add_relation_to_staffobjs(ImoWedgeDto* pEndInfo);
+};
+
+
+//---------------------------------------------------------------------------------------
+// helper class to save octave-shift dto items, match them and build the octave-shift lines
+class MxlOctaveShiftBuilder : public RelationBuilder<ImoOctaveShiftDto, MxlAnalyser>
+{
+public:
+    MxlOctaveShiftBuilder(ostream& reporter, MxlAnalyser* pAnalyser)
+        : RelationBuilder<ImoOctaveShiftDto, MxlAnalyser>(
+                reporter, pAnalyser, "octave-shift", "Octave-shift")
+    {
+    }
+    virtual ~MxlOctaveShiftBuilder() {}
+
+    void add_relation_to_staffobjs(ImoOctaveShiftDto* pEndInfo);
 };
 
 
@@ -239,6 +251,7 @@ protected:
     MxlSlursBuilder*    m_pSlursBuilder;
     MxlVoltasBuilder*   m_pVoltasBuilder;
     MxlWedgesBuilder*   m_pWedgesBuilder;
+    MxlOctaveShiftBuilder*  m_pOctaveShiftBuilder;
     map<string, int>    m_lyricIndex;
     vector<ImoLyric*>   m_lyrics;
     map<string, int>    m_soundIdToIdx;     //conversion sound-instrument id to index
@@ -254,6 +267,8 @@ protected:
     int             m_voltaNum;
     map<int, ImoId> m_wedgeIds;
     int             m_wedgeNum;
+    map<int, ImoId> m_octaveShiftIds;
+    int             m_octaveShiftNum;
 
 
     //analysis input
@@ -404,15 +419,21 @@ public:
     int get_slur_id(int numSlur);
     int get_slur_id_and_close(int numSlur);
 
+    //interface for building volta brackets
+    int new_volta_id();
+    int get_volta_id();
+
     //interface for building wedges
     int new_wedge_id(int numWedge);
     bool wedge_id_exists(int numWedge);
     int get_wedge_id(int numWedge);
     int get_wedge_id_and_close(int numWedge);
 
-    //interface for building volta brackets
-    int new_volta_id();
-    int get_volta_id();
+    //interface for building octave-shift lines
+    int new_octave_shift_id(int num);
+    bool octave_shift_id_exists(int num);
+    int get_octave_shift_id(int num);
+    int get_octave_shift_id_and_close(int num);
 
     //interface for MxlTupletsBuilder
     inline bool is_tuplet_open() { return m_pTupletsBuilder->is_tuplet_open(); }

--- a/include/lomse_mxl_analyser.h
+++ b/include/lomse_mxl_analyser.h
@@ -163,6 +163,7 @@ public:
     virtual ~MxlOctaveShiftBuilder() {}
 
     void add_relation_to_staffobjs(ImoOctaveShiftDto* pEndInfo);
+    void add_to_open_octave_shifts(ImoNote* pNote);
 };
 
 
@@ -290,6 +291,8 @@ protected:
     string          m_curMeasureNum;    //Num of measure being analysed
     int             m_measuresCounter;  //counter for measures in current instrument
 
+    vector<ImoNote*> m_notes;           //last note for each staff
+
     //inherited values
 //    int m_curStaff;
     int m_curVoice;
@@ -366,8 +369,9 @@ public:
 //    inline void set_current_show_tuplet_number(int value) { m_nShowTupletNumber = value; }
 //    inline int get_current_show_tuplet_number() { return m_nShowTupletNumber; }
 
-    inline void save_last_note(ImoNote* pNote) { m_pLastNote = pNote; }
+    void save_last_note(ImoNote* pNote);
     inline ImoNote* get_last_note() { return m_pLastNote; }
+    ImoNote* get_last_note_for(int iStaff);
 
     //last barline added to current instrument
     inline void save_last_barline(ImoBarline* pBarline) { m_pLastBarline = pBarline; }
@@ -378,7 +382,7 @@ public:
     inline ImoScore* get_score_being_analysed() { return m_pCurScore; }
 
     //access to instrument being analysed
-    inline void save_current_instrument(ImoInstrument* pInstr) { m_pCurInstrument = pInstr; }
+    void save_current_instrument(ImoInstrument* pInstr);
     inline ImoInstrument* get_current_instrument() { return m_pCurInstrument; }
 
     //access to document being analysed
@@ -443,6 +447,11 @@ public:
     inline void get_factors_from_nested_tuplets(int* pTop, int* pBottom)
     {
         m_pTupletsBuilder->get_factors_from_nested_tuplets(pTop, pBottom);
+    }
+
+    //interface for MxlOctaveShiftBuilder
+    inline void add_to_open_octave_shifts(ImoNote* pNote) {
+        m_pOctaveShiftBuilder->add_to_open_octave_shifts(pNote);
     }
 
     //information for reporting errors

--- a/include/lomse_note_engraver.h
+++ b/include/lomse_note_engraver.h
@@ -56,6 +56,7 @@ class NoteEngraver : public Engraver
 protected:
     ImoNote* m_pNote;
     int m_clefType;
+    int m_octaveShift;
     ShapesStorage* m_pShapesStorage;
 
 public:
@@ -63,7 +64,7 @@ public:
                  ShapesStorage* pShapesStorage, int iInstr, int iStaff);
     virtual ~NoteEngraver() {}
 
-    GmoShape* create_shape(ImoNote* pNote, int clefType, UPoint uPos,
+    GmoShape* create_shape(ImoNote* pNote, int clefType, int octaveShift, UPoint uPos,
                            Color color=Color(0,0,0));
     GmoShape* create_tool_dragged_shape(int noteType, EAccidentals acc, int dots);
     UPoint get_drag_offset();

--- a/include/lomse_octave_shift_engraver.h
+++ b/include/lomse_octave_shift_engraver.h
@@ -56,7 +56,8 @@ protected:
 
     int m_numShapes;
     ImoOctaveShift* m_pOctaveShift;
-    bool m_fOctaveShiftAbove;
+    GmoShape* m_pShapeNumeral[2];
+    GmoShapeOctaveShift* m_pMainShape[2];
     LUnits m_uPrologWidth;
 
     ImoDirection* m_pStartDirection;
@@ -64,9 +65,9 @@ protected:
     GmoShapeInvisible* m_pStartDirectionShape;
     GmoShapeInvisible* m_pEndDirectionShape;
 
-    bool m_fTwoOctaveShifts;
-    UPoint m_points1[4];    //points for first wedge
-    UPoint m_points2[4];    //points for second wedge, when fisrt one is split
+    bool m_fUseTwoShapes;
+    bool m_fPlaceAtTop;
+    UPoint m_points[2][2];  //points for shapes, 2 points per shape (top-left, bottom-left).
     ShapeBoxInfo m_shapesInfo[2];
 
 public:
@@ -91,10 +92,16 @@ public:
 
 protected:
     void decide_placement();
-    void decide_if_one_or_two_wedges();
-    inline bool two_wedges_needed() { return m_fTwoOctaveShifts; }
+    void decide_if_one_or_two_shapes();
+    inline bool two_shapes_needed() { return m_fUseTwoShapes; }
     void create_two_shapes();
     void create_one_shape();
+    inline bool octave_shift_at_top() { return m_fPlaceAtTop; }
+
+    void create_main_container_shape(int iShape);
+    void add_shape_numeral(int iShape);
+    void add_line_info(int iShape);
+    int find_glyph(int shift);
 
     void compute_first_shape_position();
     void compute_second_shape_position();

--- a/include/lomse_octave_shift_engraver.h
+++ b/include/lomse_octave_shift_engraver.h
@@ -1,0 +1,109 @@
+//---------------------------------------------------------------------------------------
+// This file is part of the Lomse library.
+// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice, this
+//      list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright notice, this
+//      list of conditions and the following disclaimer in the documentation and/or
+//      other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+// SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// For any comment, suggestion or feature request, please contact the manager of
+// the project at cecilios@users.sourceforge.net
+//---------------------------------------------------------------------------------------
+
+#ifndef __LOMSE_OCTAVE_SHIFT_H__        //to avoid nested includes
+#define __LOMSE_OCTAVE_SHIFT_H__
+
+#include "lomse_basic.h"
+#include "lomse_injectors.h"
+#include "lomse_engraver.h"
+
+namespace lomse
+{
+
+//forward declarations
+class ImoOctaveShiftData;
+class ImoOctaveShift;
+class ImoDirection;
+class GmoShapeOctaveShift;
+class GmoShapeInvisible;
+class ScoreMeter;
+class InstrumentEngraver;
+
+//---------------------------------------------------------------------------------------
+class OctaveShiftEngraver : public RelObjEngraver
+{
+protected:
+    InstrumentEngraver* m_pInstrEngrv;
+    LUnits m_uStaffTopStart;    //top line of start system
+    LUnits m_uStaffTopEnd;      //top line of end system
+
+    int m_numShapes;
+    ImoOctaveShift* m_pOctaveShift;
+    bool m_fOctaveShiftAbove;
+    LUnits m_uPrologWidth;
+
+    ImoDirection* m_pStartDirection;
+    ImoDirection* m_pEndDirection;
+    GmoShapeInvisible* m_pStartDirectionShape;
+    GmoShapeInvisible* m_pEndDirectionShape;
+
+    bool m_fTwoOctaveShifts;
+    UPoint m_points1[4];    //points for first wedge
+    UPoint m_points2[4];    //points for second wedge, when fisrt one is split
+    ShapeBoxInfo m_shapesInfo[2];
+
+public:
+    OctaveShiftEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
+                 InstrumentEngraver* pInstrEngrv);
+    ~OctaveShiftEngraver() {}
+
+    void set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
+                            GmoShape* pStaffObjShape, int iInstr, int iStaff,
+                            int iSystem, int iCol,
+                            LUnits xRight, LUnits xLeft, LUnits yTop);
+    void set_end_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
+                          GmoShape* pStaffObjShape, int iInstr, int iStaff,
+                          int iSystem, int iCol,
+                          LUnits xRight, LUnits xLeft, LUnits yTop);
+    int create_shapes(Color color);
+    int create_shapes();
+    int get_num_shapes();
+    ShapeBoxInfo* get_shape_box_info(int i);
+
+    void set_prolog_width(LUnits width);
+
+protected:
+    void decide_placement();
+    void decide_if_one_or_two_wedges();
+    inline bool two_wedges_needed() { return m_fTwoOctaveShifts; }
+    void create_two_shapes();
+    void create_one_shape();
+
+    void compute_first_shape_position();
+    void compute_second_shape_position();
+    //void add_user_displacements(int iOctaveShift, UPoint* points);
+
+};
+
+
+}   //namespace lomse
+
+#endif    // __LOMSE_OCTAVE_SHIFT_H__
+

--- a/include/lomse_octave_shift_engraver.h
+++ b/include/lomse_octave_shift_engraver.h
@@ -40,9 +40,9 @@ namespace lomse
 //forward declarations
 class ImoOctaveShiftData;
 class ImoOctaveShift;
-class ImoDirection;
+class ImoNote;
 class GmoShapeOctaveShift;
-class GmoShapeInvisible;
+class GmoShapeNote;
 class ScoreMeter;
 class InstrumentEngraver;
 
@@ -60,10 +60,10 @@ protected:
     GmoShapeOctaveShift* m_pMainShape[2];
     LUnits m_uPrologWidth;
 
-    ImoDirection* m_pStartDirection;
-    ImoDirection* m_pEndDirection;
-    GmoShapeInvisible* m_pStartDirectionShape;
-    GmoShapeInvisible* m_pEndDirectionShape;
+    ImoNote* m_pStartNote;
+    ImoNote* m_pEndNote;
+    GmoShapeNote* m_pStartNoteShape;
+    GmoShapeNote* m_pEndNoteShape;
 
     bool m_fUseTwoShapes;
     bool m_fPlaceAtTop;

--- a/include/lomse_octave_shift_engraver.h
+++ b/include/lomse_octave_shift_engraver.h
@@ -94,8 +94,6 @@ protected:
     void decide_placement();
     void decide_if_one_or_two_shapes();
     inline bool two_shapes_needed() { return m_fUseTwoShapes; }
-    void create_two_shapes();
-    void create_one_shape();
     inline bool octave_shift_at_top() { return m_fPlaceAtTop; }
 
     void create_main_container_shape(int iShape);

--- a/include/lomse_score_layouter.h
+++ b/include/lomse_score_layouter.h
@@ -341,7 +341,8 @@ public:
 
     //StaffObj shapes
     GmoShape* create_staffobj_shape(ImoStaffObj* pSO, int iInstr, int iStaff,
-                                    UPoint pos, int clefType=0, unsigned flags=0);
+                                    UPoint pos, int clefType=0, int octaveShift=0,
+                                    unsigned flags=0);
     GmoShape* create_auxobj_shape(ImoAuxObj* pAO, int iInstr, int iStaff,
                                   GmoShape* pParentShape);
     GmoShape* create_invisible_shape(ImoObj* pSO, int iInstr, int iStaff,

--- a/include/lomse_shape_line.h
+++ b/include/lomse_shape_line.h
@@ -83,6 +83,7 @@ protected:
 
     friend class LineEngraver;
     friend class LyricEngraver;
+    friend class OctaveShiftEngraver;
     GmoShapeLine(ImoObj* pCreatorImo, ShapeId idx,
                  LUnits xStart, LUnits yStart, LUnits xEnd, LUnits yEnd,
                  LUnits uWidth, LUnits uBoundsExtraWidth, ELineStyle nStyle,

--- a/include/lomse_shape_octave_shift.h
+++ b/include/lomse_shape_octave_shift.h
@@ -55,6 +55,7 @@ class GmoShapeOctaveShift : public GmoCompositeShape
 {
 protected:
     bool m_fTwoLines;
+    bool m_fEndCorner;
     LUnits m_xLineStart;
     LUnits m_xLineEnd;
     LUnits m_yLineStart;
@@ -68,10 +69,7 @@ public:
     void on_draw(Drawer* pDrawer, RenderOptions& opt);
 
     void set_layout_data(LUnits xStart, LUnits xEnd, LUnits yStart, LUnits yEnd,
-                         LUnits uLineThick);
-    void add_label(GmoShapeText* pShape);
-//    inline void enable_final_jog(bool value) { m_fStopJog = value; }
-    inline void set_two_brackets() { m_fTwoLines = true; }
+                         LUnits uLineThick, bool fEndCorner);
 
     //support for handlers
     int get_num_handlers();
@@ -80,7 +78,6 @@ public:
     void on_end_of_handler_drag(int iHandler, UPoint newPos);
 
 protected:
-    void compute_bounds(LUnits xStart, LUnits xEnd, LUnits yPos);
 
 };
 

--- a/include/lomse_shape_octave_shift.h
+++ b/include/lomse_shape_octave_shift.h
@@ -1,0 +1,92 @@
+//---------------------------------------------------------------------------------------
+// This file is part of the Lomse library.
+// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice, this
+//      list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright notice, this
+//      list of conditions and the following disclaimer in the documentation and/or
+//      other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+// SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// For any comment, suggestion or feature request, please contact the manager of
+// the project at cecilios@users.sourceforge.net
+//---------------------------------------------------------------------------------------
+
+#ifndef __LOMSE_SHAPE_OCTAVE_SHIFT_H__        //to avoid nested includes
+#define __LOMSE_SHAPE_OCTAVE_SHIFT_H__
+
+#include "lomse_basic.h"
+#include "lomse_injectors.h"
+#include "lomse_engraver.h"
+#include "lomse_shape_base.h"
+#include "lomse_shape_text.h"
+#include "lomse_internal_model.h"
+
+#include "lomse_shape_base.h"
+#include "lomse_vertex_source.h"
+#include "agg_trans_affine.h"
+
+namespace lomse
+{
+
+//forward declarations
+class ImoObj;
+class GmoShapeBarline;
+class GmoShapeText;
+
+
+//---------------------------------------------------------------------------------------
+class GmoShapeOctaveShift : public GmoCompositeShape
+{
+protected:
+    bool m_fTwoLines;
+    LUnits m_xLineStart;
+    LUnits m_xLineEnd;
+    LUnits m_yLineStart;
+    LUnits m_yLineEnd;
+    LUnits m_uLineThick;
+
+public:
+    GmoShapeOctaveShift(ImoObj* pCreatorImo, ShapeId idx, Color color);
+    virtual ~GmoShapeOctaveShift();
+
+    void on_draw(Drawer* pDrawer, RenderOptions& opt);
+
+    void set_layout_data(LUnits xStart, LUnits xEnd, LUnits yStart, LUnits yEnd,
+                         LUnits uLineThick);
+    void add_label(GmoShapeText* pShape);
+//    inline void enable_final_jog(bool value) { m_fStopJog = value; }
+    inline void set_two_brackets() { m_fTwoLines = true; }
+
+    //support for handlers
+    int get_num_handlers();
+    UPoint get_handler_point(int i);
+    void on_handler_dragged(int iHandler, UPoint newPos);
+    void on_end_of_handler_drag(int iHandler, UPoint newPos);
+
+protected:
+    void compute_bounds(LUnits xStart, LUnits xEnd, LUnits yPos);
+
+};
+
+
+
+}   //namespace lomse
+
+#endif    // __LOMSE_SHAPE_OCTAVE_SHIFT_H__
+

--- a/include/lomse_shapes.h
+++ b/include/lomse_shapes.h
@@ -433,6 +433,19 @@ protected:
     }
 };
 
+//---------------------------------------------------------------------------------------
+class GmoShapeOctaveGlyph : public GmoShapeGlyph
+{
+protected:
+    friend class OctaveShiftEngraver;
+    GmoShapeOctaveGlyph(ImoObj* pCreatorImo, ShapeId idx, unsigned int iGlyph, UPoint pos,
+                        Color color, LibraryScope& libraryScope, double fontSize)
+        : GmoShapeGlyph(pCreatorImo, GmoObj::k_shape_octave_glyph, idx, iGlyph,
+                        pos, color, libraryScope, fontSize)
+    {
+    }
+};
+
 
 }   //namespace lomse
 

--- a/include/lomse_staffobjs_cursor.h
+++ b/include/lomse_staffobjs_cursor.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -68,6 +68,7 @@ private:
     std::vector<ColStaffObjsEntry*> m_clefs;
     std::vector<ColStaffObjsEntry*> m_keys;
     std::vector<ColStaffObjsEntry*> m_times;
+    std::vector<int> m_octave_shifts;
 
 public:
     StaffObjsCursor(ImoScore* pScore);
@@ -115,6 +116,7 @@ public:
     ImoTimeSignature* get_applicable_time_signature();
     ImoTimeSignature* get_time_signature_for_instrument(int iInstr);
     int get_applicable_clef_type();
+    int get_applicable_octave_shift();
     int get_clef_type_for_instr_staff(int iInstr, int iStaff);
     int get_applicable_key_type();
     int get_key_type_for_instr_staff(int iInstr, int iStaff);
@@ -140,6 +142,7 @@ protected:
     void save_key_signature();
     void save_time_signature();
     void save_barline();
+    void save_octave_shift(ImoDirection* pSO);
 
 };
 

--- a/include/lomse_staffobjs_cursor.h
+++ b/include/lomse_staffobjs_cursor.h
@@ -142,7 +142,8 @@ protected:
     void save_key_signature();
     void save_time_signature();
     void save_barline();
-    void save_octave_shift(ImoDirection* pSO);
+    void save_octave_shift_at_start(ImoStaffObj* pSO);
+    void save_octave_shift_at_end(ImoStaffObj* pSO);
 
 };
 

--- a/src/graphic_model/engravers/lomse_note_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_note_engraver.cpp
@@ -57,6 +57,7 @@ NoteEngraver::NoteEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
     : Engraver(libraryScope, pScoreMeter, iInstr, iStaff)
     , m_pNote(nullptr)
     , m_clefType(k_clef_undefined)
+    , m_octaveShift(0)
     , m_pShapesStorage(pShapesStorage)
     , m_fStemDown(false)
     , m_nPosOnStaff(0)
@@ -75,12 +76,13 @@ NoteEngraver::NoteEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* NoteEngraver::create_shape(ImoNote* pNote, int clefType, UPoint uPos,
-                                     Color color)
+GmoShape* NoteEngraver::create_shape(ImoNote* pNote, int clefType, int octaveShift,
+                                     UPoint uPos, Color color)
 {
     //save data and initialize
     m_pNote = pNote;
     m_clefType = clefType;
+    m_octaveShift = octaveShift;
     m_lineSpacing = m_pMeter->line_spacing_for_instr_staff(m_iInstr, m_iStaff);
     m_color = color;
     m_pNoteShape = nullptr;
@@ -363,6 +365,7 @@ int NoteEngraver::pitch_to_pos_on_staff(int clefType)
     //        etc.
 
     DiatonicPitch dpitch(m_pNote->get_step(), m_pNote->get_octave());
+    dpitch += m_octaveShift;
 
 	// pitch is defined. Position will depend on key
     switch (clefType)

--- a/src/graphic_model/engravers/lomse_octave_shift_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_octave_shift_engraver.cpp
@@ -1,0 +1,305 @@
+//---------------------------------------------------------------------------------------
+// This file is part of the Lomse library.
+// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice, this
+//      list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright notice, this
+//      list of conditions and the following disclaimer in the documentation and/or
+//      other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+// SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// For any comment, suggestion or feature request, please contact the manager of
+// the project at cecilios@users.sourceforge.net
+//---------------------------------------------------------------------------------------
+
+#include "lomse_octave_shift_engraver.h"
+
+#include "lomse_internal_model.h"
+#include "lomse_im_note.h"
+#include "lomse_engraving_options.h"
+//#include "lomse_shape_wedge.h"
+#include "lomse_score_meter.h"
+#include "lomse_instrument_engraver.h"
+
+
+namespace lomse
+{
+
+//---------------------------------------------------------------------------------------
+// OctaveShiftEngraver implementation
+//---------------------------------------------------------------------------------------
+OctaveShiftEngraver::OctaveShiftEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
+                           InstrumentEngraver* pInstrEngrv)
+    : RelObjEngraver(libraryScope, pScoreMeter)
+    , m_pInstrEngrv(pInstrEngrv)
+    , m_uStaffTopStart(0.0f)
+    , m_uStaffTopEnd(0.0f)
+    , m_numShapes(0)
+    , m_pOctaveShift(nullptr)
+    , m_fOctaveShiftAbove(false)
+    , m_uPrologWidth(0.0f)
+    , m_pStartDirection(nullptr)
+    , m_pEndDirection(nullptr)
+    , m_pStartDirectionShape(nullptr)
+    , m_pEndDirectionShape(nullptr)
+    , m_fTwoOctaveShifts(false)
+{
+}
+
+//---------------------------------------------------------------------------------------
+void OctaveShiftEngraver::set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
+                                       GmoShape* pStaffObjShape, int iInstr, int iStaff,
+                                       int iSystem, int iCol, LUnits UNUSED(xRight),
+                                       LUnits UNUSED(xLeft), LUnits yTop)
+{
+//    m_iInstr = iInstr;
+//    m_iStaff = iStaff;
+//    m_pOctaveShift = static_cast<ImoOctaveShift*>(pRO);
+//
+//    m_pStartDirection = static_cast<ImoDirection*>(pSO);
+//    m_pStartDirectionShape = static_cast<GmoShapeInvisible*>(pStaffObjShape);
+//
+//    m_shapesInfo[0].iCol = iCol;
+//    m_shapesInfo[0].iInstr = iInstr;
+//    m_shapesInfo[0].iSystem = iSystem;
+//
+//    m_points1[0].x = m_pStartDirectionShape->get_left();
+//    m_points1[0].y = yTop;
+//
+//    m_uStaffTopStart = yTop;
+}
+
+//---------------------------------------------------------------------------------------
+void OctaveShiftEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* pSO,
+                                     GmoShape* pStaffObjShape, int iInstr,
+                                     int UNUSED(iStaff), int iSystem, int iCol,
+                                     LUnits UNUSED(xRight), LUnits UNUSED(xLeft),
+                                     LUnits yTop)
+{
+//    m_pEndDirection = static_cast<ImoDirection*>(pSO);
+//    m_pEndDirectionShape = static_cast<GmoShapeInvisible*>(pStaffObjShape);
+//
+//    m_shapesInfo[1].iCol = iCol;
+//    m_shapesInfo[1].iInstr = iInstr;
+//    m_shapesInfo[1].iSystem = iSystem;
+//
+//    m_points1[1].x = m_pEndDirectionShape->get_left();
+//    m_points1[1].y = yTop;
+//
+//    m_uStaffTopEnd = yTop;
+}
+
+//---------------------------------------------------------------------------------------
+int OctaveShiftEngraver::create_shapes()
+{
+    return create_shapes( m_pOctaveShift->get_color() );
+}
+//---------------------------------------------------------------------------------------
+int OctaveShiftEngraver::create_shapes(Color color)
+{
+//    m_color = color;
+//    decide_placement();
+//    decide_if_one_or_two_wedges();
+//    if (two_wedges_needed())
+//        create_two_shapes();
+//    else
+//        create_one_shape();
+    return m_numShapes;
+}
+
+//---------------------------------------------------------------------------------------
+void OctaveShiftEngraver::create_one_shape()
+{
+    m_numShapes = 1;
+//    LUnits thickness = tenths_to_logical(LOMSE_WEDGE_LINE_THICKNESS);
+//
+//    compute_first_shape_position();
+//    //add_user_displacements(0, &m_points1[0]);
+//
+//    //determine if 'niente' circle should be drawn
+//    int niente = GmoShapeOctaveShift::k_no_niente;
+//    LUnits radius = 0.0f;
+//    if (m_pOctaveShift->is_niente())
+//    {
+//        niente = (m_pOctaveShift->is_crescendo() ? GmoShapeOctaveShift::k_niente_at_start
+//                                           : GmoShapeOctaveShift::k_niente_at_end);
+//        radius = tenths_to_logical(LOMSE_WEDGE_NIENTE_RADIUS);
+//    }
+//
+//    m_shapesInfo[0].pShape = LOMSE_NEW GmoShapeOctaveShift(m_pOctaveShift, 0, &m_points1[0],
+//                                                     thickness, m_pOctaveShift->get_color(),
+//                                                     niente, radius);
+//    m_shapesInfo[1].pShape = nullptr;
+}
+
+//---------------------------------------------------------------------------------------
+void OctaveShiftEngraver::create_two_shapes()
+{
+    m_numShapes = 2;
+//    LUnits thickness = tenths_to_logical(LOMSE_WEDGE_LINE_THICKNESS);
+//
+//    //determine if 'niente' circle should be drawn
+//    int niente1 = GmoShapeOctaveShift::k_no_niente;
+//    int niente2 = GmoShapeOctaveShift::k_no_niente;
+//    LUnits radius = 0.0f;
+//    if (m_pOctaveShift->is_niente())
+//    {
+//        radius = tenths_to_logical(LOMSE_WEDGE_NIENTE_RADIUS);
+//        if (m_pOctaveShift->is_crescendo())
+//            niente1 = GmoShapeOctaveShift::k_niente_at_start;
+//        else
+//            niente2 = GmoShapeOctaveShift::k_niente_at_end;
+//    }
+//
+//    //create first shape
+//    compute_first_shape_position();
+//    //add_user_displacements(0, &m_points1[0]);
+//    m_shapesInfo[0].pShape = LOMSE_NEW GmoShapeOctaveShift(m_pOctaveShift, 0, &m_points1[0],
+//                                                     thickness, m_pOctaveShift->get_color(),
+//                                                     niente1, radius);
+//    //create second shape
+//    compute_second_shape_position();
+//    //add_user_displacements(1, &m_points2[0]);
+//    m_shapesInfo[1].pShape = LOMSE_NEW GmoShapeOctaveShift(m_pOctaveShift, 0, &m_points2[0],
+//                                                     thickness, m_pOctaveShift->get_color(),
+//                                                     niente2, radius);
+}
+
+//---------------------------------------------------------------------------------------
+void OctaveShiftEngraver::compute_second_shape_position()
+{
+//    m_points2[0].x = m_pInstrEngrv->get_staves_left()+ m_uPrologWidth
+//                     - tenths_to_logical(10.0f);
+//    m_points2[2].x = m_points2[0].x;
+//    m_points2[1].x = m_pEndDirectionShape->get_left();
+//    m_points2[3].x = m_points2[1].x;
+//
+//    //determine center line of shape box
+//    LUnits yRef = m_uStaffTopEnd;
+//    if (m_fOctaveShiftAbove)
+//        yRef -= tenths_to_logical(50.0f);   //5 lines above top staff line
+//    else
+//        yRef += tenths_to_logical(90.0f);   //5 lines bellow first staff line
+//
+//    //determine spread to apply
+//    LUnits endSpread = tenths_to_logical(m_pOctaveShift->get_end_spread()) / 2.0f;
+//    LUnits startSpread = tenths_to_logical(m_pOctaveShift->get_start_spread()) / 2.0f;
+//    if (m_pOctaveShift->is_crescendo())
+//        startSpread = endSpread / 2.0f;
+//    else
+//        startSpread /= 2.0f;
+//
+//    //compute points
+//    m_points2[0].y = yRef - startSpread;
+//    m_points2[2].y = yRef + startSpread;
+//
+//    m_points2[1].y = yRef - endSpread;
+//    m_points2[3].y = yRef + endSpread;
+}
+
+//---------------------------------------------------------------------------------------
+void OctaveShiftEngraver::compute_first_shape_position()
+{
+//    //compute xLeft and xRight positions
+//    if (two_wedges_needed())
+//    {
+//        m_points1[0].x = m_pStartDirectionShape->get_left();    //xLeft at Direction tag
+//        m_points1[1].x = m_pInstrEngrv->get_staves_right();     //xRight at end of staff
+//    }
+//    else
+//    {
+//        m_points1[0].x = m_pStartDirectionShape->get_left();
+//        m_points1[1].x = m_pEndDirectionShape->get_left();
+//    }
+//    m_points1[2].x = m_points1[0].x;
+//    m_points1[3].x = m_points1[1].x;
+//
+//    //determine spread to apply
+//    LUnits startSpread = tenths_to_logical(m_pOctaveShift->get_start_spread()) / 2.0f;
+//    LUnits endSpread = tenths_to_logical(m_pOctaveShift->get_end_spread()) / 2.0f;
+//    if (two_wedges_needed())
+//    {
+//        if (m_pOctaveShift->is_crescendo())
+//            endSpread /= 2.0f;
+//        else
+//            endSpread = startSpread / 2.0f;
+//    }
+//
+//    //determine center line of shape box. yRef is referred to first staff
+//    LUnits yRef = m_uStaffTopStart;
+//    if (m_fOctaveShiftAbove)
+//        yRef -= tenths_to_logical(50.0f);   //5 lines above top staff line
+//    else
+//        yRef += tenths_to_logical(90.0f);   //5 lines bellow first staff line
+//
+//    //compute points
+//    m_points1[0].y = yRef - startSpread;
+//    m_points1[2].y = yRef + startSpread;
+//
+//    m_points1[1].y = yRef - endSpread;
+//    m_points1[3].y = yRef + endSpread;
+}
+
+//---------------------------------------------------------------------------------------
+void OctaveShiftEngraver::decide_placement()
+{
+//    //default is bellow
+//    m_fOctaveShiftAbove = (m_pStartDirection->get_placement() == k_placement_above);
+}
+
+//---------------------------------------------------------------------------------------
+void OctaveShiftEngraver::decide_if_one_or_two_wedges()
+{
+//    m_fTwoOctaveShifts = (m_shapesInfo[0].iSystem != m_shapesInfo[1].iSystem);
+}
+
+////---------------------------------------------------------------------------------------
+//void OctaveShiftEngraver::add_user_displacements(int iOctaveShift, UPoint* points)
+//{
+//    //ImoBezierInfo* pBezier = (iOctaveShift == 0 ? m_pOctaveShift->get_start_bezier()
+//    //                                    : m_pOctaveShift->get_stop_bezier() );
+//    //if (pBezier)
+//    //{
+//    //    for (int i=0; i < 4; i++)
+//    //    {
+//    //        (points+i)->x += tenths_to_logical(pBezier->get_point(i).x);
+//    //        (points+i)->y += tenths_to_logical(pBezier->get_point(i).y);
+//    //    }
+//    //}
+//}
+
+//---------------------------------------------------------------------------------------
+int OctaveShiftEngraver::get_num_shapes()
+{
+    return m_numShapes;
+}
+
+//---------------------------------------------------------------------------------------
+ShapeBoxInfo* OctaveShiftEngraver::get_shape_box_info(int i)
+{
+    return &m_shapesInfo[i];
+}
+
+//---------------------------------------------------------------------------------------
+void OctaveShiftEngraver::set_prolog_width(LUnits width)
+{
+    m_uPrologWidth += width;
+}
+
+
+}  //namespace lomse

--- a/src/graphic_model/engravers/lomse_octave_shift_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_octave_shift_engraver.cpp
@@ -33,6 +33,7 @@
 #include "lomse_im_note.h"
 #include "lomse_engraving_options.h"
 #include "lomse_shapes.h"
+#include "lomse_shape_note.h"
 #include "lomse_shape_octave_shift.h"
 #include "lomse_score_meter.h"
 #include "lomse_instrument_engraver.h"
@@ -46,7 +47,7 @@ namespace lomse
 // OctaveShiftEngraver implementation
 //---------------------------------------------------------------------------------------
 OctaveShiftEngraver::OctaveShiftEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                           InstrumentEngraver* pInstrEngrv)
+                                         InstrumentEngraver* pInstrEngrv)
     : RelObjEngraver(libraryScope, pScoreMeter)
     , m_pInstrEngrv(pInstrEngrv)
     , m_uStaffTopStart(0.0f)
@@ -54,10 +55,10 @@ OctaveShiftEngraver::OctaveShiftEngraver(LibraryScope& libraryScope, ScoreMeter*
     , m_numShapes(0)
     , m_pOctaveShift(nullptr)
     , m_uPrologWidth(0.0f)
-    , m_pStartDirection(nullptr)
-    , m_pEndDirection(nullptr)
-    , m_pStartDirectionShape(nullptr)
-    , m_pEndDirectionShape(nullptr)
+    , m_pStartNote(nullptr)
+    , m_pEndNote(nullptr)
+    , m_pStartNoteShape(nullptr)
+    , m_pEndNoteShape(nullptr)
     , m_fUseTwoShapes(false)
     , m_fPlaceAtTop(true)
 {
@@ -73,14 +74,14 @@ void OctaveShiftEngraver::set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
     m_iStaff = iStaff;
     m_pOctaveShift = static_cast<ImoOctaveShift*>(pRO);
 
-    m_pStartDirection = static_cast<ImoDirection*>(pSO);
-    m_pStartDirectionShape = static_cast<GmoShapeInvisible*>(pStaffObjShape);
+    m_pStartNote = static_cast<ImoNote*>(pSO);
+    m_pStartNoteShape = static_cast<GmoShapeNote*>(pStaffObjShape);
 
     m_shapesInfo[0].iCol = iCol;
     m_shapesInfo[0].iInstr = iInstr;
     m_shapesInfo[0].iSystem = iSystem;
 
-    m_points[0][0].x = m_pStartDirectionShape->get_left();
+    m_points[0][0].x = m_pStartNoteShape->get_left();
     m_points[0][0].y = yTop;
 
     m_uStaffTopStart = yTop;
@@ -93,14 +94,14 @@ void OctaveShiftEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* 
                                      LUnits UNUSED(xRight), LUnits UNUSED(xLeft),
                                      LUnits yTop)
 {
-    m_pEndDirection = static_cast<ImoDirection*>(pSO);
-    m_pEndDirectionShape = static_cast<GmoShapeInvisible*>(pStaffObjShape);
+    m_pEndNote = static_cast<ImoNote*>(pSO);
+    m_pEndNoteShape = static_cast<GmoShapeNote*>(pStaffObjShape);
 
     m_shapesInfo[1].iCol = iCol;
     m_shapesInfo[1].iInstr = iInstr;
     m_shapesInfo[1].iSystem = iSystem;
 
-    m_points[0][1].x = m_pEndDirectionShape->get_left();
+    m_points[0][1].x = m_pEndNoteShape->get_left();
     m_points[0][1].y = yTop;
 
     m_uStaffTopEnd = yTop;
@@ -223,13 +224,13 @@ void OctaveShiftEngraver::compute_first_shape_position()
     //compute xLeft and xRight positions
     if (two_shapes_needed())
     {
-        m_points[0][0].x = m_pStartDirectionShape->get_left();    //xLeft at Direction tag
+        m_points[0][0].x = m_pStartNoteShape->get_left();    //xLeft at Note tag
         m_points[0][1].x = m_pInstrEngrv->get_staves_right();     //xRight at end of staff
     }
     else
     {
-        m_points[0][0].x = m_pStartDirectionShape->get_left();
-        m_points[0][1].x = m_pEndDirectionShape->get_left();
+        m_points[0][0].x = m_pStartNoteShape->get_left();
+        m_points[0][1].x = m_pEndNoteShape->get_right();
     }
 
     //determine top line of shape box
@@ -248,7 +249,7 @@ void OctaveShiftEngraver::compute_second_shape_position()
     //compute xLeft and xRight positions
     m_points[1][0].x = m_pInstrEngrv->get_staves_left()+ m_uPrologWidth
                      - tenths_to_logical(10.0f);
-    m_points[1][1].x = m_pEndDirectionShape->get_left();
+    m_points[1][1].x = m_pEndNoteShape->get_right();
 
     //determine top line of shape box
     m_points[1][0].y = m_uStaffTopEnd;

--- a/src/graphic_model/engravers/lomse_octave_shift_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_octave_shift_engraver.cpp
@@ -32,9 +32,11 @@
 #include "lomse_internal_model.h"
 #include "lomse_im_note.h"
 #include "lomse_engraving_options.h"
-//#include "lomse_shape_wedge.h"
+#include "lomse_shapes.h"
+#include "lomse_shape_octave_shift.h"
 #include "lomse_score_meter.h"
 #include "lomse_instrument_engraver.h"
+#include "lomse_glyphs.h"
 
 
 namespace lomse
@@ -51,13 +53,13 @@ OctaveShiftEngraver::OctaveShiftEngraver(LibraryScope& libraryScope, ScoreMeter*
     , m_uStaffTopEnd(0.0f)
     , m_numShapes(0)
     , m_pOctaveShift(nullptr)
-    , m_fOctaveShiftAbove(false)
     , m_uPrologWidth(0.0f)
     , m_pStartDirection(nullptr)
     , m_pEndDirection(nullptr)
     , m_pStartDirectionShape(nullptr)
     , m_pEndDirectionShape(nullptr)
-    , m_fTwoOctaveShifts(false)
+    , m_fUseTwoShapes(false)
+    , m_fPlaceAtTop(true)
 {
 }
 
@@ -67,21 +69,21 @@ void OctaveShiftEngraver::set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
                                        int iSystem, int iCol, LUnits UNUSED(xRight),
                                        LUnits UNUSED(xLeft), LUnits yTop)
 {
-//    m_iInstr = iInstr;
-//    m_iStaff = iStaff;
-//    m_pOctaveShift = static_cast<ImoOctaveShift*>(pRO);
-//
-//    m_pStartDirection = static_cast<ImoDirection*>(pSO);
-//    m_pStartDirectionShape = static_cast<GmoShapeInvisible*>(pStaffObjShape);
-//
-//    m_shapesInfo[0].iCol = iCol;
-//    m_shapesInfo[0].iInstr = iInstr;
-//    m_shapesInfo[0].iSystem = iSystem;
-//
-//    m_points1[0].x = m_pStartDirectionShape->get_left();
-//    m_points1[0].y = yTop;
-//
-//    m_uStaffTopStart = yTop;
+    m_iInstr = iInstr;
+    m_iStaff = iStaff;
+    m_pOctaveShift = static_cast<ImoOctaveShift*>(pRO);
+
+    m_pStartDirection = static_cast<ImoDirection*>(pSO);
+    m_pStartDirectionShape = static_cast<GmoShapeInvisible*>(pStaffObjShape);
+
+    m_shapesInfo[0].iCol = iCol;
+    m_shapesInfo[0].iInstr = iInstr;
+    m_shapesInfo[0].iSystem = iSystem;
+
+    m_points[0][0].x = m_pStartDirectionShape->get_left();
+    m_points[0][0].y = yTop;
+
+    m_uStaffTopStart = yTop;
 }
 
 //---------------------------------------------------------------------------------------
@@ -91,17 +93,17 @@ void OctaveShiftEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* 
                                      LUnits UNUSED(xRight), LUnits UNUSED(xLeft),
                                      LUnits yTop)
 {
-//    m_pEndDirection = static_cast<ImoDirection*>(pSO);
-//    m_pEndDirectionShape = static_cast<GmoShapeInvisible*>(pStaffObjShape);
-//
-//    m_shapesInfo[1].iCol = iCol;
-//    m_shapesInfo[1].iInstr = iInstr;
-//    m_shapesInfo[1].iSystem = iSystem;
-//
-//    m_points1[1].x = m_pEndDirectionShape->get_left();
-//    m_points1[1].y = yTop;
-//
-//    m_uStaffTopEnd = yTop;
+    m_pEndDirection = static_cast<ImoDirection*>(pSO);
+    m_pEndDirectionShape = static_cast<GmoShapeInvisible*>(pStaffObjShape);
+
+    m_shapesInfo[1].iCol = iCol;
+    m_shapesInfo[1].iInstr = iInstr;
+    m_shapesInfo[1].iSystem = iSystem;
+
+    m_points[0][1].x = m_pEndDirectionShape->get_left();
+    m_points[0][1].y = yTop;
+
+    m_uStaffTopEnd = yTop;
 }
 
 //---------------------------------------------------------------------------------------
@@ -112,13 +114,13 @@ int OctaveShiftEngraver::create_shapes()
 //---------------------------------------------------------------------------------------
 int OctaveShiftEngraver::create_shapes(Color color)
 {
-//    m_color = color;
-//    decide_placement();
-//    decide_if_one_or_two_wedges();
-//    if (two_wedges_needed())
+    m_color = color;
+    decide_placement();
+    decide_if_one_or_two_shapes();
+//    if (two_shapes_needed())
 //        create_two_shapes();
 //    else
-//        create_one_shape();
+        create_one_shape();
     return m_numShapes;
 }
 
@@ -126,25 +128,15 @@ int OctaveShiftEngraver::create_shapes(Color color)
 void OctaveShiftEngraver::create_one_shape()
 {
     m_numShapes = 1;
-//    LUnits thickness = tenths_to_logical(LOMSE_WEDGE_LINE_THICKNESS);
-//
-//    compute_first_shape_position();
-//    //add_user_displacements(0, &m_points1[0]);
-//
-//    //determine if 'niente' circle should be drawn
-//    int niente = GmoShapeOctaveShift::k_no_niente;
-//    LUnits radius = 0.0f;
-//    if (m_pOctaveShift->is_niente())
-//    {
-//        niente = (m_pOctaveShift->is_crescendo() ? GmoShapeOctaveShift::k_niente_at_start
-//                                           : GmoShapeOctaveShift::k_niente_at_end);
-//        radius = tenths_to_logical(LOMSE_WEDGE_NIENTE_RADIUS);
-//    }
-//
-//    m_shapesInfo[0].pShape = LOMSE_NEW GmoShapeOctaveShift(m_pOctaveShift, 0, &m_points1[0],
-//                                                     thickness, m_pOctaveShift->get_color(),
-//                                                     niente, radius);
-//    m_shapesInfo[1].pShape = nullptr;
+
+    compute_first_shape_position();
+//    //add_user_displacements(0, &m_points[0][0]);
+
+    create_main_container_shape(0);
+    add_shape_numeral(0);
+    add_line_info(0);
+
+    m_shapesInfo[1].pShape = nullptr;
 }
 
 //---------------------------------------------------------------------------------------
@@ -168,8 +160,8 @@ void OctaveShiftEngraver::create_two_shapes()
 //
 //    //create first shape
 //    compute_first_shape_position();
-//    //add_user_displacements(0, &m_points1[0]);
-//    m_shapesInfo[0].pShape = LOMSE_NEW GmoShapeOctaveShift(m_pOctaveShift, 0, &m_points1[0],
+//    //add_user_displacements(0, &m_points[0][0]);
+//    m_shapesInfo[0].pShape = LOMSE_NEW GmoShapeOctaveShift(m_pOctaveShift, 0, &m_points[0][0],
 //                                                     thickness, m_pOctaveShift->get_color(),
 //                                                     niente1, radius);
 //    //create second shape
@@ -178,6 +170,107 @@ void OctaveShiftEngraver::create_two_shapes()
 //    m_shapesInfo[1].pShape = LOMSE_NEW GmoShapeOctaveShift(m_pOctaveShift, 0, &m_points2[0],
 //                                                     thickness, m_pOctaveShift->get_color(),
 //                                                     niente2, radius);
+}
+
+//---------------------------------------------------------------------------------------
+void OctaveShiftEngraver::create_main_container_shape(int iShape)
+{
+    ShapeId idx = iShape;
+    m_pMainShape[iShape] = LOMSE_NEW GmoShapeOctaveShift(m_pOctaveShift, idx,
+                                                    m_pOctaveShift->get_color());
+    m_shapesInfo[iShape].pShape = m_pMainShape[iShape];
+}
+
+//---------------------------------------------------------------------------------------
+void OctaveShiftEngraver::add_shape_numeral(int iShape)
+{
+    //determine glyph to use
+    int steps = m_pOctaveShift->get_shift_steps();
+    int iGlyph = find_glyph(steps);
+
+    //adjust position
+    Tenths yOffset = m_libraryScope.get_glyphs_table()->glyph_offset(iGlyph) + 10.0f;
+    LUnits y = m_points[0][0].y
+               + m_pMeter->tenths_to_logical(yOffset, m_iInstr, m_iStaff);
+
+    //determine font size to use
+    double fontSize = 16.0 * m_pMeter->line_spacing_for_instr_staff(m_iInstr, m_iStaff) / 180.0;
+
+   //create the shape
+    GmoShape* pShape =
+        LOMSE_NEW GmoShapeOctaveGlyph(m_pOctaveShift, 0, iGlyph, UPoint(m_points[0][0].x, y),
+                                      m_color, m_libraryScope, fontSize);
+    m_pShapeNumeral[iShape] = pShape;
+
+    m_pMainShape[iShape]->add(pShape);
+}
+
+//---------------------------------------------------------------------------------------
+void OctaveShiftEngraver::add_line_info(int iShape)
+{
+    //start point
+    LUnits xStart = m_points[iShape][0].x + m_pShapeNumeral[iShape]->get_width()
+                    + tenths_to_logical(LOMSE_OCTAVE_SHIFT_SPACE_TO_LINE);
+
+    LUnits yStart = m_points[iShape][0].y - tenths_to_logical(LOMSE_OCTAVE_SHIFT_LINE_SHIFT);
+    if (!octave_shift_at_top())
+        yStart += m_pShapeNumeral[iShape]->get_height();
+
+    //locate last applicable note in this instr/staff
+
+    //end point
+    LUnits xEnd = m_points[iShape][1].x;
+    LUnits yEnd = yStart + (octave_shift_at_top() ? 200.0f : -200.0f);
+
+    LUnits thickness = tenths_to_logical(LOMSE_OCTAVE_SHIFT_LINE_THICKNESS);
+
+    m_pMainShape[iShape]->set_layout_data(xStart, xEnd, yStart, yEnd, thickness);
+}
+
+//---------------------------------------------------------------------------------------
+int OctaveShiftEngraver::find_glyph(int shift)
+{
+    // returns the index (over global glyphs table) to the character to use to print
+    // the numeral at the start
+
+    if (shift == 14)
+        return k_glyph_quindicesimaBassaMb;     //15mb
+    else if (shift == 7)
+        return k_glyph_ottavaBassaBa;           //8ba
+    else if (shift == -7)
+        return k_glyph_ottavaAlta;              //8va
+    else if (shift == -14)
+        return k_glyph_quindicesimaAlta;        //15ma
+    else
+    {
+        LOMSE_LOG_ERROR("Octave shift not defined (%d). '22' numeral used.", shift);
+        return k_glyph_ventiduesima;
+    }
+}
+
+//---------------------------------------------------------------------------------------
+void OctaveShiftEngraver::compute_first_shape_position()
+{
+    //compute xLeft and xRight positions
+    if (two_shapes_needed())
+    {
+        m_points[0][0].x = m_pStartDirectionShape->get_left();    //xLeft at Direction tag
+        m_points[0][1].x = m_pInstrEngrv->get_staves_right();     //xRight at end of staff
+    }
+    else
+    {
+        m_points[0][0].x = m_pStartDirectionShape->get_left();
+        m_points[0][1].x = m_pEndDirectionShape->get_left();
+    }
+
+    //determine top line of shape box
+    m_points[0][0].y = m_uStaffTopStart;
+    if (octave_shift_at_top())
+        m_points[0][0].y -= tenths_to_logical(40.0f);   //4 lines above top staff line
+    else
+        m_points[0][0].y += tenths_to_logical(80.0f);   //4 lines bellow first staff line
+
+    m_points[0][1].y = m_points[0][0].y;
 }
 
 //---------------------------------------------------------------------------------------
@@ -213,59 +306,15 @@ void OctaveShiftEngraver::compute_second_shape_position()
 }
 
 //---------------------------------------------------------------------------------------
-void OctaveShiftEngraver::compute_first_shape_position()
-{
-//    //compute xLeft and xRight positions
-//    if (two_wedges_needed())
-//    {
-//        m_points1[0].x = m_pStartDirectionShape->get_left();    //xLeft at Direction tag
-//        m_points1[1].x = m_pInstrEngrv->get_staves_right();     //xRight at end of staff
-//    }
-//    else
-//    {
-//        m_points1[0].x = m_pStartDirectionShape->get_left();
-//        m_points1[1].x = m_pEndDirectionShape->get_left();
-//    }
-//    m_points1[2].x = m_points1[0].x;
-//    m_points1[3].x = m_points1[1].x;
-//
-//    //determine spread to apply
-//    LUnits startSpread = tenths_to_logical(m_pOctaveShift->get_start_spread()) / 2.0f;
-//    LUnits endSpread = tenths_to_logical(m_pOctaveShift->get_end_spread()) / 2.0f;
-//    if (two_wedges_needed())
-//    {
-//        if (m_pOctaveShift->is_crescendo())
-//            endSpread /= 2.0f;
-//        else
-//            endSpread = startSpread / 2.0f;
-//    }
-//
-//    //determine center line of shape box. yRef is referred to first staff
-//    LUnits yRef = m_uStaffTopStart;
-//    if (m_fOctaveShiftAbove)
-//        yRef -= tenths_to_logical(50.0f);   //5 lines above top staff line
-//    else
-//        yRef += tenths_to_logical(90.0f);   //5 lines bellow first staff line
-//
-//    //compute points
-//    m_points1[0].y = yRef - startSpread;
-//    m_points1[2].y = yRef + startSpread;
-//
-//    m_points1[1].y = yRef - endSpread;
-//    m_points1[3].y = yRef + endSpread;
-}
-
-//---------------------------------------------------------------------------------------
 void OctaveShiftEngraver::decide_placement()
 {
-//    //default is bellow
-//    m_fOctaveShiftAbove = (m_pStartDirection->get_placement() == k_placement_above);
+    m_fPlaceAtTop = m_pOctaveShift->get_shift_steps() < 0;
 }
 
 //---------------------------------------------------------------------------------------
-void OctaveShiftEngraver::decide_if_one_or_two_wedges()
+void OctaveShiftEngraver::decide_if_one_or_two_shapes()
 {
-//    m_fTwoOctaveShifts = (m_shapesInfo[0].iSystem != m_shapesInfo[1].iSystem);
+    m_fUseTwoShapes = (m_shapesInfo[0].iSystem != m_shapesInfo[1].iSystem);
 }
 
 ////---------------------------------------------------------------------------------------

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -62,6 +62,7 @@
 #include "lomse_lyric_engraver.h"
 #include "lomse_metronome_engraver.h"
 #include "lomse_note_engraver.h"
+#include "lomse_octave_shift_engraver.h"
 #include "lomse_ornament_engraver.h"
 #include "lomse_rest_engraver.h"
 #include "lomse_slur_engraver.h"
@@ -993,7 +994,8 @@ ShapesCreator::ShapesCreator(LibraryScope& libraryScope, ScoreMeter* pScoreMeter
 
 //---------------------------------------------------------------------------------------
 GmoShape* ShapesCreator::create_staffobj_shape(ImoStaffObj* pSO, int iInstr, int iStaff,
-                                               UPoint pos, int clefType, unsigned flags)
+                                               UPoint pos, int clefType, int octaveShift,
+                                               unsigned flags)
 {
     //factory method to create shapes for staffobjs
 
@@ -1037,7 +1039,7 @@ GmoShape* ShapesCreator::create_staffobj_shape(ImoStaffObj* pSO, int iInstr, int
             NoteEngraver engrv(m_libraryScope, m_pScoreMeter, &m_shapesStorage,
                                iInstr, iStaff);
             Color color = pImo->get_color();
-            GmoShape* pShape = engrv.create_shape(pImo, clefType, pos, color);
+            GmoShape* pShape = engrv.create_shape(pImo, clefType, octaveShift, pos, color);
 
             //AWARE: Chords are an exception to the way relations are engraved. This
             //is because chords affect to note positions (reverse noteheads, shift
@@ -1239,6 +1241,12 @@ void ShapesCreator::start_engraving_relobj(ImoRelObj* pRO,
         case k_imo_wedge:
         {
             pEngrv = LOMSE_NEW WedgeEngraver(m_libraryScope, m_pScoreMeter, pInstrEngrv);   //xLeft, xRight);
+            break;
+        }
+
+        case k_imo_octave_shift:
+        {
+            pEngrv = LOMSE_NEW OctaveShiftEngraver(m_libraryScope, m_pScoreMeter, pInstrEngrv);   //xLeft, xRight);
             break;
         }
 

--- a/src/graphic_model/layouters/lomse_spacing_algorithm.cpp
+++ b/src/graphic_model/layouters/lomse_spacing_algorithm.cpp
@@ -362,7 +362,7 @@ void ColumnsBuilder::collect_content_for_this_column()
                 unsigned flags = fInProlog ? 0 : ShapesCreator::k_flag_small_clef;
                 int clefType = pClef->get_clef_type();
                 pShape = m_pShapesCreator->create_staffobj_shape(pSO, iInstr, iStaff,
-                         m_pagePos, clefType, flags);
+                         m_pagePos, clefType, 0, flags);
                 pShape->assign_id_as_main_shape();
                 m_pSpAlgorithm->include_object(m_pSysCursor->cur_entry(), m_iColumn,
                                                iLine, iInstr, pSO, -1.0f, iStaff,
@@ -376,7 +376,7 @@ void ColumnsBuilder::collect_content_for_this_column()
                 bool fInProlog = determine_if_is_in_prolog(pSO, rTime, iInstr, idx);
                 int clefType = m_pSysCursor->get_applicable_clef_type();
                 pShape = m_pShapesCreator->create_staffobj_shape(pSO, iInstr, iStaff,
-                         m_pagePos, clefType, flags);
+                         m_pagePos, clefType, 0, flags);
                 pShape->assign_id_as_main_or_implicit_shape(iStaff);
                 m_pSpAlgorithm->include_object(m_pSysCursor->cur_entry(), m_iColumn,
                                                iLine, iInstr, pSO, -1.0f, iStaff,
@@ -386,8 +386,9 @@ void ColumnsBuilder::collect_content_for_this_column()
             else
             {
                 int clefType = m_pSysCursor->get_applicable_clef_type();
+                int octaveShift = m_pSysCursor->get_applicable_octave_shift();
                 pShape = m_pShapesCreator->create_staffobj_shape(pSO, iInstr, iStaff,
-                         m_pagePos, clefType);
+                         m_pagePos, clefType, octaveShift);
                 TimeUnits time = (pSO->is_spacer() ? -1.0f : rTime);
                 m_pSpAlgorithm->include_object(m_pSysCursor->cur_entry(), m_iColumn,
                                                iLine, iInstr, pSO, time, iStaff, pShape);

--- a/src/graphic_model/layouters/lomse_staffobjs_cursor.cpp
+++ b/src/graphic_model/layouters/lomse_staffobjs_cursor.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -68,6 +68,7 @@ void StaffObjsCursor::initialize_clefs_keys_times(ImoScore* pScore)
     m_clefs.assign(m_numStaves, (ColStaffObjsEntry*)nullptr);     //GCC complains if nullptr not casted
     m_keys.assign(m_numStaves, (ColStaffObjsEntry*)nullptr);
     m_times.assign(m_numInstruments, (ColStaffObjsEntry*)nullptr);
+    m_octave_shifts.assign(m_numStaves, 0);
 }
 
 //---------------------------------------------------------------------------------------
@@ -82,6 +83,8 @@ void StaffObjsCursor::move_next()
         save_time_signature();
     else if (pSO->is_barline())
         save_barline();
+    else if (pSO->is_direction())
+        save_octave_shift( static_cast<ImoDirection*>(pSO) );
 
     ++m_scoreIt;
 }
@@ -92,6 +95,31 @@ void StaffObjsCursor::save_clef()
     int iInstr = num_instrument();
     int idx = m_staffIndex[iInstr] + staff();
     m_clefs[idx] = *m_scoreIt;
+}
+
+//---------------------------------------------------------------------------------------
+void StaffObjsCursor::save_octave_shift(ImoDirection* pSO)
+{
+    int steps = 0;
+    if (pSO->get_num_relations() > 0)
+    {
+        ImoRelations* pRelObjs = pSO->get_relations();
+        list<ImoRelObj*>& relObjs = pRelObjs->get_relations();
+        list<ImoRelObj*>::iterator it;
+        for(it = relObjs.begin(); it != relObjs.end(); ++it)
+        {
+            ImoRelObj* pRO = static_cast<ImoRelObj*>(*it);
+
+            if (pRO->is_octave_shift())
+            {
+		        if (pSO == pRO->get_start_object())
+		            steps = static_cast<ImoOctaveShift*>(pRO)->get_shift_steps();
+            }
+        }
+    }
+
+    int idx = m_staffIndex[num_instrument()] + staff();
+    m_octave_shifts[idx] = steps;
 }
 
 //---------------------------------------------------------------------------------------
@@ -164,6 +192,13 @@ int StaffObjsCursor::get_applicable_clef_type()
         return k_clef_undefined;
     else
         return get_clef_type_for_instr_staff( num_instrument(), staff() );
+}
+
+//---------------------------------------------------------------------------------------
+int StaffObjsCursor::get_applicable_octave_shift()
+{
+    int idx = m_staffIndex[num_instrument()] + staff();
+    return m_octave_shifts[idx];
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/layouters/lomse_system_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_system_layouter.cpp
@@ -649,10 +649,11 @@ void SystemLayouter::engrave_attached_objects(ImoStaffObj* pSO, GmoShape* pMainS
     if (pSO->get_num_relations() > 0)
     {
         ImoRelations* pRelObjs = pSO->get_relations();
-        int size = pRelObjs->get_num_items();
-	    for (int i=0; i < size; ++i)
-	    {
-            ImoRelObj* pRO = pRelObjs->get_item(i);
+        list<ImoRelObj*>& relObjs = pRelObjs->get_relations();
+        list<ImoRelObj*>::iterator it;
+        for(it = relObjs.begin(); it != relObjs.end(); ++it)
+        {
+            ImoRelObj* pRO = static_cast<ImoRelObj*>(*it);
 
             if (!pRO->is_chord())
             {

--- a/src/graphic_model/layouters/lomse_system_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_system_layouter.cpp
@@ -657,7 +657,24 @@ void SystemLayouter::engrave_attached_objects(ImoStaffObj* pSO, GmoShape* pMainS
 
             if (!pRO->is_chord())
             {
-		        if (pSO == pRO->get_start_object())
+                //special case: start and end in the same object
+		        if (pSO == pRO->get_start_object() && pSO == pRO->get_end_object())
+		        {
+                    m_pShapesCreator->start_engraving_relobj(pRO, pSO, pMainShape,
+                                                            iInstr, iStaff, iSystem, iCol,
+                                                            iLine, pInstr);
+
+                    SystemLayouter* pSysLyt = m_pScoreLyt->get_system_layouter(iSystem);
+                    LUnits prologWidth( pSysLyt->get_prolog_width() );
+
+                    m_pShapesCreator->finish_engraving_relobj(pRO, pSO, pMainShape,
+                                                            iInstr, iStaff, iSystem, iCol,
+                                                            iLine, prologWidth, pInstr);
+                    add_relobjs_shapes_to_model(pRO, GmoShape::k_layer_aux_objs);
+		        }
+
+		        //normal cases: start and end in different objects
+		        else if (pSO == pRO->get_start_object())
                     m_pShapesCreator->start_engraving_relobj(pRO, pSO, pMainShape,
                                                             iInstr, iStaff, iSystem, iCol,
                                                             iLine, pInstr);

--- a/src/graphic_model/lomse_glyphs.cpp
+++ b/src/graphic_model/lomse_glyphs.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -218,9 +218,6 @@ const GlyphData m_glyphs_smufl[] =
     GlyphData(0xE048),  // Coda sign
     GlyphData(0xE047),  // Segno sign
 
-//Octaves (U+E510 - U+E51F)
-    GlyphData(0xE510),  // Ottava alta sign
-
 //figured bass (U+EA50 - U+EA6F)
     GlyphData(0xEA50),  // Figured bass. Number 0
     GlyphData(0xEA51),  // Figured bass. Number 1
@@ -304,6 +301,24 @@ const GlyphData m_glyphs_smufl[] =
     GlyphData(0xE222),  // Combining tremolo 3
     GlyphData(0xE223),  // Combining tremolo 4
     GlyphData(0xE224),  // Combining tremolo 5
+
+//Octaves (U+E510 - U+E51F)
+    GlyphData(0xE510),  //Ottava: 8
+    GlyphData(0xE511),  //Ottava alta: 8va ('va' at top)
+    GlyphData(0xE512),  //Ottava bassa: 8va ('va' at bottom)
+    GlyphData(0xE513),  //Ottava bassa: 8ba
+    GlyphData(0xE514),  //Quindicesima: 15
+    GlyphData(0xE515),  //Quindicesima alta: 15ma ('ma' at top)
+    GlyphData(0xE516),  //Quindicesima bassa: 15ma ('ma' at bottom)
+    GlyphData(0xE517),  //Ventiduesima: 22
+    GlyphData(0xE518),  //Ventiduesima alta: 22ma ('ma' at top)
+    GlyphData(0xE519),  //Ventiduesima bassa: 22ma ('ma' at bottom)
+    GlyphData(0xE51A),  //Left parenthesis for octave signs
+    GlyphData(0xE51B),  //Right parenthesis for octave signs
+    GlyphData(0xE51C),  //Ottava bassa: 8vb
+    GlyphData(0xE51D),  //Quindicesima bassa: 15mb
+    GlyphData(0xE51E),  //Ventiduesima bassa: 22mb
+    GlyphData(0xE51F),  //'bassa' word
 
 //Brass techniques (U+E5D0 - U+E5EF)
     GlyphData(0xE5D0),  // Scoop

--- a/src/graphic_model/lomse_gm_basic.cpp
+++ b/src/graphic_model/lomse_gm_basic.cpp
@@ -202,6 +202,8 @@ const string& GmoObj::get_name(int objtype)
         m_typeToName[k_shape_metronome_mark]    = "metronome-mark ";
         m_typeToName[k_shape_note]              = "note           ";
         m_typeToName[k_shape_notehead]          = "notehead       ";
+        m_typeToName[k_shape_octave_shift]      = "octave-shift   ";
+        m_typeToName[k_shape_octave_glyph]      = "octave-glyph   ";
         m_typeToName[k_shape_ornament]          = "ornament       ";
         m_typeToName[k_shape_rectangle]         = "rectangle      ";
         m_typeToName[k_shape_rest]              = "rest           ";

--- a/src/graphic_model/lomse_shape_octave_shift.cpp
+++ b/src/graphic_model/lomse_shape_octave_shift.cpp
@@ -1,0 +1,152 @@
+//---------------------------------------------------------------------------------------
+// This file is part of the Lomse library.
+// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice, this
+//      list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright notice, this
+//      list of conditions and the following disclaimer in the documentation and/or
+//      other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+// SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// For any comment, suggestion or feature request, please contact the manager of
+// the project at cecilios@users.sourceforge.net
+//---------------------------------------------------------------------------------------
+
+#include "lomse_shape_octave_shift.h"
+
+#include "lomse_score_meter.h"
+#include "lomse_engraving_options.h"
+#include "lomse_gm_basic.h"
+#include "lomse_drawer.h"
+
+#include <cmath>   //abs
+
+namespace lomse
+{
+
+
+//=======================================================================================
+// GmoShapeOctaveShift implementation
+//=======================================================================================
+GmoShapeOctaveShift::GmoShapeOctaveShift(ImoObj* pCreatorImo, ShapeId idx, Color color)
+    : GmoCompositeShape(pCreatorImo, GmoObj::k_shape_octave_shift, idx, color)
+    , m_fTwoLines(false)
+    , m_xLineStart(0.0f)
+    , m_xLineEnd(0.0f)
+    , m_yLineStart(0.0f)
+    , m_yLineEnd(0.0f)
+    , m_uLineThick(0.0f)
+{
+}
+
+//---------------------------------------------------------------------------------------
+GmoShapeOctaveShift::~GmoShapeOctaveShift()
+{
+}
+
+//---------------------------------------------------------------------------------------
+void GmoShapeOctaveShift::set_layout_data(LUnits xStart, LUnits xEnd, LUnits yStart,
+                                          LUnits yEnd, LUnits uLineThick)
+{
+    //save data
+    m_xLineStart = xStart;
+    m_xLineEnd = xEnd;
+    m_yLineStart = yStart;
+    m_yLineEnd = yEnd;
+    m_uLineThick = uLineThick;
+
+//    compute_bounds(xStart, xEnd, yPos);       //TODO
+}
+
+//---------------------------------------------------------------------------------------
+void GmoShapeOctaveShift::on_draw(Drawer* pDrawer, RenderOptions& opt)
+{
+    Color color = determine_color_to_use(opt);      //Color(255,0,0);
+
+    LUnits dxLine = 100.0f;
+    LUnits dxSpace = 100.0f;
+
+    pDrawer->begin_path();
+    pDrawer->fill_none();
+    pDrawer->stroke(color);
+    pDrawer->stroke_width(m_uLineThick);
+
+    //horizontal line
+    pDrawer->move_to(m_xLineStart, m_yLineStart);
+    LUnits xPos = m_xLineStart + dxLine;
+    while (xPos < m_xLineEnd)
+    {
+        pDrawer->hline_to(xPos);
+        xPos += dxSpace;
+        pDrawer->move_to(xPos, m_yLineStart);
+        xPos += dxLine;
+    }
+
+    //vertical line
+    xPos -= (dxLine + dxSpace);
+    pDrawer->move_to(xPos, m_yLineStart);       //to end of last stroke
+    pDrawer->hline_to(m_xLineEnd);              //continue it to end point
+    pDrawer->vline_to(m_yLineEnd);              //add vertical stroke
+
+    pDrawer->end_path();
+    pDrawer->render();
+
+    GmoCompositeShape::on_draw(pDrawer, opt);
+}
+
+//---------------------------------------------------------------------------------------
+void GmoShapeOctaveShift::compute_bounds(LUnits xStart, LUnits xEnd, LUnits yPos)
+{
+//TODO
+//    m_origin.x = xStart;
+//    m_size.width = abs(xEnd - xStart);
+//    m_origin.y = yPos;
+//
+//    if (m_pShapeText)
+//        m_size.height = max(m_uJogLength, m_pShapeText->get_height());
+//    else
+//        m_size.height = m_uJogLength;
+}
+
+//---------------------------------------------------------------------------------------
+int GmoShapeOctaveShift::get_num_handlers()
+{
+    return 4;
+}
+
+//---------------------------------------------------------------------------------------
+UPoint GmoShapeOctaveShift::get_handler_point(int UNUSED(i))
+{
+    //TODO
+    return UPoint(0.0f, 0.0f);
+}
+
+//---------------------------------------------------------------------------------------
+void GmoShapeOctaveShift::on_handler_dragged(int UNUSED(iHandler), UPoint UNUSED(newPos))
+{
+    //TODO
+}
+
+//---------------------------------------------------------------------------------------
+void GmoShapeOctaveShift::on_end_of_handler_drag(int UNUSED(iHandler), UPoint UNUSED(newPos))
+{
+    //TODO
+}
+
+
+}  //namespace lomse

--- a/src/graphic_model/lomse_shape_octave_shift.cpp
+++ b/src/graphic_model/lomse_shape_octave_shift.cpp
@@ -46,6 +46,7 @@ namespace lomse
 GmoShapeOctaveShift::GmoShapeOctaveShift(ImoObj* pCreatorImo, ShapeId idx, Color color)
     : GmoCompositeShape(pCreatorImo, GmoObj::k_shape_octave_shift, idx, color)
     , m_fTwoLines(false)
+    , m_fEndCorner(true)
     , m_xLineStart(0.0f)
     , m_xLineEnd(0.0f)
     , m_yLineStart(0.0f)
@@ -61,7 +62,7 @@ GmoShapeOctaveShift::~GmoShapeOctaveShift()
 
 //---------------------------------------------------------------------------------------
 void GmoShapeOctaveShift::set_layout_data(LUnits xStart, LUnits xEnd, LUnits yStart,
-                                          LUnits yEnd, LUnits uLineThick)
+                                          LUnits yEnd, LUnits uLineThick, bool fEndCorner)
 {
     //save data
     m_xLineStart = xStart;
@@ -69,8 +70,10 @@ void GmoShapeOctaveShift::set_layout_data(LUnits xStart, LUnits xEnd, LUnits ySt
     m_yLineStart = yStart;
     m_yLineEnd = yEnd;
     m_uLineThick = uLineThick;
+    m_fEndCorner = fEndCorner;
 
-//    compute_bounds(xStart, xEnd, yPos);       //TODO
+    //fix bounds
+    m_size.width = abs(xEnd - m_origin.x);
 }
 
 //---------------------------------------------------------------------------------------
@@ -96,31 +99,18 @@ void GmoShapeOctaveShift::on_draw(Drawer* pDrawer, RenderOptions& opt)
         pDrawer->move_to(xPos, m_yLineStart);
         xPos += dxLine;
     }
-
-    //vertical line
     xPos -= (dxLine + dxSpace);
     pDrawer->move_to(xPos, m_yLineStart);       //to end of last stroke
     pDrawer->hline_to(m_xLineEnd);              //continue it to end point
-    pDrawer->vline_to(m_yLineEnd);              //add vertical stroke
+
+    //end corner
+    if (m_fEndCorner)
+        pDrawer->vline_to(m_yLineEnd);      //add vertical stroke
 
     pDrawer->end_path();
     pDrawer->render();
 
     GmoCompositeShape::on_draw(pDrawer, opt);
-}
-
-//---------------------------------------------------------------------------------------
-void GmoShapeOctaveShift::compute_bounds(LUnits xStart, LUnits xEnd, LUnits yPos)
-{
-//TODO
-//    m_origin.x = xStart;
-//    m_size.width = abs(xEnd - xStart);
-//    m_origin.y = yPos;
-//
-//    if (m_pShapeText)
-//        m_size.height = max(m_uJogLength, m_pShapeText->get_height());
-//    else
-//        m_size.height = m_uJogLength;
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/internal_model/lomse_im_factory.cpp
+++ b/src/internal_model/lomse_im_factory.cpp
@@ -95,6 +95,8 @@ ImoObj* ImFactory::inject(int type, Document* pDoc, ImoId id)
         case k_imo_multicolumn:         pObj = LOMSE_NEW ImoMultiColumn(pDoc);    break;
         case k_imo_music_data:          pObj = LOMSE_NEW ImoMusicData();          break;
         case k_imo_note:                pObj = LOMSE_NEW ImoNote();               break;
+        case k_imo_octave_shift:        pObj = LOMSE_NEW ImoOctaveShift();        break;
+        case k_imo_octave_shift_dto:    pObj = LOMSE_NEW ImoOctaveShiftDto();     break;
         case k_imo_option:              pObj = LOMSE_NEW ImoOptionInfo();         break;
         case k_imo_options:             pObj = LOMSE_NEW ImoOptions();            break;
         case k_imo_ornament:            pObj = LOMSE_NEW ImoOrnament();           break;

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -488,6 +488,8 @@ const string& ImoObj::get_name(int type)
         m_TypeToName[k_imo_line_style] = "line-style";
         m_TypeToName[k_imo_lyrics_text_info] = "lyric-text";
         m_TypeToName[k_imo_midi_info] = "midi-info";
+        m_TypeToName[k_imo_octave_shift] = "octave-shift";
+        m_TypeToName[k_imo_octave_shift_dto] = "octave-shift-dto";
         m_TypeToName[k_imo_option] = "opt";
         m_TypeToName[k_imo_page_info] = "page-info";
         m_TypeToName[k_imo_param_info] = "param";
@@ -552,6 +554,7 @@ const string& ImoObj::get_name(int type)
         // ImoRelObj (A)
         m_TypeToName[k_imo_beam] = "beam";
         m_TypeToName[k_imo_chord] = "chord";
+        m_TypeToName[k_imo_octave_shift] = "octave-shift";
         m_TypeToName[k_imo_slur] = "slur";
         m_TypeToName[k_imo_tie] = "tie";
         m_TypeToName[k_imo_tuplet] = "tuplet";
@@ -1859,7 +1862,7 @@ int ImoRelations::get_priority(int type)
         priority[k_imo_fermata] = 6;
         priority[k_imo_text_repetition_mark] = 7;
         priority[k_imo_wedge] = 8;
-
+        priority[k_imo_octave_shift] = 8;
         fMapInitialized = true;
     };
 
@@ -5438,46 +5441,13 @@ void ImoVoltaBracket::reorganize_after_object_deletion()
 
 
 //=======================================================================================
-// ImoSlur implementation
+// ImoWedge implementation
 //=======================================================================================
-//ImoNote* ImoWedge::get_start_note()
-//{
-//    return static_cast<ImoNote*>( get_start_object() );
-//}
-//
-////---------------------------------------------------------------------------------------
-//ImoNote* ImoWedge::get_end_note()
-//{
-//    return static_cast<ImoNote*>( get_end_object() );
-//}
-
-//---------------------------------------------------------------------------------------
 void ImoWedge::reorganize_after_object_deletion()
 {
-    //TODO
     //Nothing to do. As a wedge involves only two objects, the wedge is removed when
-    //one of the ImoDirections is deleted. Also, in note destructor, the other note is informed.
+    //one of the ImoDirections is deleted.
 }
-
-
-
-////=======================================================================================
-//// ImoWedgeData implementation
-////=======================================================================================
-//ImoWedgeData::ImoWedgeData(ImoWedgeDto* pDto)
-//    : ImoRelDataObj(k_imo_wedge_data)
-//    , m_fStart( pDto->is_start() )
-//    , m_slurNum( pDto->get_slur_number() )
-//    , m_orientation(k_orientation_default)
-//    , m_pBezier(nullptr)
-//{
-//}
-
-////---------------------------------------------------------------------------------------
-//ImoWedgeData::~ImoWedgeData()
-//{
-//    delete m_pBezier;
-//}
 
 //=======================================================================================
 // ImoWedgeDto implementation
@@ -5485,6 +5455,17 @@ void ImoWedge::reorganize_after_object_deletion()
 ImoWedgeDto::~ImoWedgeDto()
 {
 }
+
+
+//=======================================================================================
+// ImoOctaveShift implementation
+//=======================================================================================
+void ImoOctaveShift::reorganize_after_object_deletion()
+{
+    //Nothing to do. As an octave-shift involves only two objects, the wedge is removed when
+    //one of the ImoDirections is deleted.
+}
+
 
 
 

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -2639,10 +2639,7 @@ public:
                 || m_childToAnalyse.name() == "words"
                 || m_childToAnalyse.name() == "coda"
                 || m_childToAnalyse.name() == "dynamics"
-                || m_childToAnalyse.name() == "dashes"
-                || m_childToAnalyse.name() == "bracket"
                 || m_childToAnalyse.name() == "metronome"
-                || m_childToAnalyse.name() == "octave-shift"
                 || m_childToAnalyse.name() == "harp-pedals"
                 || m_childToAnalyse.name() == "damp"
                 || m_childToAnalyse.name() == "damp-all"
@@ -2650,7 +2647,6 @@ public:
                 || m_childToAnalyse.name() == "string-mute"
                 || m_childToAnalyse.name() == "scordatura"
                 || m_childToAnalyse.name() == "image"
-                || m_childToAnalyse.name() == "principal-voice"
                 || m_childToAnalyse.name() == "accordion-registration"
                 || m_childToAnalyse.name() == "percussion"
                 || m_childToAnalyse.name() == "other-direction"
@@ -2659,7 +2655,11 @@ public:
                 m_pAnalyser->analyse_node(&m_childToAnalyse, m_pAnchor);
             }
             else if (m_childToAnalyse.name() == "wedge"
+                     || m_childToAnalyse.name() == "dashes"
+                     || m_childToAnalyse.name() == "bracket"
                      || m_childToAnalyse.name() == "pedal"
+                     || m_childToAnalyse.name() == "octave-shift"
+                     || m_childToAnalyse.name() == "principal-voice"
                     )
             {
                 m_pAnalyser->analyse_node(&m_childToAnalyse, m_pAnchor);
@@ -4561,17 +4561,127 @@ public:
 
 //@--------------------------------------------------------------------------------------
 //@ <octave-shift>
+//@
+//@ <!ELEMENT octave-shift EMPTY>
+//@ <!ATTLIST octave-shift
+//@     type (up | down | stop | continue) #REQUIRED
+//@     number %number-level; #IMPLIED
+//@     size CDATA "8"
+//@     %dashed-formatting;
+//@     %print-style;
+//@     %optional-unique-id;
+//@ >
+//@
 class OctaveShiftMxlAnalyser : public MxlElementAnalyser
 {
+protected:
+    ImoOctaveShiftDto* m_pInfo1;
+    ImoOctaveShiftDto* m_pInfo2;
+
 public:
     OctaveShiftMxlAnalyser(MxlAnalyser* pAnalyser, ostream& reporter,
                             LibraryScope& libraryScope, ImoObj* pAnchor)
-        : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
+        : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor)
+        , m_pInfo1(nullptr)
+        , m_pInfo2(nullptr)
+    {
+    }
 
     ImoObj* do_analysis()
     {
-		//TODO
-        return nullptr;
+        ImoDirection* pDirection = nullptr;
+        if (m_pAnchor && m_pAnchor->is_direction())
+            pDirection = static_cast<ImoDirection*>(m_pAnchor);
+        else
+        {
+            LOMSE_LOG_ERROR("pAnchor is nullptr or it is not ImoDirection");
+            error_msg("<direction-type> <octave-shift> is not child of <direction>. Ignored.");
+            return nullptr;
+        }
+
+        Document* pDoc = m_pAnalyser->get_document_being_analysed();
+        m_pInfo1 = static_cast<ImoOctaveShiftDto*>(
+                                ImFactory::inject(k_imo_octave_shift_dto, pDoc));
+        m_pInfo1->set_line_number( m_pAnalyser->get_line_number(&m_analysedNode) );
+
+        // attrib: type (up | down | stop | continue) #REQUIRED
+        const string& type = get_mandatory_string_attribute("type", "", "octave-shift");
+
+        // attrib: number %number-level; #IMPLIED
+        int num = get_optional_int_attribute("number", 1);
+
+        // attrib: size CDATA "8"
+        int size = get_optional_int_attribute("size", 8);
+        if (!(size == 8 || size == 15))
+        {
+            const string& value = get_optional_string_attribute("size", "");
+            error_msg("Invalid octave-shift size '" + value + "'. Changed to 8.");
+            size = 8;
+        }
+
+        set_mandatory_data(type, num, size);
+
+        //TODO
+        // attrib: %dashed-formatting;
+        // attrib: %print-style;
+        // attrib: %optional-unique-id;
+
+        if (m_pInfo1)
+        {
+            m_pInfo1->set_staffobj(pDirection);
+            m_pAnalyser->add_relation_info(m_pInfo1);
+
+            if (m_pInfo2)
+            {
+                m_pInfo2->set_staffobj(pDirection);
+                m_pAnalyser->add_relation_info(m_pInfo2);
+            }
+        }
+
+        return nullptr;     //m_pInfo1 has been deleted in add_relation_info()
+    }
+
+protected:
+
+    void set_mandatory_data(const string& value, int num, int size)
+    {
+        if (value == "up" || value == "down")
+        {
+            m_pInfo1->set_start(true);
+            int id =  m_pAnalyser->new_octave_shift_id(num);
+            m_pInfo1->set_octave_shift_number(id);
+            --size;
+            if (value == "down")
+                size = -size;
+            m_pInfo1->set_shift_steps(size);
+        }
+        else if (value == "stop")
+        {
+            m_pInfo1->set_start(false);
+            int id =  m_pAnalyser->get_octave_shift_id_and_close(num);
+            m_pInfo1->set_octave_shift_number(id);
+        }
+//        else if (value == "continue")
+//        {
+//            m_pInfo1->set_start(false);
+//            int id =  m_pAnalyser->get_octave_shift_id_and_close(num);
+//            m_pInfo1->set_octave_shift_number(id);
+//
+//            Document* pDoc = m_pAnalyser->get_document_being_analysed();
+//            m_pInfo2 = static_cast<ImoWedgeDto*>(
+//                                ImFactory::inject(k_imo_octave_shift_dto, pDoc));
+//            m_pInfo2->set_start(true);
+//            m_pInfo2->set_line_number( m_pAnalyser->get_line_number(&m_analysedNode) );
+//            id =  m_pAnalyser->new_octave_shift_id(num);
+//            m_pInfo2->set_octave_shift_number(wedgeId);
+//        }
+        else
+        {
+            error_msg("Missing or invalid octave-shift type '" + value
+                      + "'. Octave-shift ignored.");
+            delete m_pInfo1;
+            m_pInfo1 = nullptr;
+        }
     }
 };
 
@@ -6976,14 +7086,14 @@ protected:
             m_pInfo2 = static_cast<ImoWedgeDto*>(
                                 ImFactory::inject(k_imo_wedge_dto, pDoc));
             m_pInfo2->set_start(true);
-//            m_pInfo1->set_crescendo(true);  //TODO
             m_pInfo2->set_line_number( m_pAnalyser->get_line_number(&m_analysedNode) );
             wedgeId =  m_pAnalyser->new_wedge_id(num);
             m_pInfo2->set_wedge_number(wedgeId);
         }
         else
         {
-            error_msg("Missing or invalid wedge type. Wedge ignored.");
+            error_msg("Missing or invalid wedge type '" + value
+                      + "'. Wedge ignored.");
             delete m_pInfo1;
             m_pInfo1 = nullptr;
         }
@@ -7124,12 +7234,14 @@ MxlAnalyser::MxlAnalyser(ostream& reporter, LibraryScope& libraryScope, Document
     , m_pSlursBuilder(nullptr)
     , m_pVoltasBuilder(nullptr)
     , m_pWedgesBuilder(nullptr)
+    , m_pOctaveShiftBuilder(nullptr)
     , m_musicxmlVersion(0)
     , m_pNodeImo(nullptr)
     , m_tieNum(0)
     , m_slurNum(0)
     , m_voltaNum(0)
     , m_wedgeNum(0)
+    , m_octaveShiftNum(0)
     , m_pTree()
     , m_fileLocator("")
 //    , m_nShowTupletBracket(k_yesno_default)
@@ -7227,6 +7339,7 @@ void MxlAnalyser::delete_relation_builders()
     delete m_pSlursBuilder;
     delete m_pVoltasBuilder;
     delete m_pWedgesBuilder;
+    delete m_pOctaveShiftBuilder;
 }
 
 //---------------------------------------------------------------------------------------
@@ -7239,6 +7352,7 @@ ImoObj* MxlAnalyser::analyse_tree_and_get_object(XmlNode* root)
     m_pSlursBuilder = LOMSE_NEW MxlSlursBuilder(m_reporter, this);
     m_pVoltasBuilder = LOMSE_NEW MxlVoltasBuilder(m_reporter, this);
     m_pWedgesBuilder = LOMSE_NEW MxlWedgesBuilder(m_reporter, this);
+    m_pOctaveShiftBuilder = LOMSE_NEW MxlOctaveShiftBuilder(m_reporter, this);
 
     m_pTree = root;
 //    m_curStaff = 0;
@@ -7343,6 +7457,8 @@ void MxlAnalyser::add_relation_info(ImoObj* pDto)
         m_pVoltasBuilder->add_item_info(static_cast<ImoVoltaBracketDto*>(pDto));
     else if (pDto->is_wedge_dto())
         m_pWedgesBuilder->add_item_info(static_cast<ImoWedgeDto*>(pDto));
+    else if (pDto->is_octave_shift_dto())
+        m_pOctaveShiftBuilder->add_item_info(static_cast<ImoOctaveShiftDto*>(pDto));
 }
 
 //---------------------------------------------------------------------------------------
@@ -7354,6 +7470,7 @@ void MxlAnalyser::clear_pending_relations()
     m_pTupletsBuilder->clear_pending_items();
     m_pVoltasBuilder->clear_pending_items();
     m_pWedgesBuilder->clear_pending_items();
+    m_pOctaveShiftBuilder->clear_pending_items();
 
     m_lyrics.clear();
     m_lyricIndex.clear();
@@ -7509,6 +7626,18 @@ int MxlAnalyser::get_slur_id_and_close(int numSlur)
 }
 
 //---------------------------------------------------------------------------------------
+int MxlAnalyser::new_volta_id()
+{
+    return ++m_voltaNum;
+}
+
+//---------------------------------------------------------------------------------------
+int MxlAnalyser::get_volta_id()
+{
+    return m_voltaNum;
+}
+
+//---------------------------------------------------------------------------------------
 int MxlAnalyser::new_wedge_id(int numWedge)
 {
     m_wedgeIds[numWedge] = ++m_wedgeNum;
@@ -7536,15 +7665,30 @@ int MxlAnalyser::get_wedge_id_and_close(int numWedge)
 }
 
 //---------------------------------------------------------------------------------------
-int MxlAnalyser::new_volta_id()
+int MxlAnalyser::new_octave_shift_id(int num)
 {
-    return ++m_voltaNum;
+    m_octaveShiftIds[num] = ++m_octaveShiftNum;
+    return m_octaveShiftNum;
 }
 
 //---------------------------------------------------------------------------------------
-int MxlAnalyser::get_volta_id()
+bool MxlAnalyser::octave_shift_id_exists(int num)
 {
-    return m_voltaNum;
+    return num <= m_octaveShiftNum && m_octaveShiftIds[num] != -1;
+}
+
+//---------------------------------------------------------------------------------------
+int MxlAnalyser::get_octave_shift_id(int num)
+{
+    return m_octaveShiftIds[num];
+}
+
+//---------------------------------------------------------------------------------------
+int MxlAnalyser::get_octave_shift_id_and_close(int num)
+{
+    int id = m_octaveShiftIds[num];
+    m_octaveShiftIds[num] = -1;
+    return id;
 }
 
 //---------------------------------------------------------------------------------------
@@ -7649,7 +7793,7 @@ MxlElementAnalyser* MxlAnalyser::new_analyser(const string& name, ImoObj* pAncho
         case k_mxl_tag_midi_instrument:      return LOMSE_NEW MidiInstrumentMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_mxl_tag_notations:            return LOMSE_NEW NotationsMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_mxl_tag_note:                 return LOMSE_NEW NoteRestMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
-//        case k_mxl_tag_octave_shift:         return LOMSE_NEW OctaveShiftMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
+        case k_mxl_tag_octave_shift:         return LOMSE_NEW OctaveShiftMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_mxl_tag_ornaments:            return LOMSE_NEW OrnamentsMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_mxl_tag_part:                 return LOMSE_NEW PartMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_mxl_tag_part_group:           return LOMSE_NEW PartGroupMxlAnalyser(this, m_reporter, m_libraryScope, pAnchor);
@@ -7969,6 +8113,38 @@ void MxlWedgesBuilder::add_relation_to_staffobjs(ImoWedgeDto* pEndDto)
     {
         ImoDirection* pDirection = (*it)->get_staffobj();
         pDirection->include_in_relation(pDoc, pWedge, nullptr);
+    }
+}
+
+
+//=======================================================================================
+// MxlOctaveShiftBuilder implementation
+//=======================================================================================
+void MxlOctaveShiftBuilder::add_relation_to_staffobjs(ImoOctaveShiftDto* pEndDto)
+{
+    ImoOctaveShiftDto* pStartDto = m_matches.front();
+    m_matches.push_back(pEndDto);
+    Document* pDoc = m_pAnalyser->get_document_being_analysed();
+
+    ImoOctaveShift* pOctave = static_cast<ImoOctaveShift*>(
+                                        ImFactory::inject(k_imo_octave_shift, pDoc));
+
+    //set data taken from start dto
+    pOctave->set_octave_shift_number( pStartDto->get_octave_shift_number() );
+    pOctave->set_shift_steps( pStartDto->get_shift_steps() );
+    pOctave->set_color( pStartDto->get_color() );
+
+    //set data taken from end dto
+        //none
+
+    //set data that can be on any of them
+        //none
+
+    std::list<ImoOctaveShiftDto*>::iterator it;
+    for (it = m_matches.begin(); it != m_matches.end(); ++it)
+    {
+        ImoDirection* pDirection = (*it)->get_staffobj();
+        pDirection->include_in_relation(pDoc, pOctave, nullptr);
     }
 }
 

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -8163,6 +8163,7 @@ void MxlWedgesBuilder::add_relation_to_staffobjs(ImoWedgeDto* pEndDto)
 void MxlOctaveShiftBuilder::add_relation_to_staffobjs(ImoOctaveShiftDto* pEndDto)
 {
     ImoOctaveShiftDto* pStartDto = m_matches.front();
+    ImoNote* pStartNote = pStartDto->get_staffobj();
     m_matches.push_back(pEndDto);
     Document* pDoc = m_pAnalyser->get_document_being_analysed();
 
@@ -8189,9 +8190,11 @@ void MxlOctaveShiftBuilder::add_relation_to_staffobjs(ImoOctaveShiftDto* pEndDto
             int iStaff = (*it)->get_staff();
             pNote = m_pAnalyser->get_last_note_for(iStaff);
             (*it)->set_staffobj(pNote);
+            if (pStartNote != pNote)
+                pNote->include_in_relation(pDoc, pOctave, nullptr);
         }
-
-        pNote->include_in_relation(pDoc, pOctave, nullptr);
+        else
+            pNote->include_in_relation(pDoc, pOctave, nullptr);
     }
 }
 

--- a/src/tests/lomse_test_beam_engraver.cpp
+++ b/src/tests/lomse_test_beam_engraver.cpp
@@ -138,7 +138,7 @@ public:
         {
             ImoNote* pNote = static_cast<ImoNote*>( (*it).first );
             GmoShapeNote* pShape = dynamic_cast<GmoShapeNote*>(
-                m_pNoteEngrv->create_shape(pNote, k_clef_G2,
+                m_pNoteEngrv->create_shape(pNote, k_clef_G2, 0,
                                            UPoint(10.0f, 15.0f)) );
             m_shapes.push_back(pShape);
         }

--- a/src/tests/lomse_test_chord_engraver.cpp
+++ b/src/tests/lomse_test_chord_engraver.cpp
@@ -130,12 +130,12 @@ public:
         m_pStorage = LOMSE_NEW ShapesStorage();
         m_pNoteEngrv = LOMSE_NEW NoteEngraver(m_libraryScope, m_pMeter, m_pStorage, 0, 0);
         m_pShape1 =
-            dynamic_cast<GmoShapeNote*>(m_pNoteEngrv->create_shape(m_pNote1, k_clef_G2, UPoint(10.0f, 15.0f)) );
+            dynamic_cast<GmoShapeNote*>(m_pNoteEngrv->create_shape(m_pNote1, k_clef_G2, 0, UPoint(10.0f, 15.0f)) );
         m_pShape2 =
-            dynamic_cast<GmoShapeNote*>(m_pNoteEngrv->create_shape(m_pNote2, k_clef_G2, UPoint(10.0f, 15.0f)) );
+            dynamic_cast<GmoShapeNote*>(m_pNoteEngrv->create_shape(m_pNote2, k_clef_G2, 0, UPoint(10.0f, 15.0f)) );
         if (step3 >= 0)
             m_pShape3 =
-                dynamic_cast<GmoShapeNote*>(m_pNoteEngrv->create_shape(m_pNote3, k_clef_G2, UPoint(10.0f, 15.0f)) );
+                dynamic_cast<GmoShapeNote*>(m_pNoteEngrv->create_shape(m_pNote3, k_clef_G2, 0, UPoint(10.0f, 15.0f)) );
         else
             m_pShape3 = nullptr;
     }

--- a/src/tests/lomse_test_mxl_analyser.cpp
+++ b/src/tests/lomse_test_mxl_analyser.cpp
@@ -3175,7 +3175,7 @@ SUITE(MxlAnalyserTest)
                 CHECK( pMD != nullptr );
 
                 ImoObj::children_iterator it = pMD->begin();
-                CHECK( pMD->get_num_children() == 4 );
+                CHECK( pMD->get_num_children() == 2 );
 
 //                cout << test_name() << endl;
 //                cout << "num.children=" << pMD->get_num_children() << endl;
@@ -3186,15 +3186,12 @@ SUITE(MxlAnalyserTest)
 //                }
 //                it = pMD->begin();
 
-                ImoDirection* pDir = dynamic_cast<ImoDirection*>( *it );
-                CHECK( pDir != nullptr );
-                if (pDir)
+                ImoNote* pNote = dynamic_cast<ImoNote*>( *it );
+                CHECK( pNote != nullptr );
+                if (pNote)
                 {
-                    CHECK( pDir->get_num_attachments() == 0 );
-                    CHECK( pDir->get_placement() == k_placement_default );
-
                     ImoOctaveShift* pOctave = dynamic_cast<ImoOctaveShift*>(
-                                                    pDir->find_relation(k_imo_octave_shift) );
+                                                    pNote->find_relation(k_imo_octave_shift) );
                     CHECK( pOctave != nullptr );
                     if (pOctave)
                     {
@@ -3230,6 +3227,9 @@ SUITE(MxlAnalyserTest)
             "<note><pitch><step>G</step><octave>5</octave></pitch>"
                 "<duration>4</duration><type>16th</type>"
             "</note>"
+            "<note><pitch><step>E</step><octave>5</octave></pitch>"
+                "<duration>4</duration><type>16th</type>"
+            "</note>"
             "<direction><direction-type>"
                 "<octave-shift type='stop'/>"
             "</direction-type></direction>"
@@ -3244,6 +3244,7 @@ SUITE(MxlAnalyserTest)
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
 //        CHECK( errormsg.str() == expected.str() );
+
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -3257,7 +3258,7 @@ SUITE(MxlAnalyserTest)
                 CHECK( pMD != nullptr );
 
                 ImoObj::children_iterator it = pMD->begin();
-                CHECK( pMD->get_num_children() == 4 );
+                CHECK( pMD->get_num_children() == 3 );
 
 //                cout << test_name() << endl;
 //                cout << "num.children=" << pMD->get_num_children() << endl;
@@ -3268,15 +3269,12 @@ SUITE(MxlAnalyserTest)
 //                }
 //                it = pMD->begin();
 
-                ImoDirection* pDir = dynamic_cast<ImoDirection*>( *it );
-                CHECK( pDir != nullptr );
-                if (pDir)
+                ImoNote* pNote = dynamic_cast<ImoNote*>( *it );
+                CHECK( pNote != nullptr );
+                if (pNote)
                 {
-                    CHECK( pDir->get_num_attachments() == 0 );
-                    CHECK( pDir->get_placement() == k_placement_default );
-
                     ImoOctaveShift* pOctave = dynamic_cast<ImoOctaveShift*>(
-                                                    pDir->find_relation(k_imo_octave_shift) );
+                                                    pNote->find_relation(k_imo_octave_shift) );
                     CHECK( pOctave != nullptr );
                     if (pOctave)
                     {

--- a/src/tests/lomse_test_mxl_analyser.cpp
+++ b/src/tests/lomse_test_mxl_analyser.cpp
@@ -2671,7 +2671,6 @@ SUITE(MxlAnalyserTest)
 
     //@ note -----------------------------------------------------------------------------
 
-
     TEST_FIXTURE(MxlAnalyserTestFixture, MxlAnalyser_note_00)
     {
         //@00 minimum content parsed ok. Note saved
@@ -3121,6 +3120,173 @@ SUITE(MxlAnalyserTest)
         CHECK( pNote && pNote->is_in_chord() == false );
         CHECK( pNote && pNote->is_start_of_chord() == false );
         CHECK( pNote && pNote->is_end_of_chord() == false );
+
+        a.do_not_delete_instruments_in_destructor();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+
+    //@ octave-shift --------------------------------------------------------------------
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, octave_shift_01)
+    {
+        //@01. minimum content parsed ok
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser(errormsg);
+        stringstream expected;
+        parser.parse_text(
+            "<score-partwise version='3.0'><part-list>"
+            "<score-part id='P1'><part-name>Music</part-name></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "<direction><direction-type>"
+                "<octave-shift type='down'/>"
+            "</direction-type></direction>"
+            "<note><pitch><step>G</step><octave>5</octave></pitch>"
+                "<duration>4</duration><type>16th</type>"
+            "</note>"
+            "<direction><direction-type>"
+                "<octave-shift type='stop'/>"
+            "</direction-type></direction>"
+            "</measure>"
+            "</part></score-partwise>"
+        );
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot =  a.analyse_tree(tree, "string:");
+
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pRoot != nullptr);
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
+        if (pDoc)
+        {
+            ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+            CHECK( pScore != nullptr );
+            if (pScore)
+            {
+                ImoInstrument* pInstr = pScore->get_instrument(0);
+                ImoMusicData* pMD = pInstr->get_musicdata();
+                CHECK( pMD != nullptr );
+
+                ImoObj::children_iterator it = pMD->begin();
+                CHECK( pMD->get_num_children() == 4 );
+
+//                cout << test_name() << endl;
+//                cout << "num.children=" << pMD->get_num_children() << endl;
+//                while (it != pMD->end())
+//                {
+//                    cout << (*it)->to_string() << ", " << (*it)->get_name() << endl;
+//                    ++it;
+//                }
+//                it = pMD->begin();
+
+                ImoDirection* pDir = dynamic_cast<ImoDirection*>( *it );
+                CHECK( pDir != nullptr );
+                if (pDir)
+                {
+                    CHECK( pDir->get_num_attachments() == 0 );
+                    CHECK( pDir->get_placement() == k_placement_default );
+
+                    ImoOctaveShift* pOctave = dynamic_cast<ImoOctaveShift*>(
+                                                    pDir->find_relation(k_imo_octave_shift) );
+                    CHECK( pOctave != nullptr );
+                    if (pOctave)
+                    {
+                        CHECK( pOctave->get_shift_steps() == -7 );
+                        CHECK( pOctave->get_octave_shift_number() == 1 );
+                        CHECK( !is_different(pOctave->get_color(), Color(0,0,0)) );
+                    }
+                }
+            }
+        }
+
+        a.do_not_delete_instruments_in_destructor();
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, octave_shift_02)
+    {
+        //@02. invalid size
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser(errormsg);
+        stringstream expected;
+        expected << "Line 0. Invalid octave-shift size '6'. Changed to 8." << endl;
+        parser.parse_text(
+            "<score-partwise version='3.0'><part-list>"
+            "<score-part id='P1'><part-name>Music</part-name></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "<direction><direction-type>"
+                "<octave-shift type='up' size='6'/>"
+            "</direction-type></direction>"
+            "<note><pitch><step>G</step><octave>5</octave></pitch>"
+                "<duration>4</duration><type>16th</type>"
+            "</note>"
+            "<direction><direction-type>"
+                "<octave-shift type='stop'/>"
+            "</direction-type></direction>"
+            "</measure>"
+            "</part></score-partwise>"
+        );
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot =  a.analyse_tree(tree, "string:");
+
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+//        CHECK( errormsg.str() == expected.str() );
+        CHECK( pRoot != nullptr);
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
+        if (pDoc)
+        {
+            ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+            CHECK( pScore != nullptr );
+            if (pScore)
+            {
+                ImoInstrument* pInstr = pScore->get_instrument(0);
+                ImoMusicData* pMD = pInstr->get_musicdata();
+                CHECK( pMD != nullptr );
+
+                ImoObj::children_iterator it = pMD->begin();
+                CHECK( pMD->get_num_children() == 4 );
+
+//                cout << test_name() << endl;
+//                cout << "num.children=" << pMD->get_num_children() << endl;
+//                while (it != pMD->end())
+//                {
+//                    cout << (*it)->to_string() << ", " << (*it)->get_name() << endl;
+//                    ++it;
+//                }
+//                it = pMD->begin();
+
+                ImoDirection* pDir = dynamic_cast<ImoDirection*>( *it );
+                CHECK( pDir != nullptr );
+                if (pDir)
+                {
+                    CHECK( pDir->get_num_attachments() == 0 );
+                    CHECK( pDir->get_placement() == k_placement_default );
+
+                    ImoOctaveShift* pOctave = dynamic_cast<ImoOctaveShift*>(
+                                                    pDir->find_relation(k_imo_octave_shift) );
+                    CHECK( pOctave != nullptr );
+                    if (pOctave)
+                    {
+                        CHECK( pOctave->get_shift_steps() == 7 );
+                        CHECK( pOctave->get_octave_shift_number() == 1 );
+                        CHECK( !is_different(pOctave->get_color(), Color(0,0,0)) );
+                    }
+                }
+            }
+        }
 
         a.do_not_delete_instruments_in_destructor();
         if (pRoot && !pRoot->is_document()) delete pRoot;

--- a/src/tests/lomse_test_note_engraver.cpp
+++ b/src/tests/lomse_test_note_engraver.cpp
@@ -111,11 +111,11 @@ public:
         m_pStorage = LOMSE_NEW ShapesStorage();
         m_pEngrv = LOMSE_NEW NoteEngraver(m_libraryScope, m_pMeter, m_pStorage, 0, 0);
         m_pShape1 =
-            dynamic_cast<GmoShapeNote*>(m_pEngrv->create_shape(m_pNote1, k_clef_G2, UPoint(10.0f, 15.0f)) );
+            dynamic_cast<GmoShapeNote*>(m_pEngrv->create_shape(m_pNote1, k_clef_G2, 0, UPoint(10.0f, 15.0f)) );
         m_pShape2 =
-            dynamic_cast<GmoShapeNote*>(m_pEngrv->create_shape(m_pNote2, k_clef_G2, UPoint(10.0f, 15.0f)) );
+            dynamic_cast<GmoShapeNote*>(m_pEngrv->create_shape(m_pNote2, k_clef_G2, 0, UPoint(10.0f, 15.0f)) );
         m_pShape3 =
-            dynamic_cast<GmoShapeNote*>(m_pEngrv->create_shape(m_pNote3, k_clef_G2, UPoint(10.0f, 15.0f)) );
+            dynamic_cast<GmoShapeNote*>(m_pEngrv->create_shape(m_pNote3, k_clef_G2, 0, UPoint(10.0f, 15.0f)) );
     }
 
     void delete_tuplet()
@@ -158,7 +158,7 @@ SUITE(NoteEngraverTest)
         ShapesStorage storage;
         NoteEngraver engraver(m_libraryScope, &meter, &storage, 0, 0);
         GmoShapeNote* pShape =
-            dynamic_cast<GmoShapeNote*>(engraver.create_shape(pNote, k_clef_F4, UPoint(10.0f, 15.0f)) );
+            dynamic_cast<GmoShapeNote*>(engraver.create_shape(pNote, k_clef_F4, 0, UPoint(10.0f, 15.0f)) );
         CHECK( pShape != nullptr );
         CHECK( pShape->is_shape_note() == true );
         std::list<GmoShape*>& components = pShape->get_components();
@@ -181,7 +181,7 @@ SUITE(NoteEngraverTest)
         ShapesStorage storage;
         NoteEngraver engraver(m_libraryScope, &meter, &storage, 0, 0);
         GmoShapeNote* pShape =
-            dynamic_cast<GmoShapeNote*>(engraver.create_shape(pNote, k_clef_F4, UPoint(10.0f, 15.0f)) );
+            dynamic_cast<GmoShapeNote*>(engraver.create_shape(pNote, k_clef_F4, 0, UPoint(10.0f, 15.0f)) );
         CHECK( pShape != nullptr );
         CHECK( pShape->is_shape_note() == true );
         std::list<GmoShape*>& components = pShape->get_components();
@@ -206,7 +206,7 @@ SUITE(NoteEngraverTest)
         ShapesStorage storage;
         NoteEngraver engraver(m_libraryScope, &meter, &storage, 0, 0);
         GmoShapeNote* pShape =
-            dynamic_cast<GmoShapeNote*>(engraver.create_shape(pNote, k_clef_F4, UPoint(10.0f, 15.0f)) );
+            dynamic_cast<GmoShapeNote*>(engraver.create_shape(pNote, k_clef_F4, 0, UPoint(10.0f, 15.0f)) );
         CHECK( pShape != nullptr );
         CHECK( pShape->is_shape_note() == true );
         std::list<GmoShape*>& components = pShape->get_components();
@@ -234,7 +234,7 @@ SUITE(NoteEngraverTest)
         ShapesStorage storage;
         NoteEngraver engraver(m_libraryScope, &meter, &storage, 0, 0);
         GmoShapeNote* pShape =
-            dynamic_cast<GmoShapeNote*>(engraver.create_shape(pNote, k_clef_F4, UPoint(10.0f, 15.0f)) );
+            dynamic_cast<GmoShapeNote*>(engraver.create_shape(pNote, k_clef_F4, 0, UPoint(10.0f, 15.0f)) );
         CHECK( pShape != nullptr );
         CHECK( pShape->is_shape_note() == true );
         std::list<GmoShape*>& components = pShape->get_components();
@@ -260,7 +260,7 @@ SUITE(NoteEngraverTest)
         ShapesStorage storage;
         NoteEngraver engraver(m_libraryScope, &meter, &storage, 0, 0);
         GmoShapeNote* pShape =
-            dynamic_cast<GmoShapeNote*>(engraver.create_shape(pNote, k_clef_F4, UPoint(10.0f, 15.0f)) );
+            dynamic_cast<GmoShapeNote*>(engraver.create_shape(pNote, k_clef_F4, 0, UPoint(10.0f, 15.0f)) );
         CHECK( pShape != nullptr );
         CHECK( pShape->is_shape_note() == true );
         std::list<GmoShape*>& components = pShape->get_components();

--- a/src/tests/lomse_test_shapes.cpp
+++ b/src/tests/lomse_test_shapes.cpp
@@ -107,7 +107,7 @@ SUITE(GmoShapeTest)
         ShapesStorage storage;
         NoteEngraver engraver(m_libraryScope, &meter, &storage, 0, 0);
         GmoShapeNote* pShape =
-            dynamic_cast<GmoShapeNote*>(engraver.create_shape(pNote, k_clef_F4, UPoint(10.0f, 15.0f)) );
+            dynamic_cast<GmoShapeNote*>(engraver.create_shape(pNote, k_clef_F4, 0, UPoint(10.0f, 15.0f)) );
 
         CHECK( pShape != nullptr );
         CHECK( pShape && pShape->is_locked() == true );
@@ -127,7 +127,7 @@ SUITE(GmoShapeTest)
         ShapesStorage storage;
         NoteEngraver engraver(m_libraryScope, &meter, &storage, 0, 0);
         GmoShapeNote* pShape =
-            dynamic_cast<GmoShapeNote*>(engraver.create_shape(pNote, k_clef_F4, UPoint(10.0f, 15.0f)) );
+            dynamic_cast<GmoShapeNote*>(engraver.create_shape(pNote, k_clef_F4, 0, UPoint(10.0f, 15.0f)) );
 
         CHECK( pShape != nullptr);
         if (pShape)
@@ -163,7 +163,7 @@ SUITE(GmoShapeTest)
         ShapesStorage storage;
         NoteEngraver engraver(m_libraryScope, &meter, &storage, 0, 0);
         GmoShapeNote* pShape =
-            dynamic_cast<GmoShapeNote*>(engraver.create_shape(pNote, k_clef_F4, UPoint(10.0f, 15.0f)) );
+            dynamic_cast<GmoShapeNote*>(engraver.create_shape(pNote, k_clef_F4, 0, UPoint(10.0f, 15.0f)) );
 
         CHECK( pShape != nullptr);
         if (pShape)

--- a/src/tests/lomse_test_tuplet_engraver.cpp
+++ b/src/tests/lomse_test_tuplet_engraver.cpp
@@ -123,7 +123,7 @@ public:
             if (pNR->is_note())
             {
                 ImoNote* pNote = static_cast<ImoNote*>(pNR);
-                pShape = m_pNoteEngrv->create_shape(pNote, k_clef_G2,
+                pShape = m_pNoteEngrv->create_shape(pNote, k_clef_G2, 0,
                                                     UPoint(10.0f, 15.0f) );
             }
             else

--- a/test-scores/50041-octave_shift.xml
+++ b/test-scores/50041-octave_shift.xml
@@ -1,72 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise>
-  <work>
-    <work-title>Title</work-title>
-    </work>
-  <identification>
-    <creator type="composer">Composer</creator>
-    <encoding>
-      <software>MuseScore 2.1.0</software>
-      <encoding-date>2018-04-16</encoding-date>
-      <supports element="accidental" type="yes"/>
-      <supports element="beam" type="yes"/>
-      <supports element="print" attribute="new-page" type="yes" value="yes"/>
-      <supports element="print" attribute="new-system" type="yes" value="yes"/>
-      <supports element="stem" type="yes"/>
-      </encoding>
-    </identification>
-  <defaults>
-    <scaling>
-      <millimeters>7.05556</millimeters>
-      <tenths>40</tenths>
-      </scaling>
-    <page-layout>
-      <page-height>1584</page-height>
-      <page-width>1224</page-width>
-      <page-margins type="even">
-        <left-margin>56.6929</left-margin>
-        <right-margin>56.6929</right-margin>
-        <top-margin>56.6929</top-margin>
-        <bottom-margin>113.386</bottom-margin>
-        </page-margins>
-      <page-margins type="odd">
-        <left-margin>56.6929</left-margin>
-        <right-margin>56.6929</right-margin>
-        <top-margin>56.6929</top-margin>
-        <bottom-margin>113.386</bottom-margin>
-        </page-margins>
-      </page-layout>
-    <word-font font-family="FreeSerif" font-size="10"/>
-    <lyric-font font-family="FreeSerif" font-size="11"/>
-    </defaults>
   <part-list>
     <score-part id="P1">
-      <part-name>Piano</part-name>
-      <part-abbreviation>Pno.</part-abbreviation>
-      <score-instrument id="P1-I1">
-        <instrument-name>Piano</instrument-name>
-        </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
-      <midi-instrument id="P1-I1">
-        <midi-channel>1</midi-channel>
-        <midi-program>1</midi-program>
-        <volume>78.7402</volume>
-        <pan>0</pan>
-        </midi-instrument>
-      </score-part>
-    </part-list>
+      <part-name>Octave-shift lines</part-name>
+    </score-part>
+  </part-list>
   <part id="P1">
-    <measure number="1" width="238.56">
-      <print>
-        <system-layout>
-          <system-margins>
-            <left-margin>-0.00</left-margin>
-            <right-margin>0.00</right-margin>
-            </system-margins>
-          <top-system-distance>70.00</top-system-distance>
-          </system-layout>
-        </print>
+    <measure number="1">
       <attributes>
         <divisions>1</divisions>
         <key>
@@ -81,7 +22,7 @@
           <line>2</line>
           </clef>
         </attributes>
-      <note default-x="75.17" default-y="35.00">
+      <note>
         <pitch>
           <step>F</step>
           <octave>6</octave>
@@ -91,7 +32,7 @@
         <type>quarter</type>
         <stem>down</stem>
         </note>
-      <note default-x="115.62" default-y="30.00">
+      <note>
         <pitch>
           <step>E</step>
           <octave>6</octave>
@@ -101,7 +42,7 @@
         <type>quarter</type>
         <stem>down</stem>
         </note>
-      <note default-x="156.07" default-y="25.00">
+      <note>
         <pitch>
           <step>D</step>
           <octave>6</octave>
@@ -111,7 +52,7 @@
         <type>quarter</type>
         <stem>down</stem>
         </note>
-      <note default-x="196.52" default-y="20.00">
+      <note>
         <pitch>
           <step>C</step>
           <octave>6</octave>
@@ -122,7 +63,7 @@
         <stem>down</stem>
         </note>
       </measure>
-    <measure number="2" width="159.79">
+    <measure number="2">
 
       <direction placement="above">
         <direction-type>
@@ -130,7 +71,7 @@
         </direction-type>
       </direction>
 
-      <note default-x="12.00" default-y="0.00">
+      <note>
         <pitch>
           <step>F</step>
           <octave>6</octave>
@@ -140,7 +81,7 @@
         <type>quarter</type>
         <stem>down</stem>
         </note>
-      <note default-x="48.55" default-y="-5.00">
+      <note>
         <pitch>
           <step>E</step>
           <octave>6</octave>
@@ -150,7 +91,7 @@
         <type>quarter</type>
         <stem>down</stem>
         </note>
-      <note default-x="85.09" default-y="-10.00">
+      <note>
         <pitch>
           <step>D</step>
           <octave>6</octave>
@@ -160,7 +101,7 @@
         <type>quarter</type>
         <stem>down</stem>
         </note>
-      <note default-x="121.64" default-y="-15.00">
+      <note>
         <pitch>
           <step>C</step>
           <octave>6</octave>
@@ -176,13 +117,13 @@
           </direction-type>
         </direction>
       </measure>
-    <measure number="3" width="159.79">
+    <measure number="3">
       <direction placement="above">
         <direction-type>
           <octave-shift type="down" size="15" number="1"/>
           </direction-type>
         </direction>
-      <note default-x="12.00" default-y="-35.00">
+      <note>
         <pitch>
           <step>F</step>
           <octave>6</octave>
@@ -192,7 +133,7 @@
         <type>quarter</type>
         <stem>up</stem>
         </note>
-      <note default-x="48.55" default-y="-40.00">
+      <note>
         <pitch>
           <step>E</step>
           <octave>6</octave>
@@ -202,7 +143,7 @@
         <type>quarter</type>
         <stem>up</stem>
         </note>
-      <note default-x="85.09" default-y="-45.00">
+      <note>
         <pitch>
           <step>D</step>
           <octave>6</octave>
@@ -212,7 +153,7 @@
         <type>quarter</type>
         <stem>up</stem>
         </note>
-      <note default-x="121.64" default-y="-50.00">
+      <note>
         <pitch>
           <step>C</step>
           <octave>6</octave>
@@ -228,14 +169,14 @@
           </direction-type>
         </direction>
       </measure>
-    <measure number="4" width="207.89">
+    <measure number="4">
       <attributes>
         <clef>
           <sign>F</sign>
           <line>4</line>
           </clef>
         </attributes>
-      <note default-x="44.50" default-y="-80.00">
+      <note>
         <pitch>
           <step>F</step>
           <octave>1</octave>
@@ -245,7 +186,7 @@
         <type>quarter</type>
         <stem>up</stem>
         </note>
-      <note default-x="84.95" default-y="-85.00">
+      <note>
         <pitch>
           <step>E</step>
           <octave>1</octave>
@@ -255,7 +196,7 @@
         <type>quarter</type>
         <stem>up</stem>
         </note>
-      <note default-x="125.40" default-y="-90.00">
+      <note>
         <pitch>
           <step>D</step>
           <octave>1</octave>
@@ -265,7 +206,7 @@
         <type>quarter</type>
         <stem>up</stem>
         </note>
-      <note default-x="165.84" default-y="-95.00">
+      <note>
         <pitch>
           <step>C</step>
           <octave>1</octave>
@@ -276,13 +217,13 @@
         <stem>up</stem>
         </note>
       </measure>
-    <measure number="5" width="175.79">
+    <measure number="5">
       <direction placement="below">
         <direction-type>
           <octave-shift type="up" size="8" number="1"/>
           </direction-type>
         </direction>
-      <note default-x="12.00" default-y="-45.00">
+      <note>
         <pitch>
           <step>F</step>
           <octave>1</octave>
@@ -292,7 +233,7 @@
         <type>quarter</type>
         <stem>up</stem>
         </note>
-      <note default-x="52.55" default-y="-50.00">
+      <note>
         <pitch>
           <step>E</step>
           <octave>1</octave>
@@ -302,7 +243,7 @@
         <type>quarter</type>
         <stem>up</stem>
         </note>
-      <note default-x="93.09" default-y="-55.00">
+      <note>
         <pitch>
           <step>D</step>
           <octave>1</octave>
@@ -312,7 +253,7 @@
         <type>quarter</type>
         <stem>up</stem>
         </note>
-      <note default-x="133.64" default-y="-60.00">
+      <note>
         <pitch>
           <step>C</step>
           <octave>1</octave>
@@ -328,13 +269,13 @@
           </direction-type>
         </direction>
       </measure>
-    <measure number="6" width="168.79">
+    <measure number="6">
       <direction placement="below">
         <direction-type>
           <octave-shift type="up" size="15" number="1"/>
           </direction-type>
         </direction>
-      <note default-x="12.00" default-y="-10.00">
+      <note>
         <pitch>
           <step>F</step>
           <octave>1</octave>
@@ -344,7 +285,7 @@
         <type>quarter</type>
         <stem>down</stem>
         </note>
-      <note default-x="48.55" default-y="-15.00">
+      <note>
         <pitch>
           <step>E</step>
           <octave>1</octave>
@@ -354,7 +295,7 @@
         <type>quarter</type>
         <stem>down</stem>
         </note>
-      <note default-x="85.09" default-y="-20.00">
+      <note>
         <pitch>
           <step>D</step>
           <octave>1</octave>
@@ -364,7 +305,7 @@
         <type>quarter</type>
         <stem>down</stem>
         </note>
-      <note default-x="121.64" default-y="-25.00">
+      <note>
         <pitch>
           <step>C</step>
           <octave>1</octave>
@@ -379,6 +320,268 @@
           <octave-shift type="stop" size="15" number="1"/>
           </direction-type>
         </direction>
+      </measure>
+    <measure number="7">
+      <direction placement="below">
+        <direction-type>
+          <octave-shift type="up" size="15" number="1"/>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="8">
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="9">
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="10">
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="11">
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <octave-shift type="stop" size="15" number="1"/>
+          </direction-type>
+        </direction>
+      </measure>
+    <measure number="12">
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
       <barline location="right">
         <bar-style>light-heavy</bar-style>
         </barline>

--- a/test-scores/50041-octave_shift.xml
+++ b/test-scores/50041-octave_shift.xml
@@ -1,0 +1,387 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise>
+  <work>
+    <work-title>Title</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Composer</creator>
+    <encoding>
+      <software>MuseScore 2.1.0</software>
+      <encoding-date>2018-04-16</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.05556</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1584</page-height>
+      <page-width>1224</page-width>
+      <page-margins type="even">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <word-font font-family="FreeSerif" font-size="10"/>
+    <lyric-font font-family="FreeSerif" font-size="11"/>
+    </defaults>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="238.56">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>-0.00</left-margin>
+            <right-margin>0.00</right-margin>
+            </system-margins>
+          <top-system-distance>70.00</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="75.17" default-y="35.00">
+        <pitch>
+          <step>F</step>
+          <octave>6</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="115.62" default-y="30.00">
+        <pitch>
+          <step>E</step>
+          <octave>6</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="156.07" default-y="25.00">
+        <pitch>
+          <step>D</step>
+          <octave>6</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="196.52" default-y="20.00">
+        <pitch>
+          <step>C</step>
+          <octave>6</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      </measure>
+    <measure number="2" width="159.79">
+
+      <direction placement="above">
+        <direction-type>
+          <octave-shift type="down" size="8" number="1"/>
+        </direction-type>
+      </direction>
+
+      <note default-x="12.00" default-y="0.00">
+        <pitch>
+          <step>F</step>
+          <octave>6</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="48.55" default-y="-5.00">
+        <pitch>
+          <step>E</step>
+          <octave>6</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="85.09" default-y="-10.00">
+        <pitch>
+          <step>D</step>
+          <octave>6</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="121.64" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <octave>6</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <direction placement="above">
+        <direction-type>
+          <octave-shift type="stop" size="8" number="1"/>
+          </direction-type>
+        </direction>
+      </measure>
+    <measure number="3" width="159.79">
+      <direction placement="above">
+        <direction-type>
+          <octave-shift type="down" size="15" number="1"/>
+          </direction-type>
+        </direction>
+      <note default-x="12.00" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>6</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="48.55" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>6</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="85.09" default-y="-45.00">
+        <pitch>
+          <step>D</step>
+          <octave>6</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="121.64" default-y="-50.00">
+        <pitch>
+          <step>C</step>
+          <octave>6</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <direction placement="above">
+        <direction-type>
+          <octave-shift type="stop" size="15" number="1"/>
+          </direction-type>
+        </direction>
+      </measure>
+    <measure number="4" width="207.89">
+      <attributes>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note default-x="44.50" default-y="-80.00">
+        <pitch>
+          <step>F</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="84.95" default-y="-85.00">
+        <pitch>
+          <step>E</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="125.40" default-y="-90.00">
+        <pitch>
+          <step>D</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="165.84" default-y="-95.00">
+        <pitch>
+          <step>C</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="5" width="175.79">
+      <direction placement="below">
+        <direction-type>
+          <octave-shift type="up" size="8" number="1"/>
+          </direction-type>
+        </direction>
+      <note default-x="12.00" default-y="-45.00">
+        <pitch>
+          <step>F</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="52.55" default-y="-50.00">
+        <pitch>
+          <step>E</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="93.09" default-y="-55.00">
+        <pitch>
+          <step>D</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="133.64" default-y="-60.00">
+        <pitch>
+          <step>C</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <octave-shift type="stop" size="8" number="1"/>
+          </direction-type>
+        </direction>
+      </measure>
+    <measure number="6" width="168.79">
+      <direction placement="below">
+        <direction-type>
+          <octave-shift type="up" size="15" number="1"/>
+          </direction-type>
+        </direction>
+      <note default-x="12.00" default-y="-10.00">
+        <pitch>
+          <step>F</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="48.55" default-y="-15.00">
+        <pitch>
+          <step>E</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="85.09" default-y="-20.00">
+        <pitch>
+          <step>D</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="121.64" default-y="-25.00">
+        <pitch>
+          <step>C</step>
+          <octave>1</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <direction placement="below">
+        <direction-type>
+          <octave-shift type="stop" size="15" number="1"/>
+          </direction-type>
+        </direction>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>


### PR DESCRIPTION
This PR closes #216. It adds support for octave-shift lines and modifies the MusicXML importer. Octave shift lines are now imported and rendered.