### PR TITLE
Implement auto-scaling when the paper height is too small

### DIFF
--- a/include/lomse_document.h
+++ b/include/lomse_document.h
@@ -284,6 +284,13 @@ public:
         return (m_pImoDoc != nullptr ? m_pImoDoc->get_language() : "en");
     }
 
+    /** Return the scaling factor to apply to the content when rendered divided into
+        pages of the size defined by the paper size. Normally this factor is 1.0.
+    */
+    inline float get_page_content_scale() {
+        return (m_pImoDoc != nullptr ? m_pImoDoc->get_page_content_scale() : 1.0f);
+    }
+
     //@}    //Access to the internal model
 
 
@@ -294,6 +301,14 @@ public:
     drawn from ISO 639, optionally extended with a country code drawn from ISO 3166, as
     'en-US'. It represents the default language for all texts in the document. */
     inline void set_language(const string& language) { m_pImoDoc->m_language = language; }
+
+    /** Set the scaling factor to apply to the content when rendered divided into
+        pages of the size defined by the paper size. By default this factor is 1.0.
+    */
+    inline void set_page_content_scale(float scale) {
+        if (m_pImoDoc)
+            m_pImoDoc->set_page_content_scale(scale);
+    }
 
     /** When you modify the content of a %Document it is necessary to update some
         structures associated to music scores, such as the staffobjs collection.

--- a/include/lomse_document_layouter.h
+++ b/include/lomse_document_layouter.h
@@ -56,8 +56,6 @@ class DocLayouter : public Layouter
 {
 protected:
     ImoDocument* m_pDoc;
-    LUnits m_pageWidth;
-    LUnits m_pageHeight;
 
     //for unit tests: need to access ScoreLayouter.
     Layouter* m_pScoreLayouter;
@@ -80,8 +78,9 @@ public:
     void save_score_layouter(Layouter* pLayouter);
 
 protected:
-    void layout_content();
+    int layout_content();
     void fix_document_size();
+    void delete_last_trial();
 
     GmoBoxDocPage* create_document_page();
     void assign_paper_size_to(GmoBox* pBox);

--- a/include/lomse_internal_model.h
+++ b/include/lomse_internal_model.h
@@ -4382,6 +4382,7 @@ class ImoDocument : public ImoBlocksContainer
 {
 protected:
     friend class Document;
+    float m_scale;     //page content scaling factor
     string m_version;
     string m_language;
     ImoPageInfo m_pageInfo;
@@ -4399,6 +4400,8 @@ public:
     inline Document* get_owner() { return m_pDoc; }
     inline std::string& get_language() { return m_language; }
     inline void set_language(const string& language) { m_language = language; }
+    inline float get_page_content_scale() { return m_scale; }
+    inline void set_page_content_scale(float scale) { m_scale = scale; }
 
     //document intended paper size
     void add_page_info(ImoPageInfo* pPI);

--- a/include/lomse_layouter.h
+++ b/include/lomse_layouter.h
@@ -51,7 +51,7 @@ class ImoStyles;
 class Layouter
 {
 protected:
-    bool m_fIsLayouted;
+    int m_result;               //value from ELayoutResult
     GraphicModel* m_pGModel;
     Layouter* m_pParentLayouter;
     LibraryScope& m_libraryScope;
@@ -77,10 +77,18 @@ protected:
 public:
     virtual ~Layouter() {}
 
+    enum ELayoutResult
+    {
+        k_layout_not_finished = 0,
+        k_layout_success,
+        k_layout_failed_auto_scale,        //auto-scaling applied. Need to re-layout
+    };
+
     virtual void layout_in_box() = 0;
-    virtual void prepare_to_start_layout() { m_fIsLayouted = false; }
-    virtual bool is_item_layouted() { return m_fIsLayouted; }
-    virtual void set_layout_is_finished(bool value) { m_fIsLayouted = value; }
+    virtual void prepare_to_start_layout() { m_result = k_layout_not_finished; }
+    virtual bool is_item_layouted() { return m_result != k_layout_not_finished; }
+    virtual void set_layout_result(int value) { m_result = value; }
+    virtual int get_layout_result() { return m_result; }
     virtual void create_main_box(GmoBox* pParentBox, UPoint pos, LUnits width,
                                  LUnits height) = 0;
     virtual void save_score_layouter(Layouter* pLayouter) {
@@ -102,7 +110,7 @@ protected:
     virtual GmoBox* start_new_page();
 
     Layouter* create_layouter(ImoContentObj* pItem, int constrains=0);
-    void layout_item(ImoContentObj* pItem, GmoBox* pParentBox, int constrains);
+    int layout_item(ImoContentObj* pItem, GmoBox* pParentBox, int constrains);
 
     void set_cursor_and_available_space();
 
@@ -140,10 +148,10 @@ public:
     }
     ~NullLayouter() {}
 
-    void layout_in_box() {}
-    bool is_item_layouted() { return true; }
+    void layout_in_box() override {}
+    bool is_item_layouted() override { return true; }
     void create_main_box(GmoBox* UNUSED(pParentBox), UPoint UNUSED(pos),
-                         LUnits UNUSED(width), LUnits UNUSED(height)) {}
+                         LUnits UNUSED(width), LUnits UNUSED(height)) override {}
 };
 
 

--- a/include/lomse_score_layouter.h
+++ b/include/lomse_score_layouter.h
@@ -238,6 +238,7 @@ protected:
 
     void delete_system_layouters();
     void get_score_renderization_options();
+    void auto_scale();
 
     bool m_fFirstSystemInPage;
     inline void is_first_system_in_page(bool value) { m_fFirstSystemInPage = value; }

--- a/src/graphic_model/layouters/lomse_inlines_container_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_inlines_container_layouter.cpp
@@ -128,7 +128,7 @@ void InlinesContainerLayouter::layout_in_box()
     if (m_fAddShapesToModel && !fMoreText)
         m_pItemMainBox->add_shapes_to_tables();
 
-    set_layout_is_finished( !fMoreText );
+    set_layout_result(fMoreText ? k_layout_not_finished : k_layout_success);
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -200,19 +200,24 @@ void ScoreLayouter::layout_in_box()
                 msg << "  Page size too small for " << m_pScore->get_num_instruments()
                     << " instruments.";
                 add_error_message(msg.str());
-                set_layout_is_finished(true);
+                set_layout_result(k_layout_success);
                 delete_system();
                 return;
-            #else
+            #elseif (0)
                 //Overrun paper
                 add_system_to_page();
                 fSystemsAdded = true;
+            #else
+                auto_scale();
+                set_layout_result(k_layout_failed_auto_scale);
+                delete_system();
+                return;
             #endif
         }
         else
         {
             //inform parent layouter for allocating a new page.
-            set_layout_is_finished(false);
+            set_layout_result(k_layout_not_finished);
             return;
         }
     }
@@ -227,7 +232,7 @@ void ScoreLayouter::layout_in_box()
         remove_unused_space();
     }
 
-    set_layout_is_finished( !fMoreColumns );
+    set_layout_result(fMoreColumns ? k_layout_not_finished : k_layout_success);
     m_pageCursor = m_cursor;
 }
 
@@ -261,6 +266,17 @@ void ScoreLayouter::create_system()
     create_system_layouter();
     create_system_box();
     engrave_system();
+}
+
+//---------------------------------------------------------------------------------------
+void ScoreLayouter::auto_scale()
+{
+    LUnits systemHeight = m_pCurBoxSystem->get_height();
+    LUnits pageHeight = m_pCurBoxPage->get_height();
+    float scale = pageHeight / systemHeight;
+    ImoDocument* pDoc = m_pScore->get_document();
+    scale *= pDoc->get_page_content_scale();
+    pDoc->set_page_content_scale(scale);
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/layouters/lomse_table_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_table_layouter.cpp
@@ -118,7 +118,7 @@ void TableLayouter::layout_in_box()
         if (!is_body_row_ready())
         {
             //problem or empty body. Terminate table laying out
-            set_layout_is_finished(true);
+            set_layout_result(k_layout_success);
             return;
         }
 
@@ -131,7 +131,7 @@ void TableLayouter::layout_in_box()
     }
 
     bool fMoreRows = (m_bodyLayouter && m_bodyLayouter->is_row_ready());
-    set_layout_is_finished( !fMoreRows );
+    set_layout_result(fMoreRows ? k_layout_not_finished : k_layout_success);
 }
 
 //---------------------------------------------------------------------------------------
@@ -572,7 +572,7 @@ void TableRowLayouter::layout_in_box()
     m_pageCursor.y = yPos;
     m_availableHeight -= height;
 
-    set_layout_is_finished(true);
+    set_layout_result(k_layout_success);
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -2318,6 +2318,7 @@ void ImoAnonymousBlock::accept_visitor(BaseVisitor& v)
 //=======================================================================================
 ImoDocument::ImoDocument(const std::string& version)
     : ImoBlocksContainer(k_imo_document)
+    , m_scale(1.0f)
     , m_version(version)
     , m_language("en")
     , m_pageInfo()


### PR DESCRIPTION
Fixes #226 

This PR implements auto-scaling when the paper height is too small.

A document content scaling factor has been defined. It is used for scaling the content of the document pages. Paper and paper margins are not affected, only the content inside the page margins. This is equivalent to scaling paper size in the opposite direction, e.g.:
    make the score 10% smaller ==> make paper and page margings 10% greater

This scaling factor is now used in all methods for building the graphic model, whenever the paper size and page margins are retrieved.

Layouters have been modified for adjusting the scaling factor when the system height is greater than the page height. This can only occur in two cases:
1) malformed scores: paper too small for the number of instruments  and staff size, or
3) importing scores from other formats (e.g.: MusicXML scores without defining the paper size).

AWARE: This scaling factor must be taken now into account for other purposes such as for printing or for exporting images of the renderization.