### PR TITLE
Add FreeFlow and SinglePage Views

### DIFF
--- a/docs/api/doxyfile
+++ b/docs/api/doxyfile
@@ -19,7 +19,7 @@
 
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "Lomse library. API documentation"
-PROJECT_NUMBER         = 0.27.0
+PROJECT_NUMBER         = 0.27.1
 PROJECT_BRIEF          =
 PROJECT_LOGO           = ./images/logo_100x195.png
 OUTPUT_DIRECTORY       = ../../zz_build-api

--- a/examples/samples/viewtypes/viewtypes-wx.cpp
+++ b/examples/samples/viewtypes/viewtypes-wx.cpp
@@ -431,6 +431,8 @@ enum
     k_menu_view_vertical_book,
     k_menu_view_horizontal_book,
     k_menu_view_single_system,
+    k_menu_view_single_page,
+    k_menu_view_free_flow,
 
     //menu Effects
     k_menu_effect_highlight,
@@ -532,7 +534,10 @@ void MyFrame::create_menu()
                        _T("Use Vertical book View"), wxITEM_RADIO);
     m_viewMenu->Append(k_menu_view_horizontal_book, _T("k_view_horizontal_book"),
                        _T("Use Horizontal book View"), wxITEM_RADIO);
-
+    m_viewMenu->Append(k_menu_view_single_page, _T("k_view_single_page"),
+                       _T("Use Single Page View"), wxITEM_RADIO);
+    m_viewMenu->Append(k_menu_view_free_flow, _T("k_view_free_flow"),
+                       _T("Use Free Flow View"), wxITEM_RADIO);
     m_effectMenu = new wxMenu;
     m_effectMenu->Append(k_menu_effect_highlight, _T("k_tracking_highlight_notes"),
                          _T("Highlight the notes and rest being played back"), wxITEM_CHECK);
@@ -636,6 +641,10 @@ int MyFrame::select_view_type()
         viewType = k_view_vertical_book;
     else if (m_viewMenu->IsChecked(k_menu_view_horizontal_book))
         viewType = k_view_horizontal_book;
+    else if (m_viewMenu->IsChecked(k_menu_view_single_page))
+        viewType = k_view_single_page;
+    else if (m_viewMenu->IsChecked(k_menu_view_free_flow))
+        viewType = k_view_free_flow;
 
     return viewType;
 }
@@ -1222,17 +1231,15 @@ void MyCanvas::play_start(int effects)
 {
     if (SpInteractor spInteractor = m_pPresenter->get_interactor(0).lock())
     {
-        Document* pDoc = m_pPresenter->get_document_raw_ptr();
+        ADocument doc = m_pPresenter->get_document();
 
         //AWARE: Then next line of code is just an example, in which it is assumed that
-        //the score to play is the first element in the document.
-        //In a real application, as the document could contain texts, images and many
-        //scores, you shoud get the pointer to the score to play in a suitable way.
-        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
-
-        if (pScore)
+        //the score to play is the first score in the document.
+        AScore score = doc.first_score();
+        if (score.is_valid())
         {
             spInteractor->set_visual_tracking_mode(effects);
+            ImoScore* pScore = score.internal_object();
             m_pPlayer->load_score(pScore, this);
             m_pPlayer->play(k_do_visual_tracking, 0, spInteractor.get());
         }

--- a/include/lomse_basic.h
+++ b/include/lomse_basic.h
@@ -285,7 +285,7 @@ typedef Point<Pixels> VPoint;   //point, in pixels
 typedef Size<Pixels> VSize;     //size, in pixels
 typedef Rectangle<Pixels> VRect; //rectangle, in pixels
 
-//for compilers that not use <stdint.h>  (i.e. MS VisualStudio 2003)
+//for compilers that not use <stdint.h>  (e.g., MS VisualStudio 2003)
 #ifndef UINT32_MAX
     typedef int             int_least32_t;
     typedef unsigned int    uint_least32_t;

--- a/include/lomse_command.h
+++ b/include/lomse_command.h
@@ -1532,7 +1532,7 @@ public:
 	            //get object pointed by the cursor
                 ImoStaffObj* pSO = dynamic_cast<ImoStaffObj*>( m_cursor->get_pointee() );
 
-                //if no object, ignore command. i.e. user clicked 'Del' key on no object
+                //if no object, ignore command. e.g., user clicked 'Del' key on no object
                 if (pSO)
                 {
                     string name = gettext("Delete " + pSO->get_name() );

--- a/include/lomse_document_layouter.h
+++ b/include/lomse_document_layouter.h
@@ -56,12 +56,14 @@ class DocLayouter : public Layouter
 {
 protected:
     ImoDocument* m_pDoc;
+    LUnits m_viewWidth;
 
     //for unit tests: need to access ScoreLayouter.
     Layouter* m_pScoreLayouter;
 
 public:
-    DocLayouter(Document* pDoc, LibraryScope& libraryScope, int constrains=0);
+    DocLayouter(Document* pDoc, LibraryScope& libraryScope, int constrains=0,
+                LUnits width=0.0f);
     virtual ~DocLayouter();
 
     void layout_document();

--- a/include/lomse_doorway.h
+++ b/include/lomse_doorway.h
@@ -107,7 +107,7 @@ public:
         Lomse for reporting errors.
 
         @param pixel_format A value from the global enumeration type #EPixelFormat
-        @param ppi The required resolution in pixels per inch (i.e. 72)
+        @param ppi The required resolution in pixels per inch (e.g., 72)
         @param reverse_y_axis Lomse needs to know if the presentation device in which
             the bitmaps are going to be rendered follows the standard convention
             used in screen displays in which the y coordinates increases downwards,
@@ -409,17 +409,17 @@ public:
 
     //library info
 
-	/** Returns Lomse version as string "major.minor.patch" i.e. "0.17.20"    */
+	/** Returns Lomse version as string "major.minor.patch" e.g., "0.17.20"    */
     string get_version_string();
 
-	/** Returns Lomse version and build information as string. i.e. "0.17.20+aaf5e23"  */
+	/** Returns Lomse version and build information as string. e.g., "0.17.20+aaf5e23"  */
     string get_version_long_string();
 
 	/** Returns the build date and time of the Lomse library. The string is twenty
         characters long and looks like "12-Feb-2016 17:54:03". Date and time are
         separated by one space. Date is in format dd-mm-yyyy and time in format hh:mm:ss.
         Day, hour, minutes and seconds are always padded with zero if only one digit
-        i.e. "02-Mar-2016 07:54:03"    */
+        e.g., "02-Mar-2016 07:54:03"    */
     string get_build_date();
 
 	/** Returns Lomse major version as integer number. For instance, if version string

--- a/include/lomse_drawer.h
+++ b/include/lomse_drawer.h
@@ -88,7 +88,7 @@ struct RenderOptions
     //for debug: draw a box around boxes of selected types
     bitset<GmoObj::k_max> boxes;
 
-    bool draw_anchor_objects;   //draw anchor objs. (i.e. invisible shapes)
+    bool draw_anchor_objects;   //draw anchor objs. (e.g., invisible shapes)
     bool draw_anchor_lines;     //draw anchor lines. (spacing algorithm)
     bool draw_shape_bounds;     //draw bounds around selected shapes
     //bool g_fShowMargins;    //draw margins in scores, so user can change them

--- a/include/lomse_events.h
+++ b/include/lomse_events.h
@@ -229,7 +229,7 @@ typedef std::shared_ptr<EventDoc>  SpEventDoc;
 	inform the user application that it must immediately update the content of the
 	window associated to the lomse View, by displaying the current bitmap. User
 	application must put immediately the content of the currently rendered buffer
-	into the window without calling any Lomse methods (i.e. force_redraw) or generating
+	into the window without calling any Lomse methods (e.g., force_redraw) or generating
 	application events. .
 
 	For receiving these events you will have to register a callback when
@@ -661,7 +661,7 @@ typedef std::shared_ptr<EventUpdateUI>  SpEventUpdateUI;
         different box areas. Probably your application should ignore these events.
     - TaskDataEntry selected: As mouse moves, mouse in and out events are generated,
         as mouse flies over the different box areas. Your application can handle these
-        events and react to them as convenient (i.e. highlighting the implied
+        events and react to them as convenient (e.g., highlighting the implied
         insertion point/area).
 
     <b>Type k_on_click_event</b>
@@ -1464,8 +1464,8 @@ public:
         //use operating system services to find a suitable font
 
         //notes on parameters received:
-        // - fontname can be either the face name (i.e. "Book Antiqua") or
-        //   the familly name (i.e. "Liberation sans")
+        // - fontname can be either the face name (e.g., "Book Antiqua") or
+        //   the familly name (e.g., "Liberation sans")
 
         const string& fontname = pRequest->get_fontname();
         bool bold = pRequest->get_bold();
@@ -1553,7 +1553,7 @@ public:
 
     //getters
     /** Returns the <i>fontname</i>. It can be either the face name (i.e.
-        "Book Antiqua") or the familly name (i.e. "Liberation sans"). */
+        "Book Antiqua") or the familly name (e.g., "Liberation sans"). */
     inline const string& get_fontname() { return m_fontname; }
     ///Returns @true is the font is requested in bold face. */
     inline bool get_bold() { return m_bold; }

--- a/include/lomse_injectors.h
+++ b/include/lomse_injectors.h
@@ -65,6 +65,8 @@ class SimpleView;
 class VerticalBookView;
 class HorizontalBookView;
 class SingleSystemView;
+class SinglePageView;
+class FreeFlowView;
 class Interactor;
 class Presenter;
 class LomseDoorway;
@@ -116,7 +118,7 @@ protected:
     //debug options
     bool m_fJustifySystems;         //if false, prevents systems justification
     bool m_fDumpColumnTables;       //dump columns and slices data
-    bool m_fDrawAnchorObjects;      //draw anchor objects (i.e. invisible shapes)
+    bool m_fDrawAnchorObjects;      //draw anchor objects (e.g., invisible shapes)
     bool m_fDrawAnchorLines;        //draw a line at anchor positions (spacing algorithm)
     bool m_fShowShapeBounds;        //draw a box around each shape
     bool m_fUnitTests;              //library is running for Unit Tests
@@ -284,6 +286,9 @@ public:
                                                          Document* pDoc);
     static SingleSystemView* inject_SingleSystemView(LibraryScope& libraryScope,
                                                      Document* pDoc);
+    static SinglePageView* inject_SinglePageView(LibraryScope& libraryScope,
+                                                 Document* pDoc);
+    static FreeFlowView* inject_FreeFlowView(LibraryScope& libraryScope, Document* pDoc);
     static Interactor* inject_Interactor(LibraryScope& libraryScope,
                                          WpDocument wpDoc, View* pView,
                                          DocCommandExecuter* pExec);

--- a/include/lomse_interactor.h
+++ b/include/lomse_interactor.h
@@ -142,7 +142,7 @@ struct ptime
 
 	The %Interactor for a %View is provided by the Presenter. It is best practice not
 	to save pointers to the %Interactor because when processing a Lomse event the
-	Document (and thus, the Interactor) could have been deleted (i.e. because your
+	Document (and thus, the Interactor) could have been deleted (e.g., because your
     application has closed the window displaying the document).
 
 	Lomse provides type @b SpInteractor, an smart pointer to the %Interactor. The
@@ -260,6 +260,7 @@ public:
 
                 pPlayer->play(fVisualTracking, nMM, spInteractor.get());
             }
+        }
         @endcode
     */
     void set_operating_mode(int mode);
@@ -480,7 +481,6 @@ public:
         @endcode
     */
     virtual void set_rendering_buffer(RenderingBuffer* rbuf);
-
 
     /** Set/reset a rendering option for the view associated to this %Interactor.
 
@@ -1630,6 +1630,7 @@ protected:
 
     void create_graphic_model();
     void delete_graphic_model();
+    bool graphic_model_must_be_updated();
     void request_window_update();
     VRect get_damaged_rectangle();
     GmoObj* find_object_at(Pixels x, Pixels y);

--- a/include/lomse_pitch.h
+++ b/include/lomse_pitch.h
@@ -298,7 +298,7 @@ public:
     /// Operator to cast to an int
     operator int() { return m_pitch; }
 
-    /** Returns the name of this pitch in LPD format, i.e. MidiPitch 60 will
+    /** Returns the name of this pitch in LPD format, e.g., MidiPitch 60 will
         return "c4".    */
     string get_ldp_name();
 
@@ -360,7 +360,7 @@ public:
     FPitch(DiatonicPitch dp, int nAcc);
     /// Constructor from pitch components.
     FPitch(int nStep, int nOctave, int nAcc);
-    /// Constructor from an string representing the pitch in LDP name, i.e. "+c4".
+    /// Constructor from an string representing the pitch in LDP name, e.g., "+c4".
     FPitch(const string& note);
 //    FPitch(int nStep, int nOctave, EKeySignature nKey);
 

--- a/include/lomse_presenter.h
+++ b/include/lomse_presenter.h
@@ -166,7 +166,7 @@ public:
         @param pData	The application data to associate with the %Presenter.
 
         This method is a commodity for your application, in case you would like to save
-        some data associated to %Presenter objects, i.e. for Document identification
+        some data associated to %Presenter objects, e.g., for Document identification
         or other.
 
         @attention Your application has the ownership of the associated data.

--- a/include/lomse_xml_parser.h
+++ b/include/lomse_xml_parser.h
@@ -73,13 +73,13 @@ public:
     enum {
 		k_node_null = 0,	// Empty (null) node handle
 		k_node_document,	// A document tree's absolute root
-		k_node_element,		// Element tag, i.e. '<node/>'
-		k_node_pcdata,		// Plain character data, i.e. 'text'
-		k_node_cdata,		// Character data, i.e. '<![CDATA[text]]>'
-		k_node_comment,		// Comment tag, i.e. '<!-- text -->'
-		k_node_pi,			// Processing instruction, i.e. '<?name?>'
-		k_node_declaration,	// Document declaration, i.e. '<?xml version="1.0"?>'
-		k_node_doctype,		// Document type declaration, i.e. '<!DOCTYPE doc>'
+		k_node_element,		// Element tag, e.g., '<node/>'
+		k_node_pcdata,		// Plain character data, e.g., 'text'
+		k_node_cdata,		// Character data, e.g., '<![CDATA[text]]>'
+		k_node_comment,		// Comment tag, e.g., '<!-- text -->'
+		k_node_pi,			// Processing instruction, e.g., '<?name?>'
+		k_node_declaration,	// Document declaration, e.g., '<?xml version="1.0"?>'
+		k_node_doctype,		// Document type declaration, e.g., '<!DOCTYPE doc>'
         k_node_unknown
     };
 
@@ -116,7 +116,7 @@ class XmlParser : public Parser
 private:
     XmlDocument m_doc;
     XmlNode m_root;
-    string m_encoding;         //i.e. "utf-8"
+    string m_encoding;         //e.g., "utf-8"
     string m_errorMsg;
     int m_errorOffset;
     vector<ptrdiff_t> m_offsetData;     // offset -> line mapping

--- a/include/private/lomse_document_p.h
+++ b/include/private/lomse_document_p.h
@@ -93,6 +93,7 @@ enum EDocLayoutOptions
     k_use_paper_height      = 0x0002,   //Use paper height to determine constrains
     k_infinite_width        = 0x0004,   //No width constrains
     k_infinite_height       = 0x0008,   //No height constrains
+    k_use_viewport_width    = 0x0010,   //Use viewport width to determine constrains
 };
 
 

--- a/include/private/lomse_internal_model_p.h
+++ b/include/private/lomse_internal_model_p.h
@@ -816,7 +816,7 @@ enum EJustifyLastSystemOpts
 	type final is entered.
 
     Option 'k_truncate_always' truncates staff lines after last staff object. It can
-	be useful for creating score samples (i.e. for ebooks).
+	be useful for creating score samples (e.g., for ebooks).
 
     @#include <lomse_internal_model.h>
 */

--- a/src/document/lomse_document_cursor.cpp
+++ b/src/document/lomse_document_cursor.cpp
@@ -989,7 +989,7 @@ bool DocCursor::jailed_mode_in(ImoId id)
 //{
 //    //if id==k_no_imoid move to first object satisfying all other conditions
 //
-//    //TODO: This method will fail when several objects at same timepos (i.e. notes
+//    //TODO: This method will fail when several objects at same timepos (e.g., notes
 //    //in chord, notes in different voices, prolog -- clef, key, time, note --)
 //    //because it will always move to first object, not to desired one.
 //    //It is necessary to modify parameters list to pass object id and ref.obj id
@@ -2725,7 +2725,7 @@ void ScoreCursor::p_to_start_of_staff(int instr, int staff)
 //{
 //    //if id==k_no_imoid move to first object satisfying all other conditions
 //
-//    //TODO: This method will fail when several objects at same timepos (i.e. notes
+//    //TODO: This method will fail when several objects at same timepos (e.g., notes
 //    //in chord, notes in different voices, prolog -- clef, key, time, note --)
 //    //because it will always move to first object, not to desired one.
 //    //It is necessary to modify parameters list to pass object id and ref.obj id

--- a/src/graphic_model/engravers/lomse_chord_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_chord_engraver.cpp
@@ -176,15 +176,15 @@ void ChordEngraver::decide_on_stem_direction()
     //
     //  a) Two notes in chord:
     //    a1. If the interval above the middle line is greater than the interval below
-    //      the middle line: downward stems. i.e. (a4,d5) (f4,f5) (a4,g5)
+    //      the middle line: downward stems. e.g., (a4,d5) (f4,f5) (a4,g5)
     //      ==>   (MaxNotePos + MinNotePos)/2 > MiddleLinePos
     //
     //    a2. If the interval below the middle line is greater than the interval above
-    //      the middle line: upward stems. i.e. (e4,c5)(g4,c5)(d4,e5)
+    //      the middle line: upward stems. e.g., (e4,c5)(g4,c5)(d4,e5)
     //
     //    a3. If the two notes are at the same distance from the middle line: stem can
     //      go in either direction, but most engravers prefer downward stems.
-    //      i.e. (g4.d5)(a4,c5)
+    //      e.g., (g4.d5)(a4,c5)
     //
     //
     //  b) More than two notes in chord:

--- a/src/graphic_model/layouters/lomse_document_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_document_layouter.cpp
@@ -48,11 +48,13 @@ namespace lomse
 //  delegates in specialized layouters.
 //---------------------------------------------------------------------------------------
 
-DocLayouter::DocLayouter(Document* pDoc, LibraryScope& libraryScope, int constrains)
+DocLayouter::DocLayouter(Document* pDoc, LibraryScope& libraryScope, int constrains,
+                         LUnits width)
     : Layouter(libraryScope)
+    , m_pDoc( pDoc->get_im_root() )
+    , m_viewWidth(width)
     , m_pScoreLayouter(nullptr)
 {
-    m_pDoc = pDoc->get_im_root();
     m_pStyles = m_pDoc->get_styles();
     m_pGModel = LOMSE_NEW GraphicModel();
     m_constrains = constrains;
@@ -137,9 +139,17 @@ GmoBoxDocPage* DocLayouter::create_document_page()
 //---------------------------------------------------------------------------------------
 void DocLayouter::assign_paper_size_to(GmoBox* pBox)
 {
-    m_availableWidth = (m_constrains & k_infinite_width) ? LOMSE_INFINITE_LENGTH
-                        : m_pDoc->get_paper_width() / m_pDoc->get_page_content_scale();
+    //width
+    if (m_constrains & k_infinite_width)
+        m_availableWidth = LOMSE_INFINITE_LENGTH;
+    else if (m_constrains & k_use_viewport_width)
+    {
+        m_availableWidth = m_viewWidth;
+    }
+    else
+        m_availableWidth = m_pDoc->get_paper_width() / m_pDoc->get_page_content_scale();
 
+    //height
     m_availableHeight = (m_constrains & k_infinite_height) ? LOMSE_INFINITE_LENGTH
                          : m_pDoc->get_paper_height() / m_pDoc->get_page_content_scale();
 

--- a/src/graphic_model/layouters/lomse_spacing_algorithm_gourlay.cpp
+++ b/src/graphic_model/layouters/lomse_spacing_algorithm_gourlay.cpp
@@ -1564,7 +1564,7 @@ void TimeSliceBarline::assign_spacing_values(vector<StaffObjData*>& data,
     }
 
     //if previous slice is non-timed and is visible, transfer the space to the
-    //previous note so that non-timed is just before the barline (i.e. an intermediate
+    //previous note so that non-timed is just before the barline (e.g., an intermediate
     //clef). But if non-timed i, suppress barline previous space.
     else if (m_prev && m_prev->get_type() == TimeSlice::k_non_timed)
     {

--- a/src/graphic_model/layouters/lomse_system_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_system_layouter.cpp
@@ -330,7 +330,7 @@ bool SystemLayouter::system_must_be_truncated()
     //of type final is entered.
     //
     //Option 3 truncates staff lines after last staff object. It can be
-    //useful for creating score samples (i.e. for ebooks).
+    //useful for creating score samples (e.g., for ebooks).
 
 
     //never truncate empty scores

--- a/src/internal_model/lomse_api_internal_model.cpp
+++ b/src/internal_model/lomse_api_internal_model.cpp
@@ -77,7 +77,7 @@ namespace lomse
 ////    type final is entered.
 ////
 //    Option 'k_truncate_always' truncates staff lines after last staff object. It can
-//    be useful for creating score samples (i.e. for ebooks).
+//    be useful for creating score samples (e.g., for ebooks).
 //        k_isolated=0,       Independent barlines for each score part
 //        k_joined,           Barlines joined across all parts
 //        k_mensurstrich,     Barlines only in the gaps between parts, but not on

--- a/src/internal_model/lomse_im_figured_bass.cpp
+++ b/src/internal_model/lomse_im_figured_bass.cpp
@@ -241,7 +241,7 @@ void ImoFiguredBassInfo::set_from_string(const std::string& sData)
     EIntervalQuality quality = k_interval_as_implied;
     bool fParenthesis = false;
     std::string interval;
-    std::string fingerprint = "";       //explicit present intervals (i.e. "53", "642"
+    std::string fingerprint = "";       //explicit present intervals (e.g., "53", "642"
 
     //Finite automata to parse the string
 

--- a/src/module/lomse_events.cpp
+++ b/src/module/lomse_events.cpp
@@ -281,7 +281,7 @@ bool EventNotifier::notify_observers(SpEventInfo pEvent, Observable* target)
 //            (*it)->notify(pEvent);
             return true;
             //TODO: remove 'return' when following problem is fixed:
-            //    Object receiving notification might modify the document (i.e. link
+            //    Object receiving notification might modify the document (e.g., link
             //    'new problem') and this will invalidate target and all remaining
             //    objects in m_observers (!!!!)
         }

--- a/src/module/lomse_injectors.cpp
+++ b/src/module/lomse_injectors.cpp
@@ -252,7 +252,7 @@ string LibraryScope::get_build_date()
 {
     //__DATE__ string: contains eleven characters and looks like "Feb 12 1996".
     // If the day of the month is less than 10, it is padded with a space on the
-    // left, i.e. "Oct  8 2013"
+    // left, e.g., "Oct  8 2013"
     //__TIME__ : the time at which the preprocessor is being run. The string
     // contains eight characters and looks like "23:59:01"
 
@@ -406,6 +406,21 @@ SingleSystemView* Injector::inject_SingleSystemView(LibraryScope& libraryScope,
 {
     return static_cast<SingleSystemView*>(
                         inject_View(libraryScope, k_view_single_system, pDoc) );
+}
+
+//---------------------------------------------------------------------------------------
+SinglePageView* Injector::inject_SinglePageView(LibraryScope& libraryScope,
+                                                Document* pDoc)
+{
+    return static_cast<SinglePageView*>(
+                        inject_View(libraryScope, k_view_single_page, pDoc) );
+}
+
+//---------------------------------------------------------------------------------------
+FreeFlowView* Injector::inject_FreeFlowView(LibraryScope& libraryScope, Document* pDoc)
+{
+    return static_cast<FreeFlowView*>(
+                        inject_View(libraryScope, k_view_free_flow, pDoc) );
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/parser/ldp/lomse_ldp_analyser.cpp
+++ b/src/parser/ldp/lomse_ldp_analyser.cpp
@@ -1903,7 +1903,7 @@ protected:
 };
 
 //@--------------------------------------------------------------------------------------
-//@ For dynamic content, i.e. exercises
+//@ For dynamic content, e.g., exercises
 //@
 //@ <dynamic> = (dynamic <classid> <param>*)
 //@ <classid> = (classid <label>)
@@ -2312,7 +2312,7 @@ public:
 
 //@--------------------------------------------------------------------------------------
 //@ <font> = (font <font_name> <font_size> <font_style>)
-//@ <font_name> = string   i.e. "Times New Roman", "Trebuchet"
+//@ <font_name> = string   e.g., "Times New Roman", "Trebuchet"
 //@ <font_size> = num      in points
 //@ <font_style> = { "bold" | "normal" | "italic" | "bold-italic" }
 //@
@@ -2386,7 +2386,7 @@ public:
 
 //@--------------------------------------------------------------------------------------
 //@ <goFwd> = (goFwd <duration> [voice])
-//@ <duration> = note/rest duration, letter plus dots, i.e. 'e..'
+//@ <duration> = note/rest duration, letter plus dots, e.g., 'e..'
 //@
 //@ Version 1.x
 //@ <goBack> = (goBack <timeShift>)
@@ -2394,9 +2394,9 @@ public:
 //@ <timeShift> = { start | end | <number> | <duration> }
 //@
 //@ the time shift can be:
-//@   a) one of the tags 'start' and 'end': i.e. (goBack start) (goFwd end)
+//@   a) one of the tags 'start' and 'end': e.g., (goBack start) (goFwd end)
 //@   b) a number: the amount of 256th notes to go forward or backwards
-//@   c) a note/rest duration, i.e. 'e..'
+//@   c) a note/rest duration, e.g., 'e..'
 
 class GoBackFwdAnalyser : public ElementAnalyser
 {
@@ -2504,8 +2504,8 @@ protected:
         pImo->set_visible(false);
 
         // <duration> (label)
-        //AWARE: As goFwd is a rest, only note/rest duration is allowed (i.e. "e.")
-        //       Duration for goFwd is no longer alloed as number (i.e. 32)
+        //AWARE: As goFwd is a rest, only note/rest duration is allowed (e.g., "e.")
+        //       Duration for goFwd is no longer alloed as number (e.g., 32)
         if (get_mandatory(k_label))
             set_duration(pImo);
 

--- a/src/parser/lmd/lomse_lmd_analyser.cpp
+++ b/src/parser/lmd/lomse_lmd_analyser.cpp
@@ -1922,7 +1922,7 @@ public:
 
 //@--------------------------------------------------------------------------------------
 //@ <font> = (font <font_name> <font_size> <font_style>)
-//@ <font_name> = string   i.e. "Times New Roman", "Trebuchet"
+//@ <font_name> = string   e.g., "Times New Roman", "Trebuchet"
 //@ <font_size> = num      in points
 //@ <font_style> = { "bold" | "normal" | "italic" | "bold-italic" }
 //@
@@ -2001,9 +2001,9 @@ public:
 //@ <timeShift> = { start | end | <number> | <duration> }
 //@
 //@ the time shift can be:
-//@   a) one of the tags 'start' and 'end': i.e. (goBack start) (goFwd end)
+//@   a) one of the tags 'start' and 'end': e.g., (goBack start) (goFwd end)
 //@   b) a number: the amount of 256th notes to go forward or backwards
-//@   c) a note/rest duration, i.e. 'e..'
+//@   c) a note/rest duration, e.g., 'e..'
 
 class GoBackFwdLmdAnalyser : public LmdElementAnalyser
 {

--- a/src/parser/mnx/lomse_mnx_analyser.cpp
+++ b/src/parser/mnx/lomse_mnx_analyser.cpp
@@ -1297,8 +1297,8 @@ void MnxElementAnalyser::get_attributes_for_position(ImoObj* pObj)
 //-----------------------------------------------------------------------------------
 //@ % color
 //@ The color entity indicates the color of an element. Color may be represented:
-//@ - as hexadecimal RGB triples, as in HTML (i.e. "#800080" purple), or
-//@ - as hexadecimal ARGB tuples (i.e. "#40800080" transparent purple).
+//@ - as hexadecimal RGB triples, as in HTML (e.g., "#800080" purple), or
+//@ - as hexadecimal ARGB tuples (e.g., "#40800080" transparent purple).
 //@   Alpha 00 means 'totally transparent'; FF = 'totally opaque'
 //@ If RGB is used, the A value is assumed to be FF
 //@

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -775,8 +775,8 @@ protected:
     //-----------------------------------------------------------------------------------
     //@ % color
     //@ The color entity indicates the color of an element. Color may be represented:
-    //@ - as hexadecimal RGB triples, as in HTML (i.e. "#800080" purple), or
-    //@ - as hexadecimal ARGB tuples (i.e. "#40800080" transparent purple).
+    //@ - as hexadecimal RGB triples, as in HTML (e.g., "#800080" purple), or
+    //@ - as hexadecimal ARGB tuples (e.g., "#40800080" transparent purple).
     //@   Alpha 00 means 'totally transparent'; FF = 'totally opaque'
     //@ If RGB is used, the A value is assumed to be FF
     //@
@@ -6298,7 +6298,7 @@ protected:
         //The value must be a comma-separated list of positive integers arranged
         //in ascending order.
         //If error, string "1" is returned
-        //Otherwise any spaces are removed, i.e. "1, 2, 4" --> "1,2,4"
+        //Otherwise any spaces are removed, e.g., "1, 2, 4" --> "1,2,4"
             //TODO
         return string("1");
     }

--- a/src/tests/lomse_test_inlines_container_layouter.cpp
+++ b/src/tests/lomse_test_inlines_container_layouter.cpp
@@ -550,7 +550,7 @@ SUITE(InlinesContainerLayouterTest)
         LineReferences engr(120.0f, 350.0f, 500.0f, 650.0f); //top, middle, base, bottom
 
         MyInlinesContainerLayouter lyt(m_libraryScope, line);
-        LUnits shift = 400.0f - 350.0f;     //i.e. sub align
+        LUnits shift = 400.0f - 350.0f;     //e.g., sub align
         lyt.my_update_line_references(engr, shift, false /*text, no_baseline / no text*/);
 
         LineReferences& refs = lyt.get_line_refs();
@@ -574,7 +574,7 @@ SUITE(InlinesContainerLayouterTest)
         LineReferences engr(100.0f, 300.0f, 400.0f, 600.0f); //top, middle, base, bottom
 
         MyInlinesContainerLayouter lyt(m_libraryScope, line);
-        LUnits shift = 120.0f - 300.0f;     //i.e. supper align
+        LUnits shift = 120.0f - 300.0f;     //e.g., supper align
         lyt.my_update_line_references(engr, shift, false /*text, no_baseline / no text*/);
 
         LineReferences& refs = lyt.get_line_refs();

--- a/src/tests/lomse_test_internal_model.cpp
+++ b/src/tests/lomse_test_internal_model.cpp
@@ -971,7 +971,7 @@ SUITE(InternalModelTest)
     TEST_FIXTURE(InternalModelTestFixture, RelationsOrdered)
     {
         //@ Relations must be rendered in a predefined order,
-        //@ i.e. beams before tuplets. For this, they must be stored in
+        //@ e.g., beams before tuplets. For this, they must be stored in
         //@ renderization order.
 
         Document doc(m_libraryScope);


### PR DESCRIPTION
This PR closes #122 (Create a "Free flow" View) and also creates a “Single page” view, as described in #233.

### Single Page View

SinglePageView is a GraphicView for rendering documents in a single page as high as necessary. It is similar to a VerticalBookView but using a paper size of infinite height, so that only paper width is meaningful and the document has just one page (e.g., an HTML page having a body of fixed size):

- As VerticalBookView but with infinite paper height. Only paper width is meaningful
- It displays the document in a single page, having a fixed width defined by document paper width. 
- There are no gaps between ‘pages’ as there is only a single page.
- The View does not display grey background when the viewport includes areas not occupied by the document. Background colour is, by default, white. But it can be changed by the user application.


### Free Flow View

FreeFlowView is a GraphicView for rendering documents in a single page as high as necessary. It is similar to a VerticalBookView but using a paper size of infinite height, so that only paper width is meaningful and the document has just one page (e.g., an HTML page with unconstrained body width):

- It displays the document in a single page, and reflows / reformats its content to always adapt to available page width. 
- There are no gaps between ‘pages’ as there is only a single page. Horizontal scroll is non-sense as there are nothing rendered at left/right of viewport.
- The View does not display grey background when the viewport includes areas not occupied by the document. Background colour is, by default, white. But it can be changed by the user application.


