### PR TITLE
Implement option to center snippet scores

### DIFF
--- a/include/lomse_graphic_view.h
+++ b/include/lomse_graphic_view.h
@@ -663,10 +663,10 @@ protected:
 
 
 //---------------------------------------------------------------------------------------
-/** %SinglePageView is a GraphicView for rendering documents in a single page as hight
+/** %SinglePageView is a GraphicView for rendering documents in a single page as high
     as necessary. It is similar to a VerticalBookView but using a paper size of infinite
     height, so that only paper width is meaningful and the document has just one page
-    (e.g., an HTML page)
+    (e.g., an HTML page having a body of fixed size)
 
     <b>Margins</b>
 
@@ -677,7 +677,7 @@ protected:
 
     <b>Background color</b>
 
-    The white paper is surrounded by the background, that will be visible only whne the
+    The white paper is surrounded by the background, that will be visible only when the
     user application changes the viewport (e.g., by scrolling right).
     In %SinglePageView the default background color is white and, as with all Views,
     the background color can be changed by invoking Interactor::set_view_background().
@@ -714,10 +714,10 @@ protected:
 
 
 //---------------------------------------------------------------------------------------
-/** %FreeFlowView is a GraphicView for rendering documents in a single page as hight
+/** %FreeFlowView is a GraphicView for rendering documents in a single page as high
     as necessary. It is similar to a VerticalBookView but using a paper size of infinite
     height, so that only paper width is meaningful and the document has just one page
-    (e.g., an HTML page)
+    (e.g., an HTML page with unconstrained body width)
 
     <b>Margins</b>
 
@@ -728,7 +728,7 @@ protected:
 
     <b>Background color</b>
 
-    The white paper is surrounded by the background, that will be visible only whne the
+    The white paper is surrounded by the background, that will be visible only when the
     user application changes the viewport (e.g., by scrolling right).
     In %FreeFlowView the default background color is white and, as with all Views,
     the background color can be changed by invoking Interactor::set_view_background().

--- a/include/lomse_score_layouter.h
+++ b/include/lomse_score_layouter.h
@@ -232,10 +232,12 @@ protected:
     void decide_line_breaks();
     void page_initializations(GmoBox* pContainerBox);
     void decide_line_sizes();
-    void fill_page_with_empty_systems_if_required();
+    void final_touches();
     bool score_page_is_the_only_content_of_parent_box();
-    void remove_unused_space();
 
+    void fill_page_with_empty_systems_if_required();
+    void remove_unused_space();
+    void center_score_if_requested();
     void delete_system_layouters();
     void get_score_renderization_options();
     void auto_scale();

--- a/include/lomse_shape_barline.h
+++ b/include/lomse_shape_barline.h
@@ -83,7 +83,7 @@ protected:
                         Color color);
     void draw_thick_line(Drawer* pDrawer, LUnits uxLeft, LUnits uyTop, LUnits uWidth,
                          LUnits uHeight, Color color);
-    void draw_two_dots(Drawer* pDrawer, LUnits uxPos, LUnits uyPos);
+    void draw_two_dots(Drawer* pDrawer, LUnits uxPos, LUnits uyPos, Color color);
 
 };
 

--- a/src/graphic_model/lomse_shape_barline.cpp
+++ b/src/graphic_model/lomse_shape_barline.cpp
@@ -208,7 +208,7 @@ void GmoShapeBarline::on_draw(Drawer* pDrawer, RenderOptions& opt)
         case k_barline_end_repetition:
             //uxPos += m_uRadius;
             uxPos += m_uRadius * 2.7f;   //BUG-BYPASS: Need to shift right the drawing
-            draw_two_dots(pDrawer, uxPos, uyTop);
+            draw_two_dots(pDrawer, uxPos, uyTop, color);
             uxPos += m_uRadius + m_uSpacing;
             draw_thin_line(pDrawer, uxPos, uyTop, uyBottom, color);
             uxPos += m_uThinLineWidth + m_uSpacing;
@@ -220,29 +220,29 @@ void GmoShapeBarline::on_draw(Drawer* pDrawer, RenderOptions& opt)
             uxPos += m_uThickLineWidth + m_uSpacing;
             draw_thin_line(pDrawer, uxPos, uyTop, uyBottom, color);
             uxPos += m_uThinLineWidth + m_uSpacing + m_uRadius;
-            draw_two_dots(pDrawer, uxPos, uyTop);
+            draw_two_dots(pDrawer, uxPos, uyTop, color);
             break;
 
         case k_barline_double_repetition:
             uxPos += m_uRadius;
-            draw_two_dots(pDrawer, uxPos, uyTop);
+            draw_two_dots(pDrawer, uxPos, uyTop, color);
             uxPos += m_uSpacing + m_uRadius;
             draw_thin_line(pDrawer, uxPos, uyTop, uyBottom, color);
             uxPos += m_uThinLineWidth + m_uSpacing;
             draw_thin_line(pDrawer, uxPos, uyTop, uyBottom, color);
             uxPos += m_uThinLineWidth + m_uSpacing + m_uRadius;
-            draw_two_dots(pDrawer, uxPos, uyTop);
+            draw_two_dots(pDrawer, uxPos, uyTop, color);
             break;
 
         case k_barline_double_repetition_alt:
             uxPos += m_uRadius;
-            draw_two_dots(pDrawer, uxPos, uyTop);
+            draw_two_dots(pDrawer, uxPos, uyTop, color);
             uxPos += m_uSpacing + m_uRadius;
             draw_thick_line(pDrawer, uxPos, uyTop, m_uThickLineWidth, uyBottom-uyTop, color);
             uxPos += m_uThickLineWidth + m_uSpacing;
             draw_thick_line(pDrawer, uxPos, uyTop, m_uThickLineWidth, uyBottom-uyTop, color);
             uxPos += m_uThickLineWidth + m_uSpacing + m_uRadius;
-            draw_two_dots(pDrawer, uxPos, uyTop);
+            draw_two_dots(pDrawer, uxPos, uyTop, color);
             break;
 
         case k_barline_start:
@@ -272,6 +272,7 @@ void GmoShapeBarline::draw_thin_line(Drawer* pDrawer, LUnits uxPos, LUnits uyTop
 {
     pDrawer->begin_path();
     pDrawer->fill(color);
+    pDrawer->stroke(color);
     pDrawer->line(uxPos + m_uThinLineWidth/2, uyTop,
                   uxPos + m_uThinLineWidth/2, uyBottom,
                   m_uThinLineWidth, k_edge_normal);
@@ -284,6 +285,7 @@ void GmoShapeBarline::draw_thick_line(Drawer* pDrawer, LUnits uxPos, LUnits uyTo
 {
     pDrawer->begin_path();
     pDrawer->fill(color);
+    pDrawer->stroke(color);
     pDrawer->line(uxPos + uWidth/2, uyTop,
                   uxPos + uWidth/2, uyTop + uHeight,
                   uWidth, k_edge_normal);
@@ -291,11 +293,14 @@ void GmoShapeBarline::draw_thick_line(Drawer* pDrawer, LUnits uxPos, LUnits uyTo
 }
 
 //---------------------------------------------------------------------------------------
-void GmoShapeBarline::draw_two_dots(Drawer* pDrawer, LUnits uxPos, LUnits uyPos)
+void GmoShapeBarline::draw_two_dots(Drawer* pDrawer, LUnits uxPos, LUnits uyPos,
+                                    Color color)
 {
     LUnits uShift1 = m_uSpacing * 3.7f;
     LUnits uShift2 = m_uSpacing * 6.1f;
     pDrawer->begin_path();
+    pDrawer->fill(color);
+    pDrawer->stroke(color);
     pDrawer->circle(uxPos, uyPos + uShift1, m_uRadius);
     pDrawer->circle(uxPos, uyPos + uShift2, m_uRadius);
     pDrawer->end_path();

--- a/src/parser/ldp/lomse_ldp_analyser.cpp
+++ b/src/parser/ldp/lomse_ldp_analyser.cpp
@@ -4292,6 +4292,7 @@ public:
     {
         return (name == "Score.FillPageWithEmptyStaves")
             || (name == "Score.JustifyFinalBarline")
+            || (name == "Score.Center")
             || (name == "StaffLines.StopAtFinalBarline")    //deprecated 2.1
             || (name == "StaffLines.Hide")
             || (name == "Staff.DrawLeftBarline");


### PR DESCRIPTION
This PR adds support in LDP for centering snippet scores, that is, small scores with just one system and taking less width than available paper width. This option is intended for examples embedded in eBooks.

Also this PR includes some fixes for typos in Views documentation, and a fix for barlines that were not properly drawn when requested to use a colour  instead of B&W.