### PR TITLE
Add support for reading compressed MusicXML files

### DIFF
--- a/add-sources.cmake
+++ b/add-sources.cmake
@@ -188,6 +188,7 @@ set(PARSER_FILES
 
     ${LOMSE_SRC_DIR}/parser/mxl/lomse_mxl_analyser.cpp
     ${LOMSE_SRC_DIR}/parser/mxl/lomse_mxl_compiler.cpp
+    ${LOMSE_SRC_DIR}/parser/mxl/lomse_compressed_mxl_compiler.cpp
 
     ${LOMSE_SRC_DIR}/parser/mnx/lomse_mnx_analyser.cpp
     ${LOMSE_SRC_DIR}/parser/mnx/lomse_mnx_compiler.cpp

--- a/include/lomse_compressed_mxl_compiler.h
+++ b/include/lomse_compressed_mxl_compiler.h
@@ -27,60 +27,42 @@
 // the project at cecilios@users.sourceforge.net
 //---------------------------------------------------------------------------------------
 
-#ifndef __LOMSE_COMPILER_H__
-#define __LOMSE_COMPILER_H__
+#ifndef __LOMSE_COMPRESSED_MXL_COMPILER_H__
+#define __LOMSE_COMPRESSED_MXL_COMPILER_H__
 
-#include "lomse_parser.h"
-#include "lomse_analyser.h"
-
-#include <string>
-using namespace std;
+#include "lomse_compiler.h"
 
 namespace lomse
 {
 
 //forward declarations
-class ModelBuilder;
-class DocumentScope;
-class LibraryScope;
-class ImoDocument;
-class Document;
-
+class MxlCompiler;
+class ZipInputStream;
 
 //---------------------------------------------------------------------------------------
-// Compiler: base class for all compilers
-class Compiler
+// CompressedMxlCompiler: builds the tree for a document
+class CompressedMxlCompiler : public Compiler
 {
 protected:
-    Parser*         m_pParser;
-    Analyser*       m_pAnalyser;
-    ModelBuilder*   m_pModelBuilder;
-    Document*       m_pDoc;
-    string         m_fileLocator;
-
-    Compiler()
-        : m_pParser(nullptr)
-        , m_pAnalyser(nullptr)
-        , m_pModelBuilder(nullptr)
-        , m_pDoc(nullptr)
-    {
-    }
-    Compiler(Parser* p, Analyser* a, ModelBuilder* mb, Document* pDoc);
+    MxlCompiler* m_pMxlCompiler;
 
 public:
-    virtual ~Compiler();
+    explicit CompressedMxlCompiler(MxlCompiler* pMxlCompiler);
+    ~CompressedMxlCompiler();
 
     //compilation
-    virtual ImoDocument* compile_file(const std::string& filename)=0;
-    virtual ImoDocument* compile_string(const std::string& source)=0;
+    ImoDocument* compile_file(const std::string& filename) override;
+    ImoDocument* compile_string(const std::string& source) override;
 
     //info
-    virtual int get_num_errors() const;
-    string get_file_locator() { return m_fileLocator; }
+    int get_num_errors() const override;
 
+protected:
+    std::string get_rootfile_path(ZipInputStream&);
+    std::string read_rootfile(ZipInputStream&);
 };
 
 
 }   //namespace lomse
 
-#endif      //__LOMSE_COMPILER_H__
+#endif      //__LOMSE_COMPRESSED_MXL_COMPILER_H__

--- a/include/lomse_injectors.h
+++ b/include/lomse_injectors.h
@@ -52,6 +52,7 @@ class LmdAnalyser;
 class LmdCompiler;
 class MxlAnalyser;
 class MxlCompiler;
+class CompressedMxlCompiler;
 class MnxAnalyser;
 class MnxCompiler;
 class ModelBuilder;
@@ -267,6 +268,8 @@ public:
     static MxlAnalyser* inject_MxlAnalyser(LibraryScope& libraryScope, Document* pDoc,
                                            XmlParser* pParser);
     static MxlCompiler* inject_MxlCompiler(LibraryScope& libraryScope, Document* pDoc);
+    static CompressedMxlCompiler* inject_CompressedMxlCompiler(LibraryScope& libraryScope,
+                                                               Document* pDoc);
 
     //MNX format
     static MnxAnalyser* inject_MnxAnalyser(LibraryScope& libraryScope, Document* pDoc,

--- a/include/lomse_parser.h
+++ b/include/lomse_parser.h
@@ -64,7 +64,7 @@ public:
     virtual void parse_text(const std::string& sourceText) = 0;
     //virtual void parse_input(LdpReader& reader) = 0;
 
-    inline int get_num_errors() { return m_numErrors; }
+    inline int get_num_errors() const { return m_numErrors; }
 
 };
 

--- a/include/lomse_zip_stream.h
+++ b/include/lomse_zip_stream.h
@@ -35,6 +35,7 @@
 
 #include <fstream>
 #include <sstream>
+#include <vector>
 using namespace std;
 
 #include "unzip.h"      //minizip package
@@ -128,6 +129,7 @@ public:
 
     //operations
     unsigned char* get_as_string();
+    std::vector<unsigned char> get_as_vector();
 
 	//positioning
 	bool move_to_first_entry();

--- a/include/private/lomse_document_p.h
+++ b/include/private/lomse_document_p.h
@@ -159,6 +159,7 @@ public:
         k_format_ldp = 0,   ///< Lenguaje De Partituras (LDP, LISP like syntax)
         k_format_lmd,       ///< LenMus %Document (LMD, XML syntax)
         k_format_mxl,       ///< MusicXML format
+        k_format_mxl_compressed, ///< Compressed MusicXML format
         k_format_mnx,       ///< W3C MNX format
         k_format_unknown,
     };

--- a/src/document/lomse_document.cpp
+++ b/src/document/lomse_document.cpp
@@ -38,6 +38,7 @@
 #include "lomse_xml_parser.h"
 #include "lomse_lmd_compiler.h"
 #include "lomse_mxl_compiler.h"
+#include "lomse_compressed_mxl_compiler.h"
 #include "lomse_mnx_compiler.h"
 #include "lomse_injectors.h"
 #include "lomse_id_assigner.h"
@@ -205,7 +206,7 @@ int Document::from_file(const string& filename, int format)
     if (m_pImoDoc == nullptr)
         create_empty();
 
-    if (m_pImoDoc && format == Document::k_format_mxl)
+    if (m_pImoDoc && (format == Document::k_format_mxl || format == Document::k_format_mxl_compressed))
         fix_malformed_musicxml();
 
     return numErrors;
@@ -232,7 +233,7 @@ int Document::from_string(const string& source, int format)
     if (m_pImoDoc == nullptr)
         create_empty();
 
-    if (m_pImoDoc && format == Document::k_format_mxl)
+    if (m_pImoDoc && (format == Document::k_format_mxl || format == Document::k_format_mxl_compressed))
         fix_malformed_musicxml();
 
     return numErrors;
@@ -393,6 +394,11 @@ Compiler* Document::get_compiler_for_format(int format)
 
         case k_format_mxl:
             return Injector::inject_MxlCompiler(m_libraryScope, this);
+
+#if (LOMSE_ENABLE_COMPRESSION == 1)
+        case k_format_mxl_compressed:
+            return Injector::inject_CompressedMxlCompiler(m_libraryScope, this);
+#endif
 
         case k_format_mnx:
             return Injector::inject_MnxCompiler(m_libraryScope, this);

--- a/src/file_system/lomse_zip_stream.cpp
+++ b/src/file_system/lomse_zip_stream.cpp
@@ -417,6 +417,17 @@ unsigned char* ZipInputStream::get_as_string()
     return buffer;
 }
 
+//---------------------------------------------------------------------------------------
+std::vector<unsigned char> ZipInputStream::get_as_vector()
+{
+    long size = get_size();
+    std::vector<unsigned char> buffer(size+1);
+
+    long i = read(buffer.data(), size);
+    buffer[i] = '\0';
+
+    return buffer;
+}
 
 }  //namespace lomse
 

--- a/src/module/lomse_injectors.cpp
+++ b/src/module/lomse_injectors.cpp
@@ -39,6 +39,7 @@
 #include "lomse_lmd_compiler.h"
 #include "lomse_mxl_analyser.h"
 #include "lomse_mxl_compiler.h"
+#include "lomse_compressed_mxl_compiler.h"
 #include "lomse_mnx_analyser.h"
 #include "lomse_mnx_compiler.h"
 #include "lomse_model_builder.h"
@@ -332,6 +333,14 @@ MxlCompiler* Injector::inject_MxlCompiler(LibraryScope& libraryScope,
                                  inject_MxlAnalyser(libraryScope, pDoc, pParser),
                                  inject_ModelBuilder(pDoc->get_scope()),
                                  pDoc );
+}
+
+//---------------------------------------------------------------------------------------
+CompressedMxlCompiler* Injector::inject_CompressedMxlCompiler(LibraryScope& libraryScope,
+                                                              Document* pDoc)
+{
+    MxlCompiler* pMxlCompiler = Injector::inject_MxlCompiler(libraryScope, pDoc);
+    return LOMSE_NEW CompressedMxlCompiler(pMxlCompiler);
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/mvc/lomse_presenter.cpp
+++ b/src/mvc/lomse_presenter.cpp
@@ -69,6 +69,8 @@ public:
             return Document::k_format_lmd;
         else if (ext == "xml" || ext == "musicxml")
             return Document::k_format_mxl;
+        else if (ext == "mxl")
+            return Document::k_format_mxl_compressed;
         else if (ext == "mnx")
             return Document::k_format_mnx;
         else

--- a/src/parser/lomse_compiler.cpp
+++ b/src/parser/lomse_compiler.cpp
@@ -55,7 +55,7 @@ Compiler::~Compiler()
 }
 
 //---------------------------------------------------------------------------------------
-int Compiler::get_num_errors()
+int Compiler::get_num_errors() const
 {
     return m_pParser->get_num_errors();
 }

--- a/src/parser/mxl/lomse_compressed_mxl_compiler.cpp
+++ b/src/parser/mxl/lomse_compressed_mxl_compiler.cpp
@@ -1,0 +1,143 @@
+//---------------------------------------------------------------------------------------
+// This file is part of the Lomse library.
+// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice, this
+//      list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright notice, this
+//      list of conditions and the following disclaimer in the documentation and/or
+//      other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+// SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// For any comment, suggestion or feature request, please contact the manager of
+// the project at cecilios@users.sourceforge.net
+//---------------------------------------------------------------------------------------
+
+#include "lomse_compressed_mxl_compiler.h"
+
+#include "lomse_mxl_compiler.h"
+#include "lomse_xml_parser.h"
+
+#if (LOMSE_ENABLE_COMPRESSION == 1)
+	#include "lomse_zip_stream.h"
+#endif
+
+namespace lomse
+{
+
+//=======================================================================================
+// CompressedMxlCompiler implementation
+//=======================================================================================
+CompressedMxlCompiler::CompressedMxlCompiler(MxlCompiler* pMxlCompiler)
+    : Compiler()
+    , m_pMxlCompiler(pMxlCompiler)
+{
+}
+
+//---------------------------------------------------------------------------------------
+CompressedMxlCompiler::~CompressedMxlCompiler()
+{
+    delete m_pMxlCompiler;
+}
+
+//---------------------------------------------------------------------------------------
+ImoDocument* CompressedMxlCompiler::compile_file(const std::string& filename)
+{
+    m_fileLocator = filename;
+
+#if (LOMSE_ENABLE_COMPRESSION == 1)
+    ZipInputStream zip(filename);
+
+    const std::string mxmlString = read_rootfile(zip);
+
+    if (mxmlString.empty())
+    {
+        LOMSE_LOG_ERROR("[CompressedMxlCompiler::compile_file] Couldn't read rootfile");
+        return nullptr;
+    }
+
+    return m_pMxlCompiler->compile_string(mxmlString);
+#else
+    throw runtime_error("Could not open compressed file: Lomse was compiled without compression support");
+#endif
+}
+
+//---------------------------------------------------------------------------------------
+ImoDocument* CompressedMxlCompiler::compile_string(const std::string& UNUSED(source))
+{
+    m_fileLocator = "string:";
+    throw runtime_error("Could not open compressed .mxl string: reading compressed string is not supported currently");
+}
+
+//---------------------------------------------------------------------------------------
+std::string CompressedMxlCompiler::get_rootfile_path(ZipInputStream& zip)
+{
+#if (LOMSE_ENABLE_COMPRESSION == 1)
+    zip.move_to_entry("META-INF/container.xml");
+
+    if (!zip.open_current_entry())
+        return std::string();
+
+    std::vector<unsigned char> metaInfBuffer = zip.get_as_vector();
+
+    XmlParser xml;
+    xml.parse_cstring(reinterpret_cast<char*>(metaInfBuffer.data()));
+
+    XmlNode* root = xml.get_tree_root();
+
+    if (!root || root->name() != "container")
+        return std::string();
+
+    // XmlNode methods would just return empty values in case of
+    // errors so we won't do any special errors handling here.
+    XmlNode rootfiles = root->child("rootfiles");
+    XmlNode firstRootfile = rootfiles.child("rootfile");
+    return firstRootfile.attribute_value("full-path");
+#else
+    return std::string();
+#endif
+}
+
+//---------------------------------------------------------------------------------------
+std::string CompressedMxlCompiler::read_rootfile(ZipInputStream& zip)
+{
+#if (LOMSE_ENABLE_COMPRESSION == 1)
+    const std::string rootFilePath = get_rootfile_path(zip);
+
+    if (rootFilePath.empty())
+        return std::string();
+
+    zip.move_to_entry(rootFilePath);
+
+    if (!zip.open_current_entry())
+        return std::string();
+
+    std::vector<unsigned char> mxmlBuffer = zip.get_as_vector();
+
+    return std::string(reinterpret_cast<char*>(mxmlBuffer.data()));
+#else
+    return std::string();
+#endif
+}
+
+//---------------------------------------------------------------------------------------
+int CompressedMxlCompiler::get_num_errors() const
+{
+    return m_pMxlCompiler->get_num_errors();
+}
+
+}  //namespace lomse


### PR DESCRIPTION
Currently Lomse is able to read uncompressed MusicXML files but refuses to open the compressed (`.mxl`) MusicXML files. This pull request implements a `Compiler` subclass for reading `.mxl` format which uncompresses the root MusicXML file and passes its content to the usual compiler for MusicXML format. The implementation of reading `.mxl` format follows [this reference](https://www.musicxml.com/tutorial/compressed-mxl-files/). Of course all this works only if Lomse is built with compression support, although I am not sure whether it makes sense to fully exclude `.mxl` compiler and the relevant methods from Lomse build in case compression support is disabled.

In general I tried to follow architecture and coding style seen around in the Lomse library but could certainly miss something. Also in some places I took a liberty to avoid manual creation and deletion of objects and arrays and used stack allocation and standard containers for managing their lifetime. This should cause no issues, at least performance ones, especially that C++11 standard with its move semantics is already [required](https://github.com/lenmus/lomse/blob/db7f2d410777020b2ab2ca379570afd5105062db/CMakeLists.txt#L431) by the build system. However if for some reasons this is undesirable for the project I can revert that part of the proposed changes.