### PR TITLE
Implement HalfPageView

### DIFF
--- a/add-sources.cmake
+++ b/add-sources.cmake
@@ -161,6 +161,7 @@ set(MODULE_FILES
 
 set(MVC_FILES
     ${LOMSE_SRC_DIR}/mvc/lomse_graphic_view.cpp
+    ${LOMSE_SRC_DIR}/mvc/lomse_half_page_view.cpp
     ${LOMSE_SRC_DIR}/mvc/lomse_interactor.cpp
     ${LOMSE_SRC_DIR}/mvc/lomse_presenter.cpp 
     ${LOMSE_SRC_DIR}/mvc/lomse_tasks.cpp
@@ -186,9 +187,9 @@ set(PARSER_FILES
     ${LOMSE_SRC_DIR}/parser/lmd/lomse_lmd_analyser.cpp
     ${LOMSE_SRC_DIR}/parser/lmd/lomse_lmd_compiler.cpp
 
+    ${LOMSE_SRC_DIR}/parser/mxl/lomse_compressed_mxl_compiler.cpp
     ${LOMSE_SRC_DIR}/parser/mxl/lomse_mxl_analyser.cpp
     ${LOMSE_SRC_DIR}/parser/mxl/lomse_mxl_compiler.cpp
-    ${LOMSE_SRC_DIR}/parser/mxl/lomse_compressed_mxl_compiler.cpp
 
     ${LOMSE_SRC_DIR}/parser/mnx/lomse_mnx_analyser.cpp
     ${LOMSE_SRC_DIR}/parser/mnx/lomse_mnx_compiler.cpp

--- a/include/lomse_box_system.h
+++ b/include/lomse_box_system.h
@@ -54,7 +54,8 @@ protected:
 	vector<GmoShapeStaff*> m_staffShapes;
 	vector<int> m_firstStaff;       //index to first staff for each instrument
     TimeGridTable* m_pGridTable;
-    int m_iPage;            //number of score page (0..n-1) in which this system is contained
+    int m_iPage;        //index of score page (0..n-1) in which this system is contained
+    int m_iSystem;      //index of this system in the score (0..n-1)
 
 	vector<int> m_iFirstMeasure;    //index to first measure, per instrument
     vector<int> m_nMeasures;        //number of measures in this system, per instrument
@@ -86,6 +87,7 @@ public:
     LUnits get_x_for_barline_at_time(TimeUnits timepos);
 
 	//miscellaneous info
+	inline int get_system_number() { return m_iSystem; }
     GmoShapeStaff* get_staff_shape(int absStaff);
     GmoShapeStaff* get_staff_shape(int iInstr, int iStaff);
     int instr_number_for_staff(int absStaff);
@@ -132,6 +134,9 @@ protected:
 
     friend class SystemLayouter;
     inline void add_shift_to_start_measure(LUnits width) { m_dxFirstMeasure += width; }
+
+    friend class GmoBoxScorePage;
+    inline void set_system_number(int iSystem) { m_iSystem = iSystem; }
 
 
 };

--- a/include/lomse_gm_basic.h
+++ b/include/lomse_gm_basic.h
@@ -568,9 +568,10 @@ public:
 class GmoBoxScorePage : public GmoBox
 {
 protected:
-    int m_iFirstSystem;     //0..n-1
-    int m_iLastSystem;      //0..n-1
-    int m_iPage;            //0..n-1        number of this score page
+    int m_iFirstSystem;         //0..n-1
+    int m_iLastSystem;          //0..n-1
+    int m_iPage;                //0..n-1        number of this score-page
+    LUnits m_maxSystemHeight;   //height of highest system in this page
 
 public:
     GmoBoxScorePage(ImoScore* pScore);
@@ -587,6 +588,7 @@ public:
     }
 	GmoBoxSystem* get_system(int iSystem);		//nSystem = 0..n-1
 	inline int get_page_number() { return m_iPage; }
+    LUnits get_max_system_height() { return m_maxSystemHeight; }
 
 	//timepos information
 	TimeUnits end_time();

--- a/include/lomse_graphic_view.h
+++ b/include/lomse_graphic_view.h
@@ -116,6 +116,7 @@ enum EViewType {
     k_view_single_system,
     k_view_single_page,
     k_view_free_flow,
+    k_view_half_page,
 };
 
 ///@cond INTERNAL
@@ -214,7 +215,7 @@ public:
     void use_cursor(DocCursor* pCursor);
     void use_selection_set(SelectionSet* pSelectionSet);
     void add_visual_effect(VisualEffect* pEffect);
-    void set_visual_effects_for_mode(int mode);
+    virtual void on_mode_changed(int mode);
 
     ///@}    //View settings
 
@@ -444,7 +445,7 @@ public:
 protected:
     GraphicView(LibraryScope& libraryScope, ScreenDrawer* pDrawer);
 
-    void draw_all();
+    virtual void draw_all();
     void draw_graphic_model();
     void draw_time_grid();
     void generate_paths();
@@ -469,7 +470,8 @@ protected:
     void layout_selection_highlight();
     void delete_all_handlers();
     void add_handler(int iHandler, GmoObj* pOwnerGmo);
-    void do_change_viewport(Pixels x, Pixels y);
+    virtual void do_change_viewport(Pixels x, Pixels y);
+    void set_visual_effects_for_mode(int mode);
 
     //scrolling and tempo line
 
@@ -507,8 +509,8 @@ protected:
     void do_change_viewport();
 
 
-    void do_move_tempo_line_and_change_viewport(ImoId scoreId, TimeUnits timepos,
-                                                bool fTempoLine, bool fViewport);
+    virtual void do_move_tempo_line_and_change_viewport(ImoId scoreId, TimeUnits timepos,
+                                                        bool fTempoLine, bool fViewport);
 
 };
 
@@ -768,82 +770,6 @@ public:
 ///@endcond
 
 };
-
-
-//---------------------------------------------------------------------------------------
-/** %HalfPageView is a GraphicView for rendering scores.
-
-    It has a double behaviour. For displayin the score, it behaves as a SinglePageView,
-    taht is, the score is displayed as ...
-
-    But during playback, the behaviour is different. When playback starts,
-    The window is split horizontally in two halfs, originating two virtual vertical
-    windows, one at top and the other at bottom. In top window it is displayed the first
-    score chunk and the second chunk is displayed in the bottom windows. When playback
-    enters in the bottom window the top windows is updated with the third chunk. Next,
-    when the playback enters again in top window, the bottom window is updated with the
-    next chunk, and so on.
-
-- It allows to solve the problem of repetition marks and jumps: when the window being played has a jump, the other window is updated with the next logical system positioned at right measure instead of with the next chunk. The behaviour for the user is simple: when the user finds a jump he/she will know that it is necessary to jump to the other half window, unless the repetition is over and the music should continue from that point.
-
-- But, as other solutions, it is only useful when system height is not big, in this case when it is smaller than half window.
-
-    <b>Margins</b>
-
-    The document is displayed on a white paper and the view has no margins, that is, the
-    default view origin point is (0.0, 0.0). Therefore, document content will be
-    displayed with the margins defined in the document.
-
-
-    <b>Background color</b>
-
-    The white paper is surrounded by the background, that will be visible only when the
-    user application changes the viewport (e.g., by scrolling right).
-    In %FreeFlowView the default background color is white and, as with all Views,
-    the background color can be changed by invoking Interactor::set_view_background().
-
-
-    <b>AutoScroll</b>
-
-    When this View is used for rendering a music score, during playback auto-scroll
-    will be, by default, enabled. This implies that as playback advances the View
-    will generate EventUpdateViewport events so that measure being played is always
-    totally visible.
-*/
-class LOMSE_EXPORT HalfPageView : public GraphicView
-{
-public:
-///@cond INTERNALS
-//excluded from public API because the View methods are managed from Interactor
-
-    HalfPageView(LibraryScope& libraryScope, ScreenDrawer* pDrawer);
-    virtual ~HalfPageView() {}
-
-//    //overrides for SinglePageView
-//    int get_layout_constrains() override { return k_use_viewport_width | k_infinite_height; }
-//
-//    //overrides for GraphicView
-//    bool graphic_model_must_be_updated() override;
-//    void zoom_in(Pixels x=0, Pixels y=0) override;
-//    void zoom_out(Pixels x=0, Pixels y=0) override;
-//    void zoom_fit_full(Pixels width, Pixels height) override;
-//    void zoom_fit_width(Pixels width) override;
-//    void set_scale(double scale, Pixels x=0, Pixels y=0) override;
-
-    int page_at_screen_point(double x, double y) override;
-    void set_viewport_for_page_fit_full(Pixels screenWidth) override;
-    void get_view_size(Pixels* xWidth, Pixels* yHeight) override;
-    int get_layout_constrains() override { return k_use_paper_width | k_infinite_height; }
-    bool is_valid_for_this_view(Document* UNUSED(pDoc)) override { return true; }
-
-///@endcond
-
-protected:
-    void collect_page_bounds() override;
-
-};
-
-
 
 
 }   //namespace lomse

--- a/include/lomse_half_page_view.h
+++ b/include/lomse_half_page_view.h
@@ -42,39 +42,48 @@ namespace lomse
 //---------------------------------------------------------------------------------------
 /** %HalfPageView is a GraphicView for rendering scores.
 
-    It has a double behaviour. For displayin the score, it behaves as a SinglePageView,
-    that is, the score is displayed as ...
+    This view has a double behaviour. In normal mode (no playback) it behaves as
+    SinglePageView, that is the score is rendered on a single page as high as necessary
+    to contain all the score (e.g., an HTML page having a body of fixed size).
 
-    But during playback, the behaviour is different. When playback starts,
-    The window is split horizontally in two halfs, originating two virtual vertical
-    windows, one at top and the other at bottom. In top window it is displayed the first
-    score chunk and the second chunk is displayed in the bottom windows. When playback
-    enters in the bottom window the top windows is updated with the third chunk. Next,
-    when the playback enters again in top window, the bottom window is updated with the
-    next chunk, and so on.
+    But when in playback mode, the bitmap to be rendered in the application window is
+    split horizontally in two halves, originating two virtual vertical windows, one at
+    top and the other at bottom. In the top window it is displayed the first score chunk
+    and the second chunk is displayed in the bottom window. When playback enters in the
+    bottom window the top window is updated with the third chunk. Next, when the playback
+    enters again in the top window, the bottom window is updated with the next chunk,
+    and so on.
 
-    This view solves the problem of repetition marks and jumps: when the half window
-    being played has a jump, the other half window is updated with the next logical system
-    positioned at right measure instead of with the next chunk. The behaviour for the
-    user is simple: when the user finds a jump he/she will know that it is necessary to
-    jump to the other half window, unless the repetition is over and the music should
-    continue from that point.
+    When playback is finished (because the end of the score is reached or because the
+    app stops playback  -- but not when playback is paused --) the display returns
+    automatically to SinglePageView mode.
 
-    But it is only useful when system height is not big, smaller than half window.
+    This view allows to solve the problem page turning and the problem of repetition
+    marks and jumps:  when the window being played has a jump to a system not visible
+    in that window, the other window is updated  with the next logical system (the one
+    containing the jump destination) instead of with the next system. The behaviour for
+    the user is very simple: when the end of the last system in current window is reached
+    or when user finds a jump to a point that is not displayed in current window, he/she
+    will know that it is necessary to jump to the other half window.
 
-    <b>Margins</b>
+    You should note that when the view is split, only full systems are displayed in
+    the sub-windows. This is to avoid doubts about were the music continues, that could
+    appear in cases in which next system is practically fully displayed after current
+    one. It also makes the display more clear.
 
-    The document is displayed on a white paper and the view has no margins, that is, the
-    default view origin point is (0.0, 0.0). Therefore, document content will be
-    displayed with the margins defined in the document.
+    The view does not enter in split mode in the following cases:
+    - when window height is smaller than two times the highest system,
+    - when window width is lower than system width,
+    - when the score fits completely in the window height, or
+    - when the document is not only one score
+    In these cases, playback behaviour will be that of SinglePageView
 
+    When the view is in split mode (during playback) all settings for controlling what
+    to display and how, are fully controlled by the view. Therefore, the user application
+    should disable all user controls that could invoke methods to do changes, such as
+    scroll position, zoom factor or other. Invoking these methods will not cause crashes
+    but will cause unnecessary interference with what is displayed.
 
-    <b>Background color</b>
-
-    The white paper is surrounded by the background, that will be visible only when the
-    user application changes the viewport (e.g., by scrolling right).
-    In %HalfPageView the default background color is white and, as with all Views,
-    the background color can be changed by invoking Interactor::set_view_background().
 */
 class LOMSE_EXPORT HalfPageView : public SinglePageView
 {

--- a/include/lomse_half_page_view.h
+++ b/include/lomse_half_page_view.h
@@ -1,0 +1,152 @@
+//---------------------------------------------------------------------------------------
+// This file is part of the Lomse library.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice, this
+//      list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright notice, this
+//      list of conditions and the following disclaimer in the documentation and/or
+//      other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+// SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// For any comment, suggestion or feature request, please contact the manager of
+// the project at cecilios@users.sourceforge.net
+//---------------------------------------------------------------------------------------
+
+#ifndef __LOMSE_HALF_PAGE_VIEW_H__
+#define __LOMSE_HALF_PAGE_VIEW_H__
+
+#include "lomse_graphic_view.h"
+
+
+///@cond INTERNAL
+namespace lomse
+{
+///@endcond
+
+
+//---------------------------------------------------------------------------------------
+/** %HalfPageView is a GraphicView for rendering scores.
+
+    It has a double behaviour. For displayin the score, it behaves as a SinglePageView,
+    that is, the score is displayed as ...
+
+    But during playback, the behaviour is different. When playback starts,
+    The window is split horizontally in two halfs, originating two virtual vertical
+    windows, one at top and the other at bottom. In top window it is displayed the first
+    score chunk and the second chunk is displayed in the bottom windows. When playback
+    enters in the bottom window the top windows is updated with the third chunk. Next,
+    when the playback enters again in top window, the bottom window is updated with the
+    next chunk, and so on.
+
+    This view solves the problem of repetition marks and jumps: when the half window
+    being played has a jump, the other half window is updated with the next logical system
+    positioned at right measure instead of with the next chunk. The behaviour for the
+    user is simple: when the user finds a jump he/she will know that it is necessary to
+    jump to the other half window, unless the repetition is over and the music should
+    continue from that point.
+
+    But it is only useful when system height is not big, smaller than half window.
+
+    <b>Margins</b>
+
+    The document is displayed on a white paper and the view has no margins, that is, the
+    default view origin point is (0.0, 0.0). Therefore, document content will be
+    displayed with the margins defined in the document.
+
+
+    <b>Background color</b>
+
+    The white paper is surrounded by the background, that will be visible only when the
+    user application changes the viewport (e.g., by scrolling right).
+    In %HalfPageView the default background color is white and, as with all Views,
+    the background color can be changed by invoking Interactor::set_view_background().
+*/
+class LOMSE_EXPORT HalfPageView : public SinglePageView
+{
+public:
+///@cond INTERNALS
+//excluded from public API because the View methods are managed from Interactor
+
+    HalfPageView(LibraryScope& libraryScope, ScreenDrawer* pDrawer);
+    virtual ~HalfPageView() {}
+
+    //overrides for SinglePageView
+    bool is_valid_for_this_view(Document* pDoc) override;
+
+    //overrides for GraphicView
+    void on_mode_changed(int mode) override;
+    void change_viewport_if_necessary(ImoId id) override;
+
+
+protected:
+    //overrides for GraphicView
+    void draw_all() override;
+    void do_change_viewport(Pixels x, Pixels y) override;
+    void do_move_tempo_line_and_change_viewport(ImoId scoreId, TimeUnits timepos,
+                                                bool fTempoLine, bool fViewport);
+
+    //specific internal methods for this view
+    void compute_buffer_split();
+    void decide_split_or_normal_view();
+    void decide_systems_to_display();
+    void do_draw_all();
+    void draw_bottom_window();
+    void draw_separation_line();
+    void draw_top_window();
+    void remove_split();
+    void send_enable_scroll_event(bool enable);
+
+
+protected:
+    //data to control split mode
+    bool    m_fPlaybackMode;    //true during playback (pause also included)
+    bool    m_fSplitMode;       //true when the view must be split
+    bool    m_fIsScore;         //the document is only one score
+
+    //temporary data: last processed rendering buffer.
+    //User app. can change the buffer but the view does not receive notifications.
+    //Therefore, for detecting a buffer change, we need to save this information
+    unsigned char* m_buf;
+    unsigned m_bufWidth;
+    unsigned m_bufHeight;
+    int m_bufStride;
+
+    //temporary data: split buffer parameters
+    unsigned m_SplitHeight;
+    unsigned char* m_BottomBuf;
+    unsigned char* m_TopBuf;
+
+    //temporary data: viewport origin for each sub-window
+    Pixels m_vxOrgPlay[2], m_vyOrgPlay[2];
+
+    //temporary data, to control display while playback
+    GmoBoxScorePage* m_pBSP;    //score-page, to access systems
+    int m_nSysIncr;         //number of systems per sub-window
+    int m_iSystem;          //next system to display
+    int m_iPlayWindow;      //index (0=top or 1=bottom) to playback window
+    int m_curSystem;        //index to current system being played
+
+///@endcond
+};
+
+
+
+
+}   //namespace lomse
+
+#endif      //__LOMSE_HALF_PAGE_VIEW_H__

--- a/include/lomse_half_page_view.h
+++ b/include/lomse_half_page_view.h
@@ -110,13 +110,16 @@ protected:
     void draw_top_window();
     void remove_split();
     void send_enable_scroll_event(bool enable);
+    void set_viewport_for_next(int iNextWindow);
+    void create_systems_jumps_table();
+    void determine_how_many_systems_fit_and_effective_window_height(int iWindow, int iSys);
 
 
 protected:
     //data to control split mode
     bool    m_fPlaybackMode;    //true during playback (pause also included)
     bool    m_fSplitMode;       //true when the view must be split
-    bool    m_fIsScore;         //the document is only one score
+    ImoScore* m_pScore;         //if the document is only one score; otherwise, nullptr
 
     //temporary data: last processed rendering buffer.
     //User app. can change the buffer but the view does not receive notifications.
@@ -131,15 +134,21 @@ protected:
     unsigned char* m_BottomBuf;
     unsigned char* m_TopBuf;
 
+    //temporary data: for controlling real used heigh
+    LUnits m_winHeight;     //total sub-window height
+    LUnits m_height[2];     //sub-window occupied height
+    int m_nSys[2];          //number of systems displayed in each sub-window
+
     //temporary data: viewport origin for each sub-window
     Pixels m_vxOrgPlay[2], m_vyOrgPlay[2];
 
     //temporary data, to control display while playback
     GmoBoxScorePage* m_pBSP;    //score-page, to access systems
-    int m_nSysIncr;         //number of systems per sub-window
-    int m_iSystem;          //next system to display
     int m_iPlayWindow;      //index (0=top or 1=bottom) to playback window
-    int m_curSystem;        //index to current system being played
+    int m_curSystem;        //current system being played (0..n-1)
+    int m_iSystem;          //index on m_systems: next system to display
+    std::vector<int> m_systems;     //indices to systems to play, in playback order
+
 
 ///@endcond
 };

--- a/include/lomse_half_page_view.h
+++ b/include/lomse_half_page_view.h
@@ -98,7 +98,7 @@ protected:
     void draw_all() override;
     void do_change_viewport(Pixels x, Pixels y) override;
     void do_move_tempo_line_and_change_viewport(ImoId scoreId, TimeUnits timepos,
-                                                bool fTempoLine, bool fViewport);
+                                                bool fTempoLine, bool fViewport) override;
 
     //specific internal methods for this view
     void compute_buffer_split();
@@ -133,6 +133,7 @@ protected:
     unsigned m_SplitHeight;
     unsigned char* m_BottomBuf;
     unsigned char* m_TopBuf;
+    unsigned m_usedHeight[2];   //real used height by sub-window
 
     //temporary data: for controlling real used heigh
     LUnits m_winHeight;     //total sub-window height

--- a/include/lomse_injectors.h
+++ b/include/lomse_injectors.h
@@ -68,6 +68,7 @@ class HorizontalBookView;
 class SingleSystemView;
 class SinglePageView;
 class FreeFlowView;
+class HalfPageView;
 class Interactor;
 class Presenter;
 class LomseDoorway;
@@ -289,9 +290,10 @@ public:
                                                          Document* pDoc);
     static SingleSystemView* inject_SingleSystemView(LibraryScope& libraryScope,
                                                      Document* pDoc);
-    static SinglePageView* inject_SinglePageView(LibraryScope& libraryScope,
-                                                 Document* pDoc);
+    static SinglePageView* inject_SinglePageView(LibraryScope& libraryScope, Document* pDoc);
     static FreeFlowView* inject_FreeFlowView(LibraryScope& libraryScope, Document* pDoc);
+    static HalfPageView* inject_HalfPageView(LibraryScope& libraryScope, Document* pDoc);
+
     static Interactor* inject_Interactor(LibraryScope& libraryScope,
                                          WpDocument wpDoc, View* pView,
                                          DocCommandExecuter* pExec);

--- a/include/lomse_midi_table.h
+++ b/include/lomse_midi_table.h
@@ -35,7 +35,6 @@
 
 #include <vector>
 #include <string>
-using namespace std;
 
 
 namespace lomse
@@ -57,42 +56,78 @@ class SoundEventsTable;
 class JumpEntry
 {
 protected:
-	int m_measure;		    //number of the measure to jump to
+	int m_inMeasure;        //number of the measure containing this jump
+	int m_toMeasure;        //number of the measure to jump to
 	int m_timesValid;   	//num.times the jump must be executed
 	int m_timesBefore;      //num.times the jump has to be visited before executing
 	int m_executed;         //num.times the jumpTo has been executed
 	int m_visited;          //num.times the jumpTo has been visited
 	int m_event;            //index to event to jump to
-	string m_label;         //label to jump to (for To Coda, Dal Segno)
+	std::string m_label;         //label to jump to (for To Coda, Dal Segno)
 
 public:
 
-    JumpEntry(int jumpTo, int timesValid, int timesBefore);
+    JumpEntry(int inMeasure, int jumpTo, int timesValid, int timesBefore);
     virtual ~JumpEntry();
 
 	inline void reset_entry() { m_executed = 0; m_visited = 0; }
 
-	inline int get_measure() { return m_measure; }
+	inline int get_to_measure() { return m_toMeasure; }
+	inline int get_in_measure() { return m_inMeasure; }
 	inline int get_times_valid() { return m_timesValid; }
 	inline int get_executed() { return m_executed; }
 	inline int get_times_before() { return m_timesBefore; }
 	inline int get_visited() { return m_visited; }
 	inline int get_event() { return m_event; }
-	inline string& get_label() { return m_label; }
+	inline std::string& get_label() { return m_label; }
 
     inline void set_event(int iEvent) { m_event = iEvent; }
-    inline void set_measure(int measure) { m_measure = measure; }
+    inline void set_measure(int measure) { m_toMeasure = measure; }
     inline void set_times_valid(int times) { m_timesValid = times; }
     inline void increment_applied() { ++m_executed; }
     inline void set_times_before(int times) { m_timesBefore = times; }
     inline void increment_visited() { ++m_visited; }
-    inline void set_label(const string& label) { m_label = label; }
+    inline void set_label(const std::string& label) { m_label = label; }
 
 
     //debug
-    string dump_entry();
+    std::string dump_entry();
 
 };
+
+
+//---------------------------------------------------------------------------------------
+//JumpsEntry: An entry in the MeasuresJumps table. It describes a measure jump in playback.
+class MeasuresJumpsEntry
+{
+protected:
+	int m_fromMeasure;          //number of start measure
+	TimeUnits m_fromTimepos;    //start timepos
+	int m_toMeasure;            //number of last played measure
+	TimeUnits m_toTimepos;      //last timepos
+
+	int m_jmpEvent;            //index to event to jump to
+	TimeUnits m_jmpTimepos;    //timepos to jump to
+
+public:
+
+    MeasuresJumpsEntry(int fromMeasure, TimeUnits fromTimepos,
+                       int toMeasure, TimeUnits toTimepos,
+                       int jmpEvent, TimeUnits jmpTimepos);
+    virtual ~MeasuresJumpsEntry() = default;
+
+    inline int get_from_measure() { return m_fromMeasure; }
+    inline int get_to_measure() { return m_toMeasure; }
+    inline TimeUnits get_from_timepos() { return m_fromTimepos; }
+    inline TimeUnits get_to_timepos() { return m_toTimepos; }
+    inline int get_jmp_event() { return m_jmpEvent; }
+    inline TimeUnits get_jmp_timepos() { return m_jmpTimepos; }
+
+    //debug
+    std::string dump_entry();
+
+};
+
 
 //---------------------------------------------------------------------------------------
 //auxiliary class SoundEvent describes a sound event
@@ -170,12 +205,12 @@ class SoundEventsTable
 protected:
     ImoScore* m_pScore;
     int m_numMeasures;
-    vector<SoundEvent*> m_events;
-    vector<int> m_measures;
-    vector<int> m_channels;
-    vector<JumpEntry*> m_jumps;
-    vector< pair<int, string> > m_targets;          //pair measure, label
-    vector<JumpEntry*> m_pendingLabel;              //jumps to be fixed
+    std::vector<SoundEvent*> m_events;
+    std::vector<int> m_measures;
+    std::vector<int> m_channels;
+    std::vector<JumpEntry*> m_jumps;
+    std::vector< std::pair<int, std::string> > m_targets;          //pair measure, label
+    std::vector<JumpEntry*> m_pendingLabel;              //jumps to be fixed
     TimeUnits m_rAnacrusisMissingTime;
     int m_accidentals[7];
 
@@ -186,8 +221,8 @@ public:
     void create_table();
 
     inline int num_events() { return int(m_events.size()); }
-    vector<SoundEvent*>& get_events() { return m_events; }
-    vector<int>& get_channels() { return m_channels; }
+    std::vector<SoundEvent*>& get_events() { return m_events; }
+    std::vector<int>& get_channels() { return m_channels; }
     inline int get_first_event_for_measure(int nMeasure) { return m_measures[nMeasure]; }
     inline int get_last_event() { return int(m_events.size()) - 1; }
     inline int get_num_measures() { return m_numMeasures; }
@@ -198,8 +233,11 @@ public:
     JumpEntry* get_jump(int i);
     void reset_jumps();
 
+    //to create systems jumps
+    std::vector<MeasuresJumpsEntry*> get_measures_jumps();
+
     //debug
-    string dump_midi_events();
+    std::string dump_midi_events();
 
 
 protected:
@@ -223,14 +261,14 @@ protected:
     int compute_volume(TimeUnits timePos, ImoTimeSignature* pTS, TimeUnits timeShift);
     void reset_accidentals(ImoKeySignature* pKey);
     void update_context_accidentals(ImoNote* pNote);
-    JumpEntry* create_jump(int jumpTo, int timesValid, int timesBefore=0);
+    JumpEntry* create_jump(int inMeasure, int jumpTo, int timesValid, int timesBefore=0);
     void process_sound_change(ImoSoundChange* pSound, StaffObjsCursor& cursor,
                               int channel, int iInstr, int measure);
 
 
     //debug
-    string dump_events_table();
-    string dump_measures_table();
+    std::string dump_events_table();
+    std::string dump_measures_table();
 };
 
 

--- a/src/graphic_model/layouters/lomse_document_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_document_layouter.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -35,6 +35,7 @@
 #include "lomse_layouter.h"
 #include "lomse_score_layouter.h"
 #include "lomse_calligrapher.h"
+#include "lomse_box_system.h"
 
 
 namespace lomse
@@ -234,7 +235,12 @@ void DocLayouter::fix_document_size()
 
     if (m_constrains & k_infinite_height)
     {
-        //TODO: free flow view
+        //free flow view, single page view
+        //height determined by BoxDocPageContent
+        GmoBoxDocPage* pPage = static_cast<GmoBoxDocPage*>(m_pItemMainBox);
+        GmoBox* pBDPC = pPage->get_child_box(0);    //DocPageContent
+        LUnits height = pBDPC->get_size().height + 2.0f * pBDPC->get_origin().y;
+        pPage->set_height(height);
     }
 }
 

--- a/src/graphic_model/layouters/lomse_inlines_container_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_inlines_container_layouter.cpp
@@ -144,7 +144,7 @@ void InlinesContainerLayouter::prepare_line()
 
     bool fBreak = false;
 
-    LOMSE_LOG_TRACE(Logger::k_layout, "available space=%.02f", m_availableSpace);
+    LOMSE_LOG_DEBUG(Logger::k_layout, "available space=%.02f", m_availableSpace);
 
     bool fSomethingAdded = false;
     bool fFirstEngrouterOfLine = true;
@@ -172,7 +172,7 @@ void InlinesContainerLayouter::prepare_line()
         {
             if (!fSomethingAdded)
             {
-                LOMSE_LOG_TRACE(Logger::k_layout, "Line empty! No engrouter created.");
+                LOMSE_LOG_DEBUG(Logger::k_layout, "Line empty! No engrouter created.");
             }
             break;
         }

--- a/src/graphic_model/lomse_box_score_page.cpp
+++ b/src/graphic_model/lomse_box_score_page.cpp
@@ -72,7 +72,7 @@ GmoBoxSystem* GmoBoxScorePage::get_system(int iSystem)
 	//returns pointer to GmoBoxSystem for system iSystem (0..n-1)
 
 	int i = iSystem - m_iFirstSystem;
-	if (i < 0)
+	if (i < 0 || i >= get_num_systems())
 		return nullptr;		//the system is not in this page
 	else
 		return static_cast<GmoBoxSystem*>(m_childBoxes[i]);

--- a/src/graphic_model/lomse_box_score_page.cpp
+++ b/src/graphic_model/lomse_box_score_page.cpp
@@ -43,6 +43,7 @@ GmoBoxScorePage::GmoBoxScorePage(ImoScore* pScore)
     , m_iFirstSystem(-1)
     , m_iLastSystem(-1)
     , m_iPage(0)
+    , m_maxSystemHeight(0.0f)
 {
 }
 
@@ -60,6 +61,9 @@ void GmoBoxScorePage::add_system(GmoBoxSystem* pSystem, int iSystem)
     m_iLastSystem = iSystem;
 
     add_child_box(pSystem);
+    pSystem->set_system_number(iSystem);
+
+    m_maxSystemHeight = max(m_maxSystemHeight, pSystem->get_height());
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/module/lomse_injectors.cpp
+++ b/src/module/lomse_injectors.cpp
@@ -46,6 +46,7 @@
 #include "private/lomse_document_p.h"
 #include "lomse_font_storage.h"
 #include "lomse_graphic_view.h"
+#include "lomse_half_page_view.h"
 #include "lomse_interactor.h"
 #include "lomse_presenter.h"
 #include "lomse_doorway.h"
@@ -430,6 +431,13 @@ FreeFlowView* Injector::inject_FreeFlowView(LibraryScope& libraryScope, Document
 {
     return static_cast<FreeFlowView*>(
                         inject_View(libraryScope, k_view_free_flow, pDoc) );
+}
+
+//---------------------------------------------------------------------------------------
+HalfPageView* Injector::inject_HalfPageView(LibraryScope& libraryScope, Document* pDoc)
+{
+    return static_cast<HalfPageView*>(
+                        inject_View(libraryScope, k_view_half_page, pDoc) );
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/mvc/lomse_graphic_view.cpp
+++ b/src/mvc/lomse_graphic_view.cpp
@@ -383,6 +383,8 @@ bool GraphicView::determine_page_system_and_position_for(ImoId scoreId, TimeUnit
 //    }
 //    //END DEBUG ----------------------------------------------------------
 
+    LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_score_player, "Play system: %d", m_pScrollSystem->get_system_number() );
+
     return true;   //no error
 }
 

--- a/src/mvc/lomse_graphic_view.cpp
+++ b/src/mvc/lomse_graphic_view.cpp
@@ -30,7 +30,6 @@
 #define LOMSE_INTERNAL_API
 #include "lomse_graphic_view.h"
 
-#include <cstdio>       //for sprintf
 #include "lomse_graphical_model.h"
 #include "lomse_gm_basic.h"
 #include "lomse_screen_drawer.h"
@@ -48,6 +47,7 @@
 #include "lomse_box_slice_instr.h"
 #include "lomse_box_system.h"
 #include "lomse_timegrid_table.h"
+#include "lomse_half_page_view.h"
 
 using namespace std;
 
@@ -90,6 +90,9 @@ View* ViewFactory::create_view(LibraryScope& libraryScope, int viewType,
 
         case k_view_free_flow:
             return LOMSE_NEW FreeFlowView(libraryScope, pDrawer);
+
+        case k_view_half_page:
+            return LOMSE_NEW HalfPageView(libraryScope, pDrawer);
 
         default:
         {
@@ -196,6 +199,13 @@ void GraphicView::add_visual_effect(VisualEffect* pEffect)
 }
 
 //---------------------------------------------------------------------------------------
+void GraphicView::on_mode_changed(int mode)
+{
+    set_visual_effects_for_mode(mode);
+    draw_all_visual_effects();
+}
+
+//---------------------------------------------------------------------------------------
 void GraphicView::set_visual_effects_for_mode(int mode)
 {
     bool fEditionMode = (mode == Interactor::k_mode_edition);
@@ -281,7 +291,7 @@ void GraphicView::new_viewport(Pixels x, Pixels y)
 //---------------------------------------------------------------------------------------
 void GraphicView::do_change_viewport(Pixels x, Pixels y)
 {
-    LOMSE_LOG_DEBUG(Logger::k_mvc, string(""));
+    LOMSE_LOG_DEBUG(Logger::k_mvc, "New viewport x=%d, y=%d", x, y);
     std::lock_guard<std::mutex> lock(m_viewportMutex);
 
     m_vxOrg = x;
@@ -322,6 +332,8 @@ void GraphicView::move_tempo_line_and_change_viewport(ImoId scoreId, TimeUnits t
 void GraphicView::do_move_tempo_line_and_change_viewport(ImoId scoreId, TimeUnits timepos,
                                                          bool fTempoLine, bool fViewport)
 {
+    LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_score_player, string(""));
+
     if (!determine_page_system_and_position_for(scoreId, timepos))
         return;
 
@@ -377,6 +389,8 @@ bool GraphicView::determine_page_system_and_position_for(ImoId scoreId, TimeUnit
 //---------------------------------------------------------------------------------------
 void GraphicView::change_viewport_if_necessary(ImoId id)
 {
+    LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_score_player, string(""));
+
     //AWARE: This code is executed in the sound thread
 
     std::lock_guard<std::mutex> lock(m_viewportMutex);
@@ -403,6 +417,8 @@ void GraphicView::change_viewport_if_necessary(ImoId id)
 //---------------------------------------------------------------------------------------
 void GraphicView::do_change_viewport_if_necessary()
 {
+    LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_score_player, string(""));
+
     bool fDoScroll = do_determine_if_scroll_needed();
 
     if (fDoScroll)
@@ -485,8 +501,8 @@ bool GraphicView::do_determine_if_scroll_needed()
 //---------------------------------------------------------------------------------------
 void GraphicView::do_change_viewport()
 {
-//    LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_score_player,
-//        "Requesting scroll to m_vxNew=%d, m_vyNew=%d", m_vxNew, m_vyNew);
+    LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_score_player,
+        "Requesting scroll to m_vxNew=%d, m_vyNew=%d", m_vxNew, m_vyNew);
 
     if (m_vyLast != m_vyNew || m_vxLast != m_vxNew)
     {
@@ -1000,6 +1016,11 @@ void GraphicView::zoom_out(Pixels x, Pixels y)
 //---------------------------------------------------------------------------------------
 void GraphicView::zoom_fit_full(Pixels screenWidth, Pixels screenHeight)
 {
+    LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_score_player, string(""));
+
+    if (screenWidth < 10 || screenHeight < 10)
+        return;
+
     //move viewport origin (left-top window corner) to top screen, center
     double rx(double(screenWidth)/2.0);
     double ry(0);
@@ -1032,6 +1053,9 @@ void GraphicView::zoom_fit_full(Pixels screenWidth, Pixels screenHeight)
 //---------------------------------------------------------------------------------------
 void GraphicView::zoom_fit_width(Pixels screenWidth)
 {
+    if (screenWidth < 10)
+        return;
+
     //move viewport origin (left-top window corner) to top screen, center
     double rx(double(screenWidth)/2.0);
     double ry(0);
@@ -1068,6 +1092,8 @@ LUnits GraphicView::get_viewport_width()
 //---------------------------------------------------------------------------------------
 void GraphicView::set_viewport_at_page_center(Pixels screenWidth)
 {
+    LOMSE_LOG_DEBUG(Logger::k_events | Logger::k_score_player, string(""));
+
     //get page width
     //TODO: Width taken for first page. Change this to use currently displayed page
     GraphicModel* pGModel = get_graphic_model();

--- a/src/mvc/lomse_half_page_view.cpp
+++ b/src/mvc/lomse_half_page_view.cpp
@@ -1,0 +1,344 @@
+//---------------------------------------------------------------------------------------
+// This file is part of the Lomse library.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice, this
+//      list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright notice, this
+//      list of conditions and the following disclaimer in the documentation and/or
+//      other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+// SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// For any comment, suggestion or feature request, please contact the manager of
+// the project at cecilios@users.sourceforge.net
+//---------------------------------------------------------------------------------------
+
+#include "lomse_half_page_view.h"
+
+#include "lomse_graphical_model.h"
+#include "lomse_gm_basic.h"
+#include "lomse_screen_drawer.h"
+#include "lomse_interactor.h"
+#include "lomse_box_system.h"
+
+namespace lomse
+{
+
+
+//=======================================================================================
+// HalfPageView implementation
+//=======================================================================================
+HalfPageView::HalfPageView(LibraryScope& libraryScope, ScreenDrawer* pDrawer)
+    : SinglePageView(libraryScope, pDrawer)
+    , m_fPlaybackMode(false)
+    , m_fSplitMode(false)
+    , m_fIsScore(false)
+    , m_buf(nullptr)
+    , m_vxOrgPlay{0,0}
+    , m_vyOrgPlay{0,0}
+{
+    m_backgroundColor = Color(255, 255, 255);
+}
+
+//---------------------------------------------------------------------------------------
+bool HalfPageView::is_valid_for_this_view(Document* pDoc)
+{
+    m_fIsScore = pDoc->get_num_content_items() == 1
+                 && pDoc->get_content_item(0)->is_score();
+    return true;
+}
+
+//---------------------------------------------------------------------------------------
+void HalfPageView::compute_buffer_split()
+{
+    unsigned char* buf =  m_pRenderBuf->buf();
+    unsigned width = m_pRenderBuf->width();
+    unsigned height = m_pRenderBuf->height();
+
+    if (buf != nullptr)
+    {
+        if (m_buf == nullptr || width != m_bufWidth)
+        {
+            LOMSE_LOG_DEBUG(Logger::k_mvc, "New buffer: first buffer or different width");
+        }
+        else if (height == m_bufHeight && buf == m_buf)
+            return;
+        else if (height == m_SplitHeight && (buf == m_TopBuf || buf == m_BottomBuf))
+            return;
+        else
+        {
+            LOMSE_LOG_DEBUG(Logger::k_mvc, "New buffer: different height");
+        }
+
+        //save new buffer info
+        m_buf = buf;
+        m_bufWidth = width;
+        m_bufHeight = height;
+        m_bufStride = m_pRenderBuf->stride();
+
+        //compute window split
+        m_SplitHeight = m_bufHeight / 2 - 5;
+        m_BottomBuf = m_buf + (m_bufHeight / 2 + 5) * m_bufStride;
+        m_TopBuf = m_buf;
+    }
+}
+
+//---------------------------------------------------------------------------------------
+void HalfPageView::draw_all()
+{
+    LOMSE_LOG_DEBUG(Logger::k_mvc, std::string());
+
+    compute_buffer_split();
+    decide_split_or_normal_view();
+    do_draw_all();
+}
+
+//---------------------------------------------------------------------------------------
+void HalfPageView::do_draw_all()
+{
+    if (!m_fSplitMode)
+    {
+        //single page view
+        m_pRenderBuf->attach(m_buf, m_bufWidth, m_bufHeight, m_bufStride);
+        GraphicView::draw_all();
+    }
+    else
+    {
+        //we are in playback mode. Window being played must be the last one rendered,
+        //so that buffer remains positioned to receive highlight events
+        if (m_iPlayWindow == 0)
+        {
+            draw_bottom_window();
+            draw_separation_line();
+            draw_top_window();
+        }
+        else
+        {
+            draw_top_window();
+            draw_separation_line();
+            draw_bottom_window();
+        }
+    }
+}
+
+//---------------------------------------------------------------------------------------
+void HalfPageView::draw_bottom_window()
+{
+    m_pRenderBuf->attach(m_BottomBuf, m_bufWidth, m_SplitHeight, m_bufStride);
+    GraphicView::do_change_viewport(m_vxOrgPlay[1], m_vyOrgPlay[1]);
+    GraphicView::draw_all();
+}
+
+//---------------------------------------------------------------------------------------
+void HalfPageView::draw_separation_line()
+{
+    unsigned char* buf = m_buf + m_SplitHeight * m_bufStride;
+    m_pRenderBuf->attach(buf, m_bufWidth, 10, m_bufStride);
+    m_pDrawer->reset(*m_pRenderBuf, Color(128, 128, 200));
+}
+
+//---------------------------------------------------------------------------------------
+void HalfPageView::draw_top_window()
+{
+    m_pRenderBuf->attach(m_TopBuf, m_bufWidth, m_SplitHeight, m_bufStride);
+    GraphicView::do_change_viewport(m_vxOrgPlay[0], m_vyOrgPlay[0]);
+    GraphicView::draw_all();
+}
+
+//---------------------------------------------------------------------------------------
+void HalfPageView::do_change_viewport(Pixels x, Pixels y)
+{
+    LOMSE_LOG_DEBUG(Logger::k_mvc, "New viewport x=%d, y=%d", x, y);
+
+    if (!m_fSplitMode)
+    {
+        m_vxOrgPlay[0] = x;
+        m_vyOrgPlay[0] = y;
+    }
+    m_vxOrgPlay[1] = x;
+    m_vyOrgPlay[1] = y;
+
+    GraphicView::do_change_viewport(x, y);
+}
+
+//---------------------------------------------------------------------------------------
+void HalfPageView::on_mode_changed(int mode)
+{
+    LOMSE_LOG_DEBUG(Logger::k_mvc, "Change to mode = %d (0=read-only, 1=edition, 2=playback)", mode);
+
+    bool fWasInSplitMode = m_fSplitMode;
+    m_fPlaybackMode = (mode == Interactor::k_mode_playback);
+    decide_split_or_normal_view();
+
+    if (m_fSplitMode)
+    {
+        //playback started in split mode
+        send_enable_scroll_event(false);
+        decide_systems_to_display();
+    }
+    else if (fWasInSplitMode)
+    {
+        //playback finished and was in split mode
+        send_enable_scroll_event(true);
+        remove_split();
+    }
+
+    set_visual_effects_for_mode(mode);
+    do_draw_all();
+}
+
+//---------------------------------------------------------------------------------------
+void HalfPageView::decide_split_or_normal_view()
+{
+    m_fSplitMode = false;
+    if (m_fPlaybackMode && m_fIsScore)
+    {
+        //convert buffer height to LUnits
+        LUnits bufHeight = m_pDrawer->Pixels_to_LUnits(m_bufHeight);
+
+        //get maximum system height
+        GraphicModel* pGModel = get_graphic_model();
+        GmoBoxDocument* pBDoc = pGModel->get_root();
+        GmoBoxDocPage* pBDocPage = pBDoc->get_page(0);
+        GmoBoxDocPageContent* pBPC = static_cast<GmoBoxDocPageContent*>(pBDocPage->get_child_box(0));
+        m_pBSP = static_cast<GmoBoxScorePage*>(pBPC->get_child_box(0));
+        LUnits maxHeight = m_pBSP->get_max_system_height();
+
+        LOMSE_LOG_DEBUG(Logger::k_mvc, "maxHeight = %f, bufHeight=%f", maxHeight, bufHeight);
+
+        //Do not split window if height lower than 2 * maxSystemHeight + some pixels (40px)
+        LUnits extra = m_pDrawer->Pixels_to_LUnits(40);
+        if (bufHeight < (2.0f * maxHeight + extra))
+            return;
+
+        //Do not split window if width lower than system width
+        GmoBoxSystem* pSys = m_pBSP->get_system(0);
+        LUnits bufWidth = m_pDrawer->Pixels_to_LUnits(m_bufWidth);
+        if (bufWidth < (2.0f * extra + pSys->get_width()))
+            return;
+
+        m_fSplitMode = true;
+
+        //determine how many systems fit in a sub-window
+        m_nSysIncr = int(((bufHeight / 2.0f) - extra) / maxHeight);
+    }
+}
+
+//---------------------------------------------------------------------------------------
+void HalfPageView::decide_systems_to_display()
+{
+    m_iSystem = 0;                                  //system to display: first system
+    m_curSystem = 0;                                //system being played
+    m_iPlayWindow = 0;                              //playback window: top
+    int iNextWindow = (m_iPlayWindow==0 ? 1 : 0);     //next window: the other one
+
+    //set viewport for first window
+    //viewport is in pixels. It refers to user space converted to pixels
+    GmoBoxSystem* pSys = m_pBSP->get_system(m_iSystem);
+////    m_vxOrgPlay[m_iPlayWindow] = 0;
+    m_vyOrgPlay[m_iPlayWindow] = m_pDrawer->LUnits_to_Pixels(pSys->get_origin().y);
+
+    //set viewport for next window
+    m_iSystem += m_nSysIncr;
+    //TODO: limit when max number of systems reached
+    pSys = m_pBSP->get_system(m_iSystem);
+////    m_vxOrgPlay[iNextWindow] = 0;
+    m_vyOrgPlay[iNextWindow] = m_pDrawer->LUnits_to_Pixels(pSys->get_origin().y);
+}
+
+//---------------------------------------------------------------------------------------
+void HalfPageView::change_viewport_if_necessary(ImoId id)
+{
+    LOMSE_LOG_DEBUG(Logger::k_mvc, std::string());
+    if (!m_fSplitMode)
+        SinglePageView::change_viewport_if_necessary(id);
+}
+
+//---------------------------------------------------------------------------------------
+//void HalfPageView::do_change_viewport_if_necessary()
+void HalfPageView::do_move_tempo_line_and_change_viewport(ImoId scoreId, TimeUnits timepos,
+                                                          bool fTempoLine, bool fViewport)
+{
+    LOMSE_LOG_DEBUG(Logger::k_mvc, std::string());
+
+    if (!m_fSplitMode)
+        SinglePageView::do_move_tempo_line_and_change_viewport(scoreId, timepos,
+                                                               fTempoLine, fViewport);
+
+    //Here it is necessary to determine if playback has arrived to switch point. If so,
+    //switch windows and display next system
+
+    //Determine the system (in m_pScrollSystem)
+    if (!determine_page_system_and_position_for(scoreId, timepos))
+        return;
+
+    if (m_pScrollSystem->get_system_number() - m_curSystem >= m_nSysIncr)
+    {
+        //playback has arrived to switch point. Switch windows and display next system
+        int iNextWindow = m_iPlayWindow;
+        m_iPlayWindow = (m_iPlayWindow==0 ? 1 : 0);
+        //update system being played
+        m_curSystem  += m_nSysIncr;
+        //update viewport for top window
+        m_iSystem += m_nSysIncr;
+        int numSystems = m_pBSP->get_num_systems();
+        if (m_iSystem < numSystems)
+        {
+            GmoBoxSystem* pSys = m_pBSP->get_system(m_iSystem);
+            m_vyOrgPlay[iNextWindow] = m_pDrawer->LUnits_to_Pixels(pSys->get_origin().y);
+        }
+        else
+        {
+            //set viewport after last system
+            GmoBoxSystem* pSys = m_pBSP->get_system(numSystems - 1);
+            LUnits yAfter = pSys->get_origin().y + pSys->get_height() + 2000.0f;    //2cm
+            m_vyOrgPlay[iNextWindow] = m_pDrawer->LUnits_to_Pixels(yAfter);
+        }
+
+        do_draw_all();
+    }
+}
+
+//---------------------------------------------------------------------------------------
+void HalfPageView::remove_split()
+{
+    //playback has finished. Remove the split and keep last system at same window pos.
+
+    if (m_iPlayWindow == 0)
+    {
+        //nothing to do. Last system is displayed in top window. Viewport correctly set
+    }
+    else
+    {
+        //Last system is displayed in bottom window. Set viewport so that last system
+        //doesn't move from current position
+
+        int numSystems = m_pBSP->get_num_systems();
+        GmoBoxSystem* pSys = m_pBSP->get_system(numSystems - 1);
+        Pixels y = m_pDrawer->LUnits_to_Pixels( pSys->get_origin().y );
+        m_vyOrgPlay[0] = y - m_SplitHeight - 10;
+        GraphicView::do_change_viewport(m_vxOrgPlay[0], m_vyOrgPlay[0]);
+    }
+}
+
+//---------------------------------------------------------------------------------------
+void HalfPageView::send_enable_scroll_event(bool enable)
+{
+}
+
+
+}  //namespace lomse

--- a/src/mvc/lomse_half_page_view.cpp
+++ b/src/mvc/lomse_half_page_view.cpp
@@ -290,9 +290,16 @@ void HalfPageView::decide_systems_to_display()
 
     determine_how_many_systems_fit_and_effective_window_height(m_iPlayWindow, m_curSystem);
 
+    //determine viewport x position to center page on screen
+    GraphicModel* pGModel = get_graphic_model();
+    GmoBoxDocPage* pPage = pGModel->get_page(0);
+    URect rect = pPage->get_bounds();
+    Pixels pageWidth = m_pDrawer->LUnits_to_Pixels(rect.width);
+    Pixels left = (pageWidth - int(m_bufWidth)) / 2;
+    m_vxOrgPlay[0] = m_vxOrgPlay[1] = left;
+
     //set viewport for first window. Viewport is in pixels
     GmoBoxSystem* pSys = m_pBSP->get_system( m_curSystem );
-////    m_vxOrgPlay[m_iPlayWindow] = 0;
     m_vyOrgPlay[m_iPlayWindow] = m_pDrawer->LUnits_to_Pixels(pSys->get_origin().y);
 
     //now in top window there are m_nSys[0] systems displayed, starting with m_curSystem
@@ -467,7 +474,7 @@ void HalfPageView::create_systems_jumps_table()
             GmoBoxSystem* pToSys = pGModel->get_system_for(scoreId, it->get_to_timepos());
             int iFrom = pFromSys->get_system_number();
             int iTo = pToSys->get_system_number();
-            LOMSE_LOG_INFO("from s=%d to s=%d", pFromSys->get_system_number(),
+            LOMSE_LOG_DEBUG(Logger::k_mvc, "from s=%d to s=%d", pFromSys->get_system_number(),
                             pToSys->get_system_number());
             int i = (iPrevSys != iFrom ? iFrom : iFrom+1);
             for(; i <= iTo; ++i)
@@ -477,8 +484,10 @@ void HalfPageView::create_systems_jumps_table()
             iPrevSys = iTo;
         }
 
-        for(auto it : m_systems)
-            LOMSE_LOG_INFO("system %d", it);
+        #if (LOMSE_ENABLE_DEBUG_LOGS == 1)
+            for(auto it : m_systems)
+                LOMSE_LOG_DEBUG(Logger::k_mvc, "system %d", it);
+        #endif
     }
 }
 

--- a/src/mvc/lomse_interactor.cpp
+++ b/src/mvc/lomse_interactor.cpp
@@ -1381,6 +1381,8 @@ void Interactor::zoom_out(Pixels x, Pixels y, bool fForceRedraw)
 //---------------------------------------------------------------------------------------
 void Interactor::zoom_fit_full(Pixels width, Pixels height, bool fForceRedraw)
 {
+    LOMSE_LOG_DEBUG(Logger::k_mvc, std::string());
+
     m_fViewParamsChanged = true;
     GraphicView* pGView = dynamic_cast<GraphicView*>(m_pView);
     if (pGView)
@@ -1394,6 +1396,8 @@ void Interactor::zoom_fit_full(Pixels width, Pixels height, bool fForceRedraw)
 //---------------------------------------------------------------------------------------
 void Interactor::zoom_fit_width(Pixels width, bool fForceRedraw)
 {
+    LOMSE_LOG_DEBUG(Logger::k_mvc, "width=%d", width);
+
     m_fViewParamsChanged = true;
     GraphicView* pGView = dynamic_cast<GraphicView*>(m_pView);
     if (pGView)
@@ -1935,8 +1939,7 @@ void Interactor::set_operating_mode(int mode)
         GraphicView* pGView = dynamic_cast<GraphicView*>(m_pView);
         if (pGView)
         {
-            pGView->set_visual_effects_for_mode(mode);
-            pGView->draw_all_visual_effects();
+            pGView->on_mode_changed(mode);
             request_window_update();
         }
     }
@@ -1976,7 +1979,7 @@ void Interactor::enable_edition_restricted_to(ImoId id)
     GraphicView* pGView = dynamic_cast<GraphicView*>(m_pView);
     m_pCursor->jailed_mode_in(id);
     if (pGView)
-        pGView->set_visual_effects_for_mode(k_mode_edition);
+        pGView->on_mode_changed(k_mode_edition);
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/sound/lomse_midi_table.cpp
+++ b/src/sound/lomse_midi_table.cpp
@@ -849,10 +849,13 @@ vector<MeasuresJumpsEntry*> SoundEventsTable::get_measures_jumps()
 
     } while (i < maxEvent);
 
-    TimeUnits curTime = TimeUnits(m_events[maxEvent-2]->DeltaTime);
-    table.push_back(
-        LOMSE_NEW MeasuresJumpsEntry(fromMeasure, fromTime, 0, curTime,       //0 = end of score
-                                     int(maxEvent-2), curTime) );
+    if (fromMeasure != -1)      //-1 = it finished before last measure (e.g. 'Fine' mark)
+    {
+        TimeUnits curTime = TimeUnits(m_events[maxEvent-2]->DeltaTime);
+        table.push_back(
+            LOMSE_NEW MeasuresJumpsEntry(fromMeasure, fromTime, 0, curTime,       //0 = end of score
+                                         int(maxEvent-2), curTime) );
+    }
 
     reset_jumps();
 

--- a/src/tests/lomse_test_midi_table.cpp
+++ b/src/tests/lomse_test_midi_table.cpp
@@ -162,6 +162,13 @@ public:
         return true;
     }
 
+    void dump_measures_jumps(std::vector<MeasuresJumpsEntry*>& jumps)
+    {
+        cout << test_name() << ", dump of jumps:" << endl;
+        for (auto it : jumps)
+            cout << "      " << it->dump_entry();
+    }
+
 };
 
 SUITE(MidiTableTest)
@@ -1003,122 +1010,141 @@ SUITE(MidiTableTest)
         CHECK( check_measures_jump(__LINE__, jumps[2], 3,0) );      //from 3 to end
     }
 
-//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_07)
-//    {
-//        //@007. [T4] end-repetition barline with volta brackets
-//        //                  vt1    vt2
-//        //  |    |    |     |     :|     |     |     |
-//        //  1    2    3     4      5    6
-//        //                 J 4,1  J 1,1
-//        //                   5,0
-//        load_mxl_score_for_test("04-repeat-barline-simple-volta.xml");
-//        //cout << m_pTable->dump_midi_events() << endl;
-//        CHECK( m_pTable->num_jumps() == 3 );
-//        CHECK( check_jump(0, 4,1,0,10) == true );
-//        CHECK( check_jump(1, 5,0,0,13) == true );
-//        CHECK( check_jump(2, 1,1,0,1) == true );
-//    }
-//
-//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_08)
-//    {
-//        //@008. [T5]  end-repetition barline with volta, two times
-//        //                  vt1,2  vt3
-//        //  |    |    |     |     :|     |     |     |
-//        //  1    2    3     4      5    6
-//        //                 J4,2   J1,2
-//        //                 J5,0
-//        load_mxl_score_for_test("05-repeat-barline-simple-volta-two-times.xml");
-//        //cout << m_pTable->dump_midi_events() << endl;
-//        CHECK( m_pTable->num_jumps() == 3 );
-//        CHECK( check_jump(0, 4,2,0,10) == true );
-//        CHECK( check_jump(1, 5,0,0,13) == true );
-//        CHECK( check_jump(2, 1,2,0,1) == true );
-//    }
-//
-//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_09)
-//    {
-//        //@009. [T7] three voltas
-//        //            vt1   vt2    vt3
-//        //  |    |    |    :|     :|     |     |
-//        //  1    2    3     4      5    6
-//        //           J3,1  J1,1   J1,1
-//        //           J4,1
-//        //           J5,0
-//        load_mxl_score_for_test("07-repeat-barlines-three-volta.xml");
-//        //cout << m_pTable->dump_midi_events() << endl;
-//        CHECK( m_pTable->num_jumps() == 5 );
-//        CHECK( check_jump(0, 3,1) == true );
-//        CHECK( check_jump(1, 4,1) == true );
-//        CHECK( check_jump(2, 5,0) == true );
-//        CHECK( check_jump(3, 1,1) == true );
-//        CHECK( check_jump(4, 1,1) == true );
-//    }
-//
-//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_10)
-//    {
-//        //@010. [T8] three voltas long
-//        //            vt1------- vt2------- vt3---------
-//        //  |    |    |     |    :|     |    :|     |     |    |    |    |    |
-//        //  1    2    3     4      5    6     7     8     9    10   11   12
-//        //           J3,1        J1,1        J1,1
-//        //           J5,1
-//        //           J7,0
-//        load_mxl_score_for_test("08-repeat-barlines-three-volta-long.xml");
-//        //cout << m_pTable->dump_midi_events() << endl;
-//        CHECK( m_pTable->num_jumps() == 5 );
-//        CHECK( check_jump(0, 3,1) == true );
-//        CHECK( check_jump(1, 5,1) == true );
-//        CHECK( check_jump(2, 7,0) == true );
-//        CHECK( check_jump(3, 1,1) == true );
-//        CHECK( check_jump(4, 1,1) == true );
-//    }
-//
-//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_11)
-//    {
-//        //@011. three voltas long several times
-//        //            vt1,2------ vt3,5------- vt5---------
-//        //  |    |    |     |    :|     |    :|     |     |    |    |    |    |
-//        //  1    2    3     4      5    6     7     8     9    10   11   12
-//        //           J3,2        J1,2        J1,2
-//        //           J5,2
-//        //           J7,0
-//        load_mxl_score_for_test("09-repeat-barlines-three-volta-long-several-times.xml");
-//        //cout << m_pTable->dump_midi_events() << endl;
-//        CHECK( m_pTable->num_jumps() == 5 );
-//        CHECK( check_jump(0, 3,2) == true );
-//        CHECK( check_jump(1, 5,2) == true );
-//        CHECK( check_jump(2, 7,0) == true );
-//        CHECK( check_jump(3, 1,2) == true );
-//        CHECK( check_jump(4, 1,2) == true );
-//    }
-//
-//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_51)
-//    {
-//        //@051. da capo
-//        //                            D.C.
-//        //  |      |      |      |      |
-//        //  1      2      3      4
-//        //                             J1,1
-//        load_mxl_score_for_test("51-repeat-da-capo.xml");
-//        //cout << m_pTable->dump_midi_events() << endl;
-//        CHECK( m_pTable->num_jumps() == 1 );
-//        CHECK( check_jump(0, 1,1) == true );
-//    }
-//
-//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_52)
-//    {
-//        //@052. da capo al fine
-//        //             Fine           D.C.
-//        //  |      |      |      |      |
-//        //  1      2      3      4
-//        //              J-1,1,1        J1,1
-//        load_mxl_score_for_test("52-repeat-da-capo-al-fine.xml");
-//        //cout << m_pTable->dump_midi_events() << endl;
-//        CHECK( m_pTable->num_jumps() == 2);
-//        CHECK( check_jump(0, -1,1,1) == true );
-//        CHECK( check_jump(1, 1,1) == true );
-//    }
-//
+    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_05)
+    {
+        //@005. [T4] end-repetition barline with volta brackets
+        //                  vt1    vt2
+        //  |    |    |     |     :|     |     |     |
+        //  1    2    3     4      5    6
+        //                 J 4,1  J 1,1
+        //                   5,0
+        load_mxl_score_for_test("04-repeat-barline-simple-volta.xml");
+        //cout << m_pTable->dump_midi_events() << endl;
+		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
+        CHECK( jumps.size() == 4 );
+        CHECK( check_measures_jump(__LINE__, jumps[0], 1,3) );      //from 1 to 3
+        CHECK( check_measures_jump(__LINE__, jumps[1], 4,4) );      //from 4 to 4
+        CHECK( check_measures_jump(__LINE__, jumps[2], 1,3) );      //from 1 to 3
+        CHECK( check_measures_jump(__LINE__, jumps[3], 5,0) );      //from 5 to end
+    }
+
+    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_06)
+    {
+        //@006. [T5]  end-repetition barline with volta, two times
+        //                  vt1,2  vt3
+        //  |    |    |     |     :|     |     |     |
+        //  1    2    3     4      5    6
+        //                 J4,2   J1,2
+        //                 J5,0
+        load_mxl_score_for_test("05-repeat-barline-simple-volta-two-times.xml");
+        //cout << m_pTable->dump_midi_events() << endl;
+		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
+        CHECK( jumps.size() == 6 );
+        CHECK( check_measures_jump(__LINE__, jumps[0], 1,3) );      //from 1 to 3
+        CHECK( check_measures_jump(__LINE__, jumps[1], 4,4) );      //from 4 to 4
+        CHECK( check_measures_jump(__LINE__, jumps[2], 1,3) );      //from 1 to 3
+        CHECK( check_measures_jump(__LINE__, jumps[3], 4,4) );      //from 4 to 4
+        CHECK( check_measures_jump(__LINE__, jumps[4], 1,3) );      //from 1 to 3
+        CHECK( check_measures_jump(__LINE__, jumps[5], 5,0) );      //from 5 to end
+    }
+
+    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_07)
+    {
+        //@007. [T7] three voltas
+        //            vt1   vt2    vt3
+        //  |    |    |    :|     :|     |     |
+        //  1    2    3     4      5    6
+        //           J3,1  J1,1   J1,1
+        //           J4,1
+        //           J5,0
+        load_mxl_score_for_test("07-repeat-barlines-three-volta.xml");
+        //cout << m_pTable->dump_midi_events() << endl;
+		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
+        CHECK( jumps.size() == 6 );
+        CHECK( check_measures_jump(__LINE__, jumps[0], 1,2) );      //from 1 to 2
+        CHECK( check_measures_jump(__LINE__, jumps[1], 3,3) );      //from 3 to 3
+        CHECK( check_measures_jump(__LINE__, jumps[2], 1,2) );      //from 1 to 2
+        CHECK( check_measures_jump(__LINE__, jumps[3], 4,4) );      //from 4 to 4
+        CHECK( check_measures_jump(__LINE__, jumps[4], 1,2) );      //from 1 to 2
+        CHECK( check_measures_jump(__LINE__, jumps[5], 5,0) );      //from 5 to end
+    }
+
+    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_08)
+    {
+        //@008. [T8] three voltas long
+        //            vt1------- vt2------- vt3---------
+        //  |    |    |     |    :|     |    :|     |     |    |    |    |    |
+        //  1    2    3     4      5    6     7     8     9    10   11   12
+        //           J3,1        J1,1        J1,1
+        //           J5,1
+        //           J7,0
+        load_mxl_score_for_test("08-repeat-barlines-three-volta-long.xml");
+        //cout << m_pTable->dump_midi_events() << endl;
+		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
+        CHECK( jumps.size() == 6 );
+        CHECK( check_measures_jump(__LINE__, jumps[0], 1,2) );      //from 1 to 2
+        CHECK( check_measures_jump(__LINE__, jumps[1], 3,4) );      //from 3 to 4
+        CHECK( check_measures_jump(__LINE__, jumps[2], 1,2) );      //from 1 to 2
+        CHECK( check_measures_jump(__LINE__, jumps[3], 5,6) );      //from 5 to 6
+        CHECK( check_measures_jump(__LINE__, jumps[4], 1,2) );      //from 1 to 2
+        CHECK( check_measures_jump(__LINE__, jumps[5], 7,0) );      //from 7 to end
+    }
+
+    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_09)
+    {
+        //@009. three voltas long several times
+        //            vt1,2------ vt3,5------- vt5---------
+        //  |    |    |     |    :|     |    :|     |     |    |    |    |    |
+        //  1    2    3     4      5    6     7     8     9    10   11   12
+        //           J3,2        J1,2        J1,2
+        //           J5,2
+        //           J7,0
+        load_mxl_score_for_test("09-repeat-barlines-three-volta-long-several-times.xml");
+        //cout << m_pTable->dump_midi_events() << endl;
+		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
+        CHECK( jumps.size() == 10 );
+        CHECK( check_measures_jump(__LINE__, jumps[0], 1,2) );      //from 1 to 2
+        CHECK( check_measures_jump(__LINE__, jumps[1], 3,4) );      //from 3 to 4
+        CHECK( check_measures_jump(__LINE__, jumps[2], 1,2) );      //from 1 to 2
+        CHECK( check_measures_jump(__LINE__, jumps[3], 3,4) );      //from 3 to 4
+        CHECK( check_measures_jump(__LINE__, jumps[4], 1,2) );      //from 1 to 2
+        CHECK( check_measures_jump(__LINE__, jumps[5], 5,6) );      //from 5 to 6
+        CHECK( check_measures_jump(__LINE__, jumps[6], 1,2) );      //from 1 to 2
+        CHECK( check_measures_jump(__LINE__, jumps[7], 5,6) );      //from 5 to 6
+        CHECK( check_measures_jump(__LINE__, jumps[8], 1,2) );      //from 1 to 2
+        CHECK( check_measures_jump(__LINE__, jumps[9], 7,0) );      //from 7 to end
+    }
+
+    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_51)
+    {
+        //@051. da capo
+        //                            D.C.
+        //  |      |      |      |      |
+        //  1      2      3      4
+        //                             J1,1
+        load_mxl_score_for_test("51-repeat-da-capo.xml");
+        //cout << m_pTable->dump_midi_events() << endl;
+		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
+        CHECK( jumps.size() == 2 );
+        CHECK( check_measures_jump(__LINE__, jumps[0], 1,4) );      //from 1 to 4
+        CHECK( check_measures_jump(__LINE__, jumps[1], 1,0) );      //from 1 to end
+    }
+
+    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_52)
+    {
+        //@052. da capo al fine
+        //             Fine           D.C.
+        //  |      |      |      |      |
+        //  1      2      3      4
+        //              J-1,1,1        J1,1
+        load_mxl_score_for_test("52-repeat-da-capo-al-fine.xml");
+		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
+        //dump_measures_jumps(jumps);
+        CHECK( jumps.size() == 2 );
+        CHECK( check_measures_jump(__LINE__, jumps[0], 1,4) );      //from 1 to 4
+        CHECK( check_measures_jump(__LINE__, jumps[1], 1,2) );      //from 1 to 2
+    }
+
 ////    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_53)
 ////    {
 ////        //@053. da capo al segno
@@ -1132,81 +1158,90 @@ SUITE(MidiTableTest)
 ////        CHECK( check_jump(0, 4,1,1) == true );
 ////        CHECK( check_jump(1, 1,1) == true );
 ////    }
-//
-//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_54)
-//    {
-//        //@054. dal segno al fine
-//        //         Segno       Fine    D.S.al fine
-//        //  |      |      |      ||      |
-//        //  1      2      3       4
-//        //                     J-1,1,1   J2,1
-//        load_mxl_score_for_test("54-repeat-dal-segno-al-fine.xml");
-//        //cout << m_pTable->dump_midi_events() << endl;
-//        CHECK( m_pTable->num_jumps() == 2);
-//        CHECK( check_jump(0, -1,1,1) == true );
-//        CHECK( check_jump(1, 2,1) == true );
-//    }
-//
-//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_55)
-//    {
-//        //@055. dal segno al coda
-//        //                             To      D.S.al
-//        //            Segno           Coda      Coda   Coda
-//        //  |         |         |        |           ||         |
-//        //  1         2         3        4            5
-//        //                            J5,1,1        J2,1
-//        load_mxl_score_for_test("55-repeat-dal-segno-al-coda.xml");
-//        //cout << m_pTable->dump_midi_events() << endl;
-//        CHECK( m_pTable->num_jumps() == 2);
-//        CHECK( check_jump(0, 5,1,1) == true );
-//        CHECK( check_jump(1, 2,1) == true );
-//    }
-//
-//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_56)
-//    {
-//        //@056. dal segno al coda
-//        //                                     D.C.al
-//        //                To Coda                Coda  Coda
-//        //  |         |         |:      :|           ||         |
-//        //  1         2         3        4            5
-//        //                    J5,1,1   J3,1        J1,1
-//        load_mxl_score_for_test("56-repeat-da-capo-al-coda.xml");
-//        //cout << m_pTable->dump_midi_events() << endl;
-//        CHECK( m_pTable->num_jumps() == 3);
-//        CHECK( check_jump(0, 5,1,1) == true );
-//        CHECK( check_jump(1, 3,1) == true );
-//        CHECK( check_jump(2, 1,1) == true );
-//    }
-//
-//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_57)
-//    {
-//        //@057. dal segno
-//        //            Segno                       D.S.
-//        //  |         |         |:      :|           ||         |
-//        //  1         2         3        4            5
-//        //                             J3,1         J2,1
-//        load_mxl_score_for_test("57-repeat-dal-segno.xml");
-//        //cout << m_pTable->dump_midi_events() << endl;
-//        CHECK( m_pTable->num_jumps() == 2);
-//        CHECK( check_jump(0, 3,1) == true );
-//        CHECK( check_jump(1, 2,1) == true );
-//    }
-//
-//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_58)
-//    {
-//        //@058. dal segno al coda
-//        //                   To                 DS al
-//        //            Segno  Coda                Coda  Coda
-//        //  |         |         |:      :|           ||         |
-//        //  1         2         3        4            5
-//        //                    J5,1,1   J3,1        J2,1
-//        load_mxl_score_for_test("58-repeat-dal-segno-al-coda.xml");
-//        //cout << m_pTable->dump_midi_events() << endl;
-//        CHECK( m_pTable->num_jumps() == 3);
-//        CHECK( check_jump(0, 5,1,1) == true );
-//        CHECK( check_jump(1, 3,1) == true );
-//        CHECK( check_jump(2, 2,1) == true );
-//    }
+
+    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_54)
+    {
+        //@054. dal segno al fine
+        //         Segno       Fine    D.S.al fine
+        //  |      |      |      ||      |
+        //  1      2      3       4
+        //                     J-1,1,1   J2,1
+        load_mxl_score_for_test("54-repeat-dal-segno-al-fine.xml");
+		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
+        //dump_measures_jumps(jumps);
+        CHECK( jumps.size() == 2 );
+        CHECK( check_measures_jump(__LINE__, jumps[0], 1,4) );      //from 1 to 4
+        CHECK( check_measures_jump(__LINE__, jumps[1], 2,3) );      //from 2 to 3
+    }
+
+    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_55)
+    {
+        //@055. dal segno al coda
+        //                             To      D.S.al
+        //            Segno           Coda      Coda   Coda
+        //  |         |         |        |           ||         |
+        //  1         2         3        4            5
+        //                            J5,1,1        J2,1
+        load_mxl_score_for_test("55-repeat-dal-segno-al-coda.xml");
+		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
+        //dump_measures_jumps(jumps);
+        CHECK( jumps.size() == 3 );
+        CHECK( check_measures_jump(__LINE__, jumps[0], 1,4) );      //from 1 to 4
+        CHECK( check_measures_jump(__LINE__, jumps[1], 2,3) );      //from 2 to 3
+        CHECK( check_measures_jump(__LINE__, jumps[2], 5,0) );      //from 5 to end
+    }
+
+    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_56)
+    {
+        //@056. dal segno al coda
+        //                                     D.C.al
+        //                To Coda                Coda  Coda
+        //  |         |         |:      :|           ||         |
+        //  1         2         3        4            5
+        //                    J5,1,1   J3,1        J1,1
+        load_mxl_score_for_test("56-repeat-da-capo-al-coda.xml");
+		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
+        //dump_measures_jumps(jumps);
+        CHECK( jumps.size() == 4 );
+        CHECK( check_measures_jump(__LINE__, jumps[0], 1,3) );      //from 1 to 3
+        CHECK( check_measures_jump(__LINE__, jumps[1], 3,4) );      //from 3 to 4
+        CHECK( check_measures_jump(__LINE__, jumps[2], 1,2) );      //from 1 to 2
+        CHECK( check_measures_jump(__LINE__, jumps[3], 5,0) );      //from 5 to end
+    }
+
+    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_57)
+    {
+        //@057. dal segno
+        //            Segno                       D.S.
+        //  |         |         |:      :|           ||         |
+        //  1         2         3        4            5
+        //                             J3,1         J2,1
+        load_mxl_score_for_test("57-repeat-dal-segno.xml");
+		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
+        //dump_measures_jumps(jumps);
+        CHECK( jumps.size() == 3 );
+        CHECK( check_measures_jump(__LINE__, jumps[0], 1,3) );      //from 1 to 3
+        CHECK( check_measures_jump(__LINE__, jumps[1], 3,4) );      //from 3 to 4
+        CHECK( check_measures_jump(__LINE__, jumps[2], 2,0) );      //from 2 to end
+    }
+
+    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_58)
+    {
+        //@058. dal segno al coda
+        //                   To                 DS al
+        //            Segno  Coda                Coda  Coda
+        //  |         |         |:      :|           ||         |
+        //  1         2         3        4            5
+        //                    J5,1,1   J3,1        J2,1
+        load_mxl_score_for_test("58-repeat-dal-segno-al-coda.xml");
+		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
+        //dump_measures_jumps(jumps);
+        CHECK( jumps.size() == 4 );
+        CHECK( check_measures_jump(__LINE__, jumps[0], 1,3) );      //from 1 to 3
+        CHECK( check_measures_jump(__LINE__, jumps[1], 3,4) );      //from 3 to 4
+        CHECK( check_measures_jump(__LINE__, jumps[2], 2,2) );      //from 2 to 2
+        CHECK( check_measures_jump(__LINE__, jumps[3], 5,0) );      //from 5 to end
+    }
 
 }
 

--- a/src/tests/lomse_test_midi_table.cpp
+++ b/src/tests/lomse_test_midi_table.cpp
@@ -120,7 +120,7 @@ public:
     bool check_jump(int i, int measure, int timesValid, int timesBefore, int event)
     {
         JumpEntry* pEntry = static_cast<JumpEntry*>( m_pTable->get_jump(i) );
-        if (pEntry->get_measure() != measure
+        if (pEntry->get_to_measure() != measure
             || pEntry->get_times_valid() != timesValid
             || pEntry->get_times_before() != timesBefore
             || pEntry->get_executed() != 0
@@ -137,7 +137,7 @@ public:
     bool check_jump(int i, int measure, int timesValid, int timesBefore=0)
     {
         JumpEntry* pEntry = static_cast<JumpEntry*>( m_pTable->get_jump(i) );
-        if (pEntry->get_measure() != measure
+        if (pEntry->get_to_measure() != measure
             || pEntry->get_times_valid() != timesValid
             || pEntry->get_times_before() != timesBefore
             || pEntry->get_executed() != 0
@@ -145,6 +145,18 @@ public:
         {
             cout << test_name() << ". JumpEntry " << i << ": "
                  << pEntry->dump_entry();
+            return false;
+        }
+        return true;
+    }
+
+    bool check_measures_jump(int iLine, MeasuresJumpsEntry* pEntry, int fromMeasure,
+                             int toMeasure)
+    {
+        if (pEntry->get_from_measure() != fromMeasure
+            || pEntry->get_to_measure() != toMeasure)
+        {
+            cout << test_name() << " (line " << iLine << ") " << pEntry->dump_entry();
             return false;
         }
         return true;
@@ -929,6 +941,272 @@ SUITE(MidiTableTest)
         CHECK( events[10]->DeltaTime == 256L );
         CHECK( events[10]->Volume == 85 );
     }
+
+
+    //@ Measures jumps table ------------------------------------------------------------
+
+    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_01)
+    {
+        //@001. measures_jumps_score with no repetitions creates only one entry
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0)(instrument (musicData "
+            "(clef G)(n c4 q)(n e4 q)(n g4 q) )))" );
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+
+		SoundEventsTable* pTable = pScore->get_midi_table();
+		std::vector<MeasuresJumpsEntry*> jumps = pTable->get_measures_jumps();
+
+        CHECK( jumps.size() == 1 );
+        CHECK( check_measures_jump(__LINE__, jumps[0], 1,0) );  //from 1 to end
+    }
+
+    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_02)
+    {
+        //@002. [T1] end-repetition barline creates one repetition
+        //  |    |    |    :|     |     |
+        //  1    2    3     4     5
+        //                 J 2,1
+        load_mxl_score_for_test("01-repeat-end-repetition-barline.xml");
+        //cout << m_pTable->dump_midi_events() << endl;
+		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
+        CHECK( jumps.size() == 2 );
+        CHECK( check_measures_jump(__LINE__, jumps[0], 1,3) );      //from 1 to 3
+        CHECK( check_measures_jump(__LINE__, jumps[1], 1,0) );      //from 1 to end
+    }
+
+    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_03)
+    {
+        //@003. [T2] start-end-repetition barlines creates one repetition
+        //  |    |     |:    |    :|     |     |
+        //  1    2     3     4     5     6
+        //                       J 3,1
+        load_mxl_score_for_test("02-repeat-start-end-repetition-barlines.xml");
+        //cout << m_pTable->dump_midi_events() << endl;
+		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
+        CHECK( jumps.size() == 2 );
+        CHECK( check_measures_jump(__LINE__, jumps[0], 1,4) );      //from 1 to 4
+        CHECK( check_measures_jump(__LINE__, jumps[1], 3,0) );      //from 3 to end
+    }
+
+    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_04)
+    {
+        //@004. [T3] start-end-repetition barlines creates one repetition
+        //  |    |    :|:    |    :|     |     |
+        //  1    2     3     4     5     6
+        //            J 1,1       J 3,1
+        load_mxl_score_for_test("03-repeat-double-end-repetition-barlines.xml");
+        //cout << m_pTable->dump_midi_events() << endl;
+		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
+        CHECK( jumps.size() == 3 );
+        CHECK( check_measures_jump(__LINE__, jumps[0], 1,2) );      //from 1 to 2
+        CHECK( check_measures_jump(__LINE__, jumps[1], 1,4) );      //from 1 to 4
+        CHECK( check_measures_jump(__LINE__, jumps[2], 3,0) );      //from 3 to end
+    }
+
+//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_07)
+//    {
+//        //@007. [T4] end-repetition barline with volta brackets
+//        //                  vt1    vt2
+//        //  |    |    |     |     :|     |     |     |
+//        //  1    2    3     4      5    6
+//        //                 J 4,1  J 1,1
+//        //                   5,0
+//        load_mxl_score_for_test("04-repeat-barline-simple-volta.xml");
+//        //cout << m_pTable->dump_midi_events() << endl;
+//        CHECK( m_pTable->num_jumps() == 3 );
+//        CHECK( check_jump(0, 4,1,0,10) == true );
+//        CHECK( check_jump(1, 5,0,0,13) == true );
+//        CHECK( check_jump(2, 1,1,0,1) == true );
+//    }
+//
+//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_08)
+//    {
+//        //@008. [T5]  end-repetition barline with volta, two times
+//        //                  vt1,2  vt3
+//        //  |    |    |     |     :|     |     |     |
+//        //  1    2    3     4      5    6
+//        //                 J4,2   J1,2
+//        //                 J5,0
+//        load_mxl_score_for_test("05-repeat-barline-simple-volta-two-times.xml");
+//        //cout << m_pTable->dump_midi_events() << endl;
+//        CHECK( m_pTable->num_jumps() == 3 );
+//        CHECK( check_jump(0, 4,2,0,10) == true );
+//        CHECK( check_jump(1, 5,0,0,13) == true );
+//        CHECK( check_jump(2, 1,2,0,1) == true );
+//    }
+//
+//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_09)
+//    {
+//        //@009. [T7] three voltas
+//        //            vt1   vt2    vt3
+//        //  |    |    |    :|     :|     |     |
+//        //  1    2    3     4      5    6
+//        //           J3,1  J1,1   J1,1
+//        //           J4,1
+//        //           J5,0
+//        load_mxl_score_for_test("07-repeat-barlines-three-volta.xml");
+//        //cout << m_pTable->dump_midi_events() << endl;
+//        CHECK( m_pTable->num_jumps() == 5 );
+//        CHECK( check_jump(0, 3,1) == true );
+//        CHECK( check_jump(1, 4,1) == true );
+//        CHECK( check_jump(2, 5,0) == true );
+//        CHECK( check_jump(3, 1,1) == true );
+//        CHECK( check_jump(4, 1,1) == true );
+//    }
+//
+//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_10)
+//    {
+//        //@010. [T8] three voltas long
+//        //            vt1------- vt2------- vt3---------
+//        //  |    |    |     |    :|     |    :|     |     |    |    |    |    |
+//        //  1    2    3     4      5    6     7     8     9    10   11   12
+//        //           J3,1        J1,1        J1,1
+//        //           J5,1
+//        //           J7,0
+//        load_mxl_score_for_test("08-repeat-barlines-three-volta-long.xml");
+//        //cout << m_pTable->dump_midi_events() << endl;
+//        CHECK( m_pTable->num_jumps() == 5 );
+//        CHECK( check_jump(0, 3,1) == true );
+//        CHECK( check_jump(1, 5,1) == true );
+//        CHECK( check_jump(2, 7,0) == true );
+//        CHECK( check_jump(3, 1,1) == true );
+//        CHECK( check_jump(4, 1,1) == true );
+//    }
+//
+//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_11)
+//    {
+//        //@011. three voltas long several times
+//        //            vt1,2------ vt3,5------- vt5---------
+//        //  |    |    |     |    :|     |    :|     |     |    |    |    |    |
+//        //  1    2    3     4      5    6     7     8     9    10   11   12
+//        //           J3,2        J1,2        J1,2
+//        //           J5,2
+//        //           J7,0
+//        load_mxl_score_for_test("09-repeat-barlines-three-volta-long-several-times.xml");
+//        //cout << m_pTable->dump_midi_events() << endl;
+//        CHECK( m_pTable->num_jumps() == 5 );
+//        CHECK( check_jump(0, 3,2) == true );
+//        CHECK( check_jump(1, 5,2) == true );
+//        CHECK( check_jump(2, 7,0) == true );
+//        CHECK( check_jump(3, 1,2) == true );
+//        CHECK( check_jump(4, 1,2) == true );
+//    }
+//
+//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_51)
+//    {
+//        //@051. da capo
+//        //                            D.C.
+//        //  |      |      |      |      |
+//        //  1      2      3      4
+//        //                             J1,1
+//        load_mxl_score_for_test("51-repeat-da-capo.xml");
+//        //cout << m_pTable->dump_midi_events() << endl;
+//        CHECK( m_pTable->num_jumps() == 1 );
+//        CHECK( check_jump(0, 1,1) == true );
+//    }
+//
+//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_52)
+//    {
+//        //@052. da capo al fine
+//        //             Fine           D.C.
+//        //  |      |      |      |      |
+//        //  1      2      3      4
+//        //              J-1,1,1        J1,1
+//        load_mxl_score_for_test("52-repeat-da-capo-al-fine.xml");
+//        //cout << m_pTable->dump_midi_events() << endl;
+//        CHECK( m_pTable->num_jumps() == 2);
+//        CHECK( check_jump(0, -1,1,1) == true );
+//        CHECK( check_jump(1, 1,1) == true );
+//    }
+//
+////    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_53)
+////    {
+////        //@053. da capo al segno
+////        //         Segno               D.C.
+////        //  |      |      |      ||      |
+////        //  1      2      3       4
+////        //        J4,1,1                J1,1
+////        load_mxl_score_for_test("53-repeat-da-capo-al-segno.xml");
+////        cout << m_pTable->dump_midi_events() << endl;
+////        CHECK( m_pTable->num_jumps() == 2);
+////        CHECK( check_jump(0, 4,1,1) == true );
+////        CHECK( check_jump(1, 1,1) == true );
+////    }
+//
+//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_54)
+//    {
+//        //@054. dal segno al fine
+//        //         Segno       Fine    D.S.al fine
+//        //  |      |      |      ||      |
+//        //  1      2      3       4
+//        //                     J-1,1,1   J2,1
+//        load_mxl_score_for_test("54-repeat-dal-segno-al-fine.xml");
+//        //cout << m_pTable->dump_midi_events() << endl;
+//        CHECK( m_pTable->num_jumps() == 2);
+//        CHECK( check_jump(0, -1,1,1) == true );
+//        CHECK( check_jump(1, 2,1) == true );
+//    }
+//
+//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_55)
+//    {
+//        //@055. dal segno al coda
+//        //                             To      D.S.al
+//        //            Segno           Coda      Coda   Coda
+//        //  |         |         |        |           ||         |
+//        //  1         2         3        4            5
+//        //                            J5,1,1        J2,1
+//        load_mxl_score_for_test("55-repeat-dal-segno-al-coda.xml");
+//        //cout << m_pTable->dump_midi_events() << endl;
+//        CHECK( m_pTable->num_jumps() == 2);
+//        CHECK( check_jump(0, 5,1,1) == true );
+//        CHECK( check_jump(1, 2,1) == true );
+//    }
+//
+//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_56)
+//    {
+//        //@056. dal segno al coda
+//        //                                     D.C.al
+//        //                To Coda                Coda  Coda
+//        //  |         |         |:      :|           ||         |
+//        //  1         2         3        4            5
+//        //                    J5,1,1   J3,1        J1,1
+//        load_mxl_score_for_test("56-repeat-da-capo-al-coda.xml");
+//        //cout << m_pTable->dump_midi_events() << endl;
+//        CHECK( m_pTable->num_jumps() == 3);
+//        CHECK( check_jump(0, 5,1,1) == true );
+//        CHECK( check_jump(1, 3,1) == true );
+//        CHECK( check_jump(2, 1,1) == true );
+//    }
+//
+//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_57)
+//    {
+//        //@057. dal segno
+//        //            Segno                       D.S.
+//        //  |         |         |:      :|           ||         |
+//        //  1         2         3        4            5
+//        //                             J3,1         J2,1
+//        load_mxl_score_for_test("57-repeat-dal-segno.xml");
+//        //cout << m_pTable->dump_midi_events() << endl;
+//        CHECK( m_pTable->num_jumps() == 2);
+//        CHECK( check_jump(0, 3,1) == true );
+//        CHECK( check_jump(1, 2,1) == true );
+//    }
+//
+//    TEST_FIXTURE(MidiTableTestFixture, measures_jumps_58)
+//    {
+//        //@058. dal segno al coda
+//        //                   To                 DS al
+//        //            Segno  Coda                Coda  Coda
+//        //  |         |         |:      :|           ||         |
+//        //  1         2         3        4            5
+//        //                    J5,1,1   J3,1        J2,1
+//        load_mxl_score_for_test("58-repeat-dal-segno-al-coda.xml");
+//        //cout << m_pTable->dump_midi_events() << endl;
+//        CHECK( m_pTable->num_jumps() == 3);
+//        CHECK( check_jump(0, 5,1,1) == true );
+//        CHECK( check_jump(1, 3,1) == true );
+//        CHECK( check_jump(2, 2,1) == true );
+//    }
 
 }
 


### PR DESCRIPTION
Closes #247. This view has a double behaviour:
- In normal mode (no playback) it behaves as SinglePageView: a single page as high as necessary to contain all the score.
- When entered in playback mode, the bitmap to be rendered in the application window is split horizontally in two halves, originating two virtual vertical windows, one at top and the other at bottom. In the top window it is displayed the first score chunk and the second chunk is displayed in the bottom window. When playback enters in the bottom window the top window is updated with the third chunk. Next, when the playback enters again in the top window, the bottom window is updated with the next chunk, and so on.
- When playback is finished (because the end of the score is reached or because the app stops playback  -- but not when playback is paused --) the display returns automatically to SinglePageView.

This view allows to solve the problem page turning and the problem of repetition marks and jumps:  when the window being played has a jump to a system not visible in that window, the other window is updated  with the next logical system (the one containing the jump destination) instead of with the next system. The behaviour for the user is very simple: when the end of the last system in current window is reached or when user finds a jump to a point that is not displayed in current window, he/she will know that it is necessary to jump to the other half window.

You should note that when the view is split, only full systems are displayed in the sub-windows. This is to avoid doubts about were the music continues, that could appear in cases in which next system is practically fully displayed after current one. It also makes the display more clear.

The view does not enter in split mode in the following cases:
- when window height is smaller than two times the highest system,
- when window width is lower than system width,
- when the score fits completely in the window height, or
- when the document is not only one score

In these cases, playback behaviour will be that of SinglePageView

When the view is in split mode (during playback) all setting for controlling what to display and how are fully controlled by the view. Therefore, the user application should disable all user controls that could invoke methods to do changes, such as scroll position, zoom factor or other. Invoking these methods will not cause crashes but will cause unnecessary interference with what is displayed.
