### PR TITLE
Enable compilation on Android

### DIFF
--- a/packages/minizip/ioapi.c
+++ b/packages/minizip/ioapi.c
@@ -17,7 +17,7 @@
 #include "ioapi.h"
 
 //Lomse. Fix compilation on macOS, where ftello64, fseeko64 and fopen64 are not defined.
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(ANDROID)
     #define ftello64 ftello
     #define fseeko64 fseeko
     #define fopen64 fopen

--- a/packages/minizip/ioapi.h
+++ b/packages/minizip/ioapi.h
@@ -21,7 +21,8 @@
 #ifndef _ZLIBIOAPI64_H
 #define _ZLIBIOAPI64_H
 
-#if (!defined(_WIN32)) && (!defined(WIN32))
+// Lomse: excluded Android to avoid binary incompatibility with versions before Android 7
+#if (!defined(_WIN32)) && (!defined(WIN32)) && (!defined(ANDROID))
 
   // Linux needs this to support file operation on files larger then 4+GB
   // But might need better if/def to select just the platforms that needs them.


### PR DESCRIPTION
This pull request contains changes that are necessary to compile Lomse library for Android. Similar to #135, it was necessary to replace `ftello64`, `fseeko64` and `fopen64` functions which are not present on Android. In addition to that, I have added a change to `ioapi.h` which disables using 64-bit flavors of these functions when building for Android. This was necessary to get compressed files support in Lomse working on Android versions earlier than Android 7 (API level 24) since those versions didn't have 64-bit `fseeko`/`ftello` functions. This change disables support of compressed files larger than 4GB on that platform, but it doesn't seem to be needed for musical file formats anyway.

A similar change has also been done in [another fork](https://github.com/nmoinvaz/minizip/pull/138/files) of minizip, so synchronizing minizip code with that fork can also be another option to resolve compilation issues on some platforms.