### PR TITLE
Make logger output destination customizable

### DIFF
--- a/include/lomse_command.h
+++ b/include/lomse_command.h
@@ -205,7 +205,7 @@ protected:
     void log_forensic_data(Document* pDoc, DocCursor* pCursor);
     void set_command_name(const string& name, ImoObj* pImo);
     int validate_source(const string& source);
-    virtual void log_command(ofstream &logger);
+    virtual void log_command(ostream &logger);
 
 };
 
@@ -429,7 +429,7 @@ public:
 
 protected:
     void update_selection(SelectionSet* pSelection);
-    void log_command(ofstream &logger);
+    void log_command(ostream &logger);
 
 };
 
@@ -540,7 +540,7 @@ protected:
 
     //overrides and mandatory virtual methods
     void set_command_name();
-    void log_command(ofstream &logger);
+    void log_command(ostream &logger);
 
 };
 
@@ -598,7 +598,7 @@ public:
     ///@endcond
 
 protected:
-    void log_command(ofstream &logger);
+    void log_command(ostream &logger);
 };
 
 //---------------------------------------------------------------------------------------
@@ -666,7 +666,7 @@ public:
     ///@endcond
 
 protected:
-    void log_command(ofstream &logger);
+    void log_command(ostream &logger);
 };
 
 //---------------------------------------------------------------------------------------
@@ -723,7 +723,7 @@ public:
     ///@endcond
 
 protected:
-    void log_command(ofstream &logger);
+    void log_command(ostream &logger);
 };
 
 //---------------------------------------------------------------------------------------
@@ -781,7 +781,7 @@ public:
     ///@endcond
 
 protected:
-    void log_command(ofstream &logger);
+    void log_command(ostream &logger);
 };
 
 //---------------------------------------------------------------------------------------
@@ -1840,7 +1840,7 @@ public:
     ///@endcond
 
 protected:
-    void log_command(ofstream &logger);
+    void log_command(ostream &logger);
 };
 
 //---------------------------------------------------------------------------------------

--- a/include/lomse_doorway.h
+++ b/include/lomse_doorway.h
@@ -96,7 +96,8 @@ protected:
 public:
 	/** Constructor. Your application should create only one instance of LomseDoorway
         and its life scope should be as long as your application need to use Lomse.  */
-    LomseDoorway();
+    explicit LomseDoorway(std::ostream* logStream = nullptr,
+                          std::ostream* forensicLogStream = nullptr);
     virtual ~LomseDoorway();
 
     //library initialization and configuration
@@ -444,9 +445,6 @@ public:
     //communication with user application
     inline void post_event(SpEventInfo pEvent) { m_pFunc_notify(m_pObj_notify, pEvent); }
     inline void post_request(Request* pRequest) { m_pFunc_request(m_pObj_request, pRequest); }
-
-protected:
-    void clear_forensic_log();
 
 ///@endcond
 };

--- a/include/lomse_score_layouter.h
+++ b/include/lomse_score_layouter.h
@@ -199,7 +199,7 @@ public:
     void finish_measure(int iInstr, GmoShapeBarline* pBarlineShape);
 
     //support for debugging and unit tests
-    void dump_column_data(int iCol, ostream& outStream=dbgLogger);
+    void dump_column_data(int iCol, ostream& outStream=logger.get_stream());
     void delete_not_used_objects();
     void delete_pendig_aux_objects();
     void delete_system_boxes();
@@ -453,7 +453,7 @@ public:
     void decide_line_breaks();
 
     //support for debug and tests
-    void dump_entries(ostream& outStream=dbgLogger);
+    void dump_entries(ostream& outStream=logger.get_stream());
 
 protected:
     struct Entry

--- a/src/document/lomse_command.cpp
+++ b/src/document/lomse_command.cpp
@@ -76,8 +76,7 @@ void DocCommand::undo_action(Document* pDoc, DocCursor* UNUSED(pCursor))
     //default implementation based on restoring from saved checkpoint data
 
     //log command for forensic analysis
-    ofstream logger;
-    logger.open("forensic_log.txt", std::ofstream::out | std::ofstream::app);
+    ostream& logger = get_global_logger().get_forensic_log_stream();
 
     logger << "---------------------------------------------"
            << "---------------------------------------------" << endl;
@@ -97,7 +96,7 @@ void DocCommand::undo_action(Document* pDoc, DocCursor* UNUSED(pCursor))
         pDoc->from_checkpoint(m_checkpoint);
 
     logger << "IdAssigner. After: " << pDoc->dump_ids() << endl;
-    logger.close();
+    get_global_logger().close_forensic_log();
 }
 
 //---------------------------------------------------------------------------------------
@@ -105,8 +104,7 @@ void DocCommand::log_forensic_data(Document* UNUSED(pDoc), DocCursor* pCursor)
 {
     //save data for forensic analysis if a crash
 
-    ofstream logger;
-    logger.open("forensic_log.txt", std::ofstream::out | std::ofstream::app);
+    ostream& logger = get_global_logger().get_forensic_log_stream();
 
     logger << "---------------------------------------------"
            << "---------------------------------------------" << endl;
@@ -116,11 +114,11 @@ void DocCommand::log_forensic_data(Document* UNUSED(pDoc), DocCursor* pCursor)
     logger << "Cursor: " << pCursor->dump_cursor();
     logger << "Checkpoint data (last id " << m_idChk << "):" << endl;
     logger << m_checkpoint << endl;
-    logger.close();
+    get_global_logger().close_forensic_log();
 }
 
 //---------------------------------------------------------------------------------------
-void DocCommand::log_command(ofstream &logger)
+void DocCommand::log_command(ostream &logger)
 {
     //default implementation. Should be overriden in specific commands
     logger << "Command. Name: " << this->get_name() << endl;
@@ -503,7 +501,7 @@ CmdAddChordNote::CmdAddChordNote(const string& pitch, const string& name)
 }
 
 //---------------------------------------------------------------------------------------
-void CmdAddChordNote::log_command(ofstream &logger)
+void CmdAddChordNote::log_command(ostream &logger)
 {
     logger << "Command CmdAddChordNote. Name: '" << this->get_name()
         << ", pitch: " << m_pitch << endl;
@@ -613,7 +611,7 @@ CmdAddNoteRest::CmdAddNoteRest(const string& source, int UNUSED(editMode),
 }
 
 //---------------------------------------------------------------------------------------
-void CmdAddNoteRest::log_command(ofstream &logger)
+void CmdAddNoteRest::log_command(ostream &logger)
 {
     logger << "Command CmdAddNoteRest. Name: '" << this->get_name()
         << ", source: " << m_source << endl;
@@ -941,7 +939,7 @@ int CmdAddTie::set_target(Document* UNUSED(pDoc), DocCursor* UNUSED(pCursor),
 }
 
 //---------------------------------------------------------------------------------------
-void CmdAddTie::log_command(ofstream &logger)
+void CmdAddTie::log_command(ostream &logger)
 {
     logger << "Command CmdAddTie. Name: '" << this->get_name()
         << ", start & end notes: " << m_startId << ", " << m_endId << endl;
@@ -1015,7 +1013,7 @@ int CmdAddTuplet::set_target(Document* UNUSED(pDoc), DocCursor* UNUSED(pCursor),
 }
 
 //---------------------------------------------------------------------------------------
-void CmdAddTuplet::log_command(ofstream &logger)
+void CmdAddTuplet::log_command(ostream &logger)
 {
     logger << "Command CmdAddTuplet. Name: '" << this->get_name()
         << ", start & end notes: " << m_startId << ", " << m_endId
@@ -1086,7 +1084,7 @@ int CmdBreakBeam::set_target(Document* UNUSED(pDoc), DocCursor* pCursor,
 }
 
 //---------------------------------------------------------------------------------------
-void CmdBreakBeam::log_command(ofstream &logger)
+void CmdBreakBeam::log_command(ostream &logger)
 {
     logger << "Command CmdBreakBeam. Name: '" << this->get_name()
         << ", before note: " << m_beforeId << endl;
@@ -1226,7 +1224,7 @@ int CmdChangeAccidentals::set_target(Document* UNUSED(pDoc), DocCursor* UNUSED(p
 }
 
 //---------------------------------------------------------------------------------------
-void CmdChangeAccidentals::log_command(ofstream &logger)
+void CmdChangeAccidentals::log_command(ostream &logger)
 {
     logger << "Command CmdChangeAccidentals. Name: '" << this->get_name() << endl;
 }
@@ -2528,7 +2526,7 @@ int CmdJoinBeam::set_target(Document* UNUSED(pDoc), DocCursor* UNUSED(pCursor),
 }
 
 //---------------------------------------------------------------------------------------
-void CmdJoinBeam::log_command(ofstream &logger)
+void CmdJoinBeam::log_command(ostream &logger)
 {
     logger << "Command CmdJoinBeam. Name: '" << this->get_name()
         << ", notes:";

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -1662,7 +1662,7 @@ void LinesBreakerOptimal::retrieve_breaks_sequence()
     if (fTrace)
     {
         dbgLogger << "Breaks computed. Entries: ************************************" << endl;
-        dump_entries(dbgLogger);
+        dump_entries(logger.get_stream());
     }
 
     int i = m_numCols;

--- a/src/graphic_model/layouters/lomse_spacing_algorithm_gourlay.cpp
+++ b/src/graphic_model/layouters/lomse_spacing_algorithm_gourlay.cpp
@@ -420,7 +420,7 @@ void SpAlgGourlay::do_spacing(int iCol, bool fTrace)
     {
         dbgLogger << endl << to_simple_string(chrono::system_clock::now(), true)
                   << " ******************* Before spacing" << endl;
-        m_columns[iCol]->dump(dbgLogger);
+        m_columns[iCol]->dump(logger.get_stream());
     }
 
     //apply optimum force to get an initial estimation for columns width

--- a/src/module/lomse_doorway.cpp
+++ b/src/module/lomse_doorway.cpp
@@ -53,7 +53,7 @@ namespace lomse
 //=======================================================================================
 //platform independent methods
 //=======================================================================================
-LomseDoorway::LomseDoorway()
+LomseDoorway::LomseDoorway(std::ostream* logStream, std::ostream* forensicLogStream)
     : m_pLibraryScope(nullptr)
     , m_platform{ EPixelFormat::k_pix_format_undefined, false, 72.0 }
     , m_pFunc_notify(null_notify_function)
@@ -61,21 +61,13 @@ LomseDoorway::LomseDoorway()
     , m_pObj_notify(nullptr)
     , m_pObj_request(nullptr)
 {
-    clear_forensic_log();
+    logger.init(logStream, forensicLogStream);
 }
 
 //---------------------------------------------------------------------------------------
 LomseDoorway::~LomseDoorway()
 {
     delete m_pLibraryScope;
-}
-
-//---------------------------------------------------------------------------------------
-void LomseDoorway::clear_forensic_log()
-{
-    ofstream logger;
-    logger.open("forensic_log.txt");
-    logger.close();
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/platform/lomse_linux.cpp
+++ b/src/platform/lomse_linux.cpp
@@ -52,16 +52,13 @@ namespace lomse
 //=======================================================================================
 // Logger implementation
 //=======================================================================================
-Logger::Logger(int mode)
-    : m_mode(mode)
-    , m_areas(0xffffffff)       //all areas enabled
+std::string Logger::get_default_log_path()
 {
     struct passwd* pw = getpwuid(getuid());
     const char* homedir = pw->pw_dir;
     string logPath(homedir);
     logPath += "/lomse-log.txt";
-    dbgLogger.open(logPath);
-    LOMSE_LOG_INFO("lomse log path=%s", logPath.c_str());
+    return logPath;
 }
 
 

--- a/src/platform/lomse_other.cpp
+++ b/src/platform/lomse_other.cpp
@@ -43,11 +43,9 @@ namespace lomse
 //=======================================================================================
 // Logger implementation
 //=======================================================================================
-Logger::Logger(int mode)
-    : m_mode(mode)
-    , m_areas(0xffffffff)       //all areas enabled
+std::string Logger::get_default_log_path()
 {
-    dbgLogger.open("lomse-log.txt");
+    return "lomse-log.txt";
 }
 
 //=======================================================================================

--- a/src/platform/lomse_windows.cpp
+++ b/src/platform/lomse_windows.cpp
@@ -48,14 +48,11 @@ namespace lomse
 //=======================================================================================
 // Logger implementation
 //=======================================================================================
-Logger::Logger(int mode)
-    : m_mode(mode)
-    , m_areas(0xffffffff)       //all areas enabled
+std::string Logger::get_default_log_path()
 {
     string logpath = std::getenv("HOMEPATH");
     logpath += "\\lomse-log.txt";
-    dbgLogger.open(logpath);
-    LOMSE_LOG_INFO("lomse log path=%s", logpath.c_str());
+    return logpath;
 }
 
 //=======================================================================================


### PR DESCRIPTION
This pull request is more intended for a discussion of the proposed changes, although it already implements a fully working solution at the moment.

The proposed change tries to enable applications to customize the way Lomse does its logging. Currently Lomse puts its logs to files at certain predefined paths which may be not suitable for all applications. An application may want to put logs to its application-specific directory, disable logging at all (like it has been done in https://github.com/hugbug/conpianist/issues/32) or redirect logs to another destination (standard output/error streams (`stdout`/`stderr`) or platform-specific logging systems like Android Logcat).

The proposal is to allow applications initialize logging system before creating `LomseDoorway` object by calling `lomse::get_global_logger().init()` and providing custom `std::ostream` objects to be used by the logger, for example:
```
lomse::get_global_logger().init(/* logStream */ &std::cout, /* forensicLogStream */ &std::cerr);
```
If custom log streams are not provided before creating `LomseDoorway` object, it initializes logging system to use the default logging configuration (the same predefined common and forensic log files as before).

Application can also deinitialize logging system in case the provided streams somehow get invalidated:
```
lomse::get_global_logger().deinit();
```

A somewhat similar approach is already used by Lomse allowing to provide `std::ostream` objects for reporting errors when calling `init_library()`, `new_document()` and `open_document()` methods in `LomseDoorway`, so this pull request expands this approach to cover also the library-global logging system.

Another possible approach could be allowing applications to provide custom `Logger` object with certain methods being overridden, which may potentially offer more flexibility in handling of logging severity levels.

Please let me know what do you think of this proposal, and whether another way of handling logging output would be more preferable.