### PR TITLE
Fix clang warning: overrides a member but is not marked 'override'

### DIFF
--- a/include/lomse_blocks_container_layouter.h
+++ b/include/lomse_blocks_container_layouter.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -70,8 +70,8 @@ public:
     virtual ~ContentLayouter() {}
 
     //implementation of Layouter virtual methods
-    void layout_in_box();
-    void create_main_box(GmoBox* pParentBox, UPoint pos, LUnits width, LUnits height);
+    void layout_in_box() override;
+    void create_main_box(GmoBox* pParentBox, UPoint pos, LUnits width, LUnits height) override;
 
 };
 
@@ -93,8 +93,8 @@ public:
     virtual ~MultiColumnLayouter();
 
     //implementation of Layouter virtual methods
-    void layout_in_box();
-    void create_main_box(GmoBox* pParentBox, UPoint pos, LUnits width, LUnits height);
+    void layout_in_box() override;
+    void create_main_box(GmoBox* pParentBox, UPoint pos, LUnits width, LUnits height) override;
 
 protected:
     void layout_column(Layouter* pColLayouter, GmoBox* pParentBox,
@@ -113,9 +113,9 @@ public:
     virtual ~BlocksContainerLayouter() {}
 
     //generic implementation of Layouter virtual methods
-    virtual void layout_in_box();
+    virtual void layout_in_box() override;
     virtual void create_main_box(GmoBox* pParentBox, UPoint pos,
-                                 LUnits width, LUnits height);
+                                 LUnits width, LUnits height) override;
 };
 
 //----------------------------------------------------------------------------------
@@ -134,7 +134,7 @@ public:
 
     //overrides
     //void layout_in_box();
-    void create_main_box(GmoBox* pParentBox, UPoint pos, LUnits width, LUnits height);
+    void create_main_box(GmoBox* pParentBox, UPoint pos, LUnits width, LUnits height) override;
 };
 
 //---------------------------------------------------------------------------------------

--- a/include/lomse_button_ctrl.h
+++ b/include/lomse_button_ctrl.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -55,16 +55,16 @@ public:
     virtual ~ButtonCtrl() {}
 
     //Control mandatory overrides
-    USize measure();
-    GmoBoxControl* layout(LibraryScope& libraryScope, UPoint pos);
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
-    void handle_event(SpEventInfo pEvent);
-    LUnits width() { return m_width; }
-    LUnits height() { return m_height; }
-    LUnits top() { return m_pos.y; }
-    LUnits bottom() { return m_pos.y + m_height; }
-    LUnits left() { return m_pos.x; }
-    LUnits right() { return m_pos.x + m_width; }
+    USize measure() override;
+    GmoBoxControl* layout(LibraryScope& libraryScope, UPoint pos) override;
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
+    void handle_event(SpEventInfo pEvent) override;
+    LUnits width() override { return m_width; }
+    LUnits height() override { return m_height; }
+    LUnits top() override { return m_pos.y; }
+    LUnits bottom() override { return m_pos.y + m_height; }
+    LUnits left() override { return m_pos.x; }
+    LUnits right() override { return m_pos.x + m_width; }
 
     //specific methods
     void set_label(const string& text);

--- a/include/lomse_caret.h
+++ b/include/lomse_caret.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -76,8 +76,8 @@ public:
     inline void hide_caret() { m_fVisible = false; }
 
     //mandatory overrides from VisualEffect
-    void on_draw(ScreenDrawer* pDrawer);
-    URect get_bounds() { return m_bounds; }
+    void on_draw(ScreenDrawer* pDrawer) override;
+    URect get_bounds() override { return m_bounds; }
 
     //caret shapes
     enum { k_top_level=0, k_box, k_line, k_block, };

--- a/include/lomse_caret_positioner.h
+++ b/include/lomse_caret_positioner.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -133,9 +133,9 @@ public:
     ScoreCaretPositioner(GraphicModel* pGModel);
     virtual ~ScoreCaretPositioner();
 
-    void layout_caret(Caret* pCaret, DocCursor* pCursor);
+    void layout_caret(Caret* pCaret, DocCursor* pCursor) override;
     SpElementCursorState click_point_to_cursor_state(int iPage, LUnits x, LUnits y,
-                                               ImoObj* pImo, GmoObj* pGmo);
+                                               ImoObj* pImo, GmoObj* pGmo) override;
 
 protected:
     void caret_on_pointed_object(Caret* pCaret);

--- a/include/lomse_checkbox_ctrl.h
+++ b/include/lomse_checkbox_ctrl.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -69,16 +69,16 @@ public:
     virtual ~CheckboxCtrl() {}
 
     //Control mandatory overrides
-    USize measure();
-    GmoBoxControl* layout(LibraryScope& libraryScope, UPoint pos);
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
-    void handle_event(SpEventInfo pEvent);
-    LUnits width() { return m_width; }
-    LUnits height() { return m_height; }
-    LUnits top() { return m_pos.y; }
-    LUnits bottom() { return m_pos.y + m_height; }
-    LUnits left() { return m_pos.x; }
-    LUnits right() { return m_pos.x + m_width; }
+    USize measure() override;
+    GmoBoxControl* layout(LibraryScope& libraryScope, UPoint pos) override;
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
+    void handle_event(SpEventInfo pEvent) override;
+    LUnits width() override { return m_width; }
+    LUnits height() override { return m_height; }
+    LUnits top() override { return m_pos.y; }
+    LUnits bottom() override { return m_pos.y + m_height; }
+    LUnits left() override { return m_pos.x; }
+    LUnits right() override { return m_pos.x + m_width; }
 
     //specific methods
     void set_text(const string& text);
@@ -88,8 +88,8 @@ public:
     inline void set_checked(bool value) { m_status = value; }
 
     //VertexSource mandatory methods
-    unsigned vertex(double* px, double* py);
-    void rewind(int UNUSED(pathId) = 0) { m_nCurVertex = 0; }
+    unsigned vertex(double* px, double* py) override;
+    void rewind(int UNUSED(pathId) = 0) override { m_nCurVertex = 0; }
 
 protected:
     void select_font();

--- a/include/lomse_command.h
+++ b/include/lomse_command.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -223,7 +223,7 @@ public:
     virtual ~DocCmdSimple() {}
 
     /// Returns @true if the command is composite.
-    bool is_composite() { return false; }
+    bool is_composite() override { return false; }
 
 };
 
@@ -418,18 +418,18 @@ public:
     CmdAddChordNote(const string& pitch, const string& name="Add chord note");
     virtual ~CmdAddChordNote() {};
 
-    int get_cursor_update_policy() { return k_refresh; }
-    int get_undo_policy() { return k_undo_policy_partial_checkpoint; }
-    int get_selection_update_policy() { return k_sel_command_specific; }
+    int get_cursor_update_policy() override { return k_refresh; }
+    int get_undo_policy() override { return k_undo_policy_partial_checkpoint; }
+    int get_selection_update_policy() override { return k_sel_command_specific; }
 
     ///@cond INTERNALS
-    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection);
-    int perform_action(Document* pDoc, DocCursor* pCursor);
+    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection) override;
+    int perform_action(Document* pDoc, DocCursor* pCursor) override;
     ///@endcond
 
 protected:
-    void update_selection(SelectionSet* pSelection);
-    void log_command(ostream &logger);
+    void update_selection(SelectionSet* pSelection) override;
+    void log_command(ostream &logger) override;
 
 };
 
@@ -497,13 +497,13 @@ public:
     CmdAddNoteRest(const string& source, int editMode, const string& name="");
     virtual ~CmdAddNoteRest() {};
 
-    int get_cursor_update_policy() { return k_refresh; }
-    int get_undo_policy() { return k_undo_policy_partial_checkpoint; }
-    int get_selection_update_policy() { return k_sel_command_specific; }
+    int get_cursor_update_policy() override { return k_refresh; }
+    int get_undo_policy() override { return k_undo_policy_partial_checkpoint; }
+    int get_selection_update_policy() override { return k_sel_command_specific; }
 
     ///@cond INTERNALS
-    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection);
-    int perform_action(Document* pDoc, DocCursor* pCursor);
+    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection) override;
+    int perform_action(Document* pDoc, DocCursor* pCursor) override;
     ///@endcond
 
 protected:
@@ -534,13 +534,13 @@ protected:
     void insert_new_content();
     void reduce_duration_of_overlapped_at_start();
     void update_cursor();
-    void update_selection(SelectionSet* pSelection);
+    void update_selection(SelectionSet* pSelection) override;
     void clear_temporary_objects();
     void add_go_fwd_if_needed();
 
     //overrides and mandatory virtual methods
     void set_command_name();
-    void log_command(ostream &logger);
+    void log_command(ostream &logger) override;
 
 };
 
@@ -587,18 +587,18 @@ public:
     CmdAddTie(const string& name="Add tie");
     virtual ~CmdAddTie() {};
 
-    int get_cursor_update_policy() { return k_do_nothing; }
-    int get_undo_policy() { return k_undo_policy_specific; }
-    int get_selection_update_policy() { return k_sel_do_nothing; }
+    int get_cursor_update_policy() override { return k_do_nothing; }
+    int get_undo_policy() override { return k_undo_policy_specific; }
+    int get_selection_update_policy() override { return k_sel_do_nothing; }
 
     ///@cond INTERNALS
-    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection);
-    int perform_action(Document* pDoc, DocCursor* pCursor);
-    void undo_action(Document* pDoc, DocCursor* pCursor);
+    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection) override;
+    int perform_action(Document* pDoc, DocCursor* pCursor) override;
+    void undo_action(Document* pDoc, DocCursor* pCursor) override;
     ///@endcond
 
 protected:
-    void log_command(ostream &logger);
+    void log_command(ostream &logger) override;
 };
 
 //---------------------------------------------------------------------------------------
@@ -655,18 +655,18 @@ public:
     CmdAddTuplet(const string& src, const string& name="Add tuplet");
     virtual ~CmdAddTuplet() {};
 
-    int get_cursor_update_policy() { return k_do_nothing; }
-    int get_undo_policy() { return k_undo_policy_specific; }
-    int get_selection_update_policy() { return k_sel_do_nothing; }
+    int get_cursor_update_policy() override { return k_do_nothing; }
+    int get_undo_policy() override { return k_undo_policy_specific; }
+    int get_selection_update_policy() override { return k_sel_do_nothing; }
 
     ///@cond INTERNALS
-    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection);
-    int perform_action(Document* pDoc, DocCursor* pCursor);
-    void undo_action(Document* pDoc, DocCursor* pCursor);
+    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection) override;
+    int perform_action(Document* pDoc, DocCursor* pCursor) override;
+    void undo_action(Document* pDoc, DocCursor* pCursor) override;
     ///@endcond
 
 protected:
-    void log_command(ostream &logger);
+    void log_command(ostream &logger) override;
 };
 
 //---------------------------------------------------------------------------------------
@@ -713,17 +713,17 @@ public:
     CmdBreakBeam(const string& name="Break beam");
     virtual ~CmdBreakBeam() {};
 
-    int get_cursor_update_policy() { return k_do_nothing; }
-    int get_undo_policy() { return k_undo_policy_partial_checkpoint; }
-    int get_selection_update_policy() { return k_sel_do_nothing; }
+    int get_cursor_update_policy() override { return k_do_nothing; }
+    int get_undo_policy() override { return k_undo_policy_partial_checkpoint; }
+    int get_selection_update_policy() override { return k_sel_do_nothing; }
 
     ///@cond INTERNALS
-    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection);
-    int perform_action(Document* pDoc, DocCursor* pCursor);
+    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection) override;
+    int perform_action(Document* pDoc, DocCursor* pCursor) override;
     ///@endcond
 
 protected:
-    void log_command(ostream &logger);
+    void log_command(ostream &logger) override;
 };
 
 //---------------------------------------------------------------------------------------
@@ -770,18 +770,18 @@ public:
     CmdChangeAccidentals(EAccidentals acc, const string& name="Change accidentals");
     virtual ~CmdChangeAccidentals() {};
 
-    int get_cursor_update_policy() { return k_do_nothing; }
-    int get_undo_policy() { return k_undo_policy_specific; }
-    int get_selection_update_policy() { return k_sel_do_nothing; }
+    int get_cursor_update_policy() override { return k_do_nothing; }
+    int get_undo_policy() override { return k_undo_policy_specific; }
+    int get_selection_update_policy() override { return k_sel_do_nothing; }
 
     ///@cond INTERNALS
-    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection);
-    int perform_action(Document* pDoc, DocCursor* pCursor);
-    void undo_action(Document* pDoc, DocCursor* pCursor);
+    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection) override;
+    int perform_action(Document* pDoc, DocCursor* pCursor) override;
+    void undo_action(Document* pDoc, DocCursor* pCursor) override;
     ///@endcond
 
 protected:
-    void log_command(ostream &logger);
+    void log_command(ostream &logger) override;
 };
 
 //---------------------------------------------------------------------------------------
@@ -932,14 +932,14 @@ public:
 	/// Destructor
     virtual ~CmdChangeAttribute() {};
 
-    int get_cursor_update_policy() { return k_do_nothing; }
-    int get_undo_policy() { return k_undo_policy_specific; }
-    int get_selection_update_policy() { return k_sel_do_nothing; }
+    int get_cursor_update_policy() override { return k_do_nothing; }
+    int get_undo_policy() override { return k_undo_policy_specific; }
+    int get_selection_update_policy() override { return k_sel_do_nothing; }
 
     ///@cond INTERNALS
-    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection);
-    int perform_action(Document* pDoc, DocCursor* pCursor);
-    void undo_action(Document* pDoc, DocCursor* pCursor);
+    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection) override;
+    int perform_action(Document* pDoc, DocCursor* pCursor) override;
+    void undo_action(Document* pDoc, DocCursor* pCursor) override;
     ///@endcond
 
 protected:
@@ -992,14 +992,14 @@ public:
     CmdChangeDots(int dots, const string& name="Change dots");
     virtual ~CmdChangeDots() {};
 
-    int get_cursor_update_policy() { return k_refresh; }
-    int get_undo_policy() { return k_undo_policy_specific; }
-    int get_selection_update_policy() { return k_sel_do_nothing; }
+    int get_cursor_update_policy() override { return k_refresh; }
+    int get_undo_policy() override { return k_undo_policy_specific; }
+    int get_selection_update_policy() override { return k_sel_do_nothing; }
 
     ///@cond INTERNALS
-    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection);
-    int perform_action(Document* pDoc, DocCursor* pCursor);
-    void undo_action(Document* pDoc, DocCursor* pCursor);
+    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection) override;
+    int perform_action(Document* pDoc, DocCursor* pCursor) override;
+    void undo_action(Document* pDoc, DocCursor* pCursor) override;
     ///@endcond
 
 };
@@ -1285,14 +1285,14 @@ public:
     CmdCursor(DocCursorState& state, const string& name="");
     virtual ~CmdCursor() {};
 
-    int get_cursor_update_policy() { return k_do_nothing; }
-    int get_undo_policy() { return k_undo_policy_specific; }
-    int get_selection_update_policy() { return k_sel_do_nothing; }
+    int get_cursor_update_policy() override { return k_do_nothing; }
+    int get_undo_policy() override { return k_undo_policy_specific; }
+    int get_selection_update_policy() override { return k_sel_do_nothing; }
 
     ///@cond INTERNALS
-    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection);
-    int perform_action(Document* pDoc, DocCursor* pCursor);
-    void undo_action(Document* pDoc, DocCursor* pCursor);
+    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection) override;
+    int perform_action(Document* pDoc, DocCursor* pCursor) override;
+    void undo_action(Document* pDoc, DocCursor* pCursor) override;
     ///@endcond
 
 protected:
@@ -1352,13 +1352,13 @@ public:
     CmdDeleteBlockLevelObj(const string& name="");
     virtual ~CmdDeleteBlockLevelObj() {};
 
-    int get_cursor_update_policy() { return k_update_after_deletion; }
-    int get_undo_policy() { return k_undo_policy_full_checkpoint; }
-    int get_selection_update_policy() { return k_sel_do_nothing; }
+    int get_cursor_update_policy() override { return k_update_after_deletion; }
+    int get_undo_policy() override { return k_undo_policy_full_checkpoint; }
+    int get_selection_update_policy() override { return k_sel_do_nothing; }
 
     ///@cond INTERNALS
-    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection);
-    int perform_action(Document* pDoc, DocCursor* pCursor);
+    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection) override;
+    int perform_action(Document* pDoc, DocCursor* pCursor) override;
     ///@endcond
 };
 
@@ -1420,13 +1420,13 @@ public:
     CmdDeleteRelation(int type, const string& name="");
     virtual ~CmdDeleteRelation() {};
 
-    int get_cursor_update_policy() { return k_do_nothing; }
-    int get_undo_policy() { return k_undo_policy_partial_checkpoint; }
-    int get_selection_update_policy() { return k_sel_do_nothing; }
+    int get_cursor_update_policy() override { return k_do_nothing; }
+    int get_undo_policy() override { return k_undo_policy_partial_checkpoint; }
+    int get_selection_update_policy() override { return k_sel_do_nothing; }
 
     ///@cond INTERNALS
-    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection);
-    int perform_action(Document* pDoc, DocCursor* pCursor);
+    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection) override;
+    int perform_action(Document* pDoc, DocCursor* pCursor) override;
     ///@endcond
 
 private:
@@ -1478,20 +1478,20 @@ public:
     CmdDeleteSelection(const string& name="Delete selection");
     virtual ~CmdDeleteSelection() {};
 
-    int get_cursor_update_policy() { return k_update_after_deletion; }
-    int get_undo_policy() { return k_undo_policy_full_checkpoint; }
-    int get_selection_update_policy() { return k_sel_do_nothing; }
+    int get_cursor_update_policy() override { return k_update_after_deletion; }
+    int get_undo_policy() override { return k_undo_policy_full_checkpoint; }
+    int get_selection_update_policy() override { return k_sel_do_nothing; }
 
     ///@cond INTERNALS
-    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection);
-    int perform_action(Document* pDoc, DocCursor* pCursor);
+    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection) override;
+    int perform_action(Document* pDoc, DocCursor* pCursor) override;
     ///@endcond
 
 protected:
     list<ImoId> m_relIds;   //when the action is performed, all relations in deleted
                             //staffobjs are temporarily saved here
 
-    void prepare_cursor_for_deletion(DocCursor* pCursor);
+    void prepare_cursor_for_deletion(DocCursor* pCursor) override;
     bool is_going_to_be_deleted(ImoId id);
     void delete_staffobjs(Document* pDoc);
     void delete_relobjs(Document* pDoc);
@@ -1550,13 +1550,13 @@ public:
     CmdDeleteStaffObj(const string& name="");
     virtual ~CmdDeleteStaffObj() {};
 
-    int get_cursor_update_policy() { return k_update_after_deletion; }
-    int get_undo_policy() { return k_undo_policy_partial_checkpoint; }
-    int get_selection_update_policy() { return k_sel_do_nothing; }
+    int get_cursor_update_policy() override { return k_update_after_deletion; }
+    int get_undo_policy() override { return k_undo_policy_partial_checkpoint; }
+    int get_selection_update_policy() override { return k_sel_do_nothing; }
 
     ///@cond INTERNALS
-    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection);
-    int perform_action(Document* pDoc, DocCursor* pCursor);
+    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection) override;
+    int perform_action(Document* pDoc, DocCursor* pCursor) override;
     ///@endcond
 };
 
@@ -1590,7 +1590,7 @@ public:
     inline ImoId last_inserted_id() { return m_lastInsertedId; }
 
     ///@cond INTERNALS
-    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection);
+    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection) override;
     ///@endcond
 
 protected:
@@ -1665,13 +1665,13 @@ public:
     CmdInsertBlockLevelObj(const string& source, const string& name="");
     virtual ~CmdInsertBlockLevelObj() {};
 
-    int get_cursor_update_policy() { return k_refresh; }
-    int get_undo_policy() { return k_undo_policy_specific; }
-    int get_selection_update_policy() { return k_sel_do_nothing; }
+    int get_cursor_update_policy() override { return k_refresh; }
+    int get_undo_policy() override { return k_undo_policy_specific; }
+    int get_selection_update_policy() override { return k_sel_do_nothing; }
 
     ///@cond INTERNALS
-    int perform_action(Document* pDoc, DocCursor* pCursor);
-    void undo_action(Document* pDoc, DocCursor* pCursor);
+    int perform_action(Document* pDoc, DocCursor* pCursor) override;
+    void undo_action(Document* pDoc, DocCursor* pCursor) override;
     ///@endcond
 
 protected:
@@ -1712,13 +1712,13 @@ public:
 
     virtual ~CmdInsertManyStaffObjs() {};
 
-    int get_cursor_update_policy() { return k_refresh; }
-    int get_undo_policy() { return k_undo_policy_partial_checkpoint; }
-    int get_selection_update_policy() { return k_sel_do_nothing; }
+    int get_cursor_update_policy() override { return k_refresh; }
+    int get_undo_policy() override { return k_undo_policy_partial_checkpoint; }
+    int get_selection_update_policy() override { return k_sel_do_nothing; }
 
     ///@cond INTERNALS
-    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection);
-    int perform_action(Document* pDoc, DocCursor* pCursor);
+    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection) override;
+    int perform_action(Document* pDoc, DocCursor* pCursor) override;
     ///@endcond
 
 protected:
@@ -1774,14 +1774,14 @@ public:
     CmdInsertStaffObj(const string& source, const string& name="");
     virtual ~CmdInsertStaffObj() {};
 
-    int get_cursor_update_policy() { return k_refresh; }
-    int get_undo_policy() { return k_undo_policy_specific; }
-    int get_selection_update_policy() { return k_sel_do_nothing; }
+    int get_cursor_update_policy() override { return k_refresh; }
+    int get_undo_policy() override { return k_undo_policy_specific; }
+    int get_selection_update_policy() override { return k_sel_do_nothing; }
 
     ///@cond INTERNALS
-    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection);
-    int perform_action(Document* pDoc, DocCursor* pCursor);
-    void undo_action(Document* pDoc, DocCursor* pCursor);
+    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection) override;
+    int perform_action(Document* pDoc, DocCursor* pCursor) override;
+    void undo_action(Document* pDoc, DocCursor* pCursor) override;
     ///@endcond
 };
 
@@ -1830,17 +1830,17 @@ public:
     CmdJoinBeam(const string& name="Join beam");
     virtual ~CmdJoinBeam() {};
 
-    int get_cursor_update_policy() { return k_do_nothing; }
-    int get_undo_policy() { return k_undo_policy_full_checkpoint; }
-    int get_selection_update_policy() { return k_sel_do_nothing; }
+    int get_cursor_update_policy() override { return k_do_nothing; }
+    int get_undo_policy() override { return k_undo_policy_full_checkpoint; }
+    int get_selection_update_policy() override { return k_sel_do_nothing; }
 
     ///@cond INTERNALS
-    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection);
-    int perform_action(Document* pDoc, DocCursor* pCursor);
+    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection) override;
+    int perform_action(Document* pDoc, DocCursor* pCursor) override;
     ///@endcond
 
 protected:
-    void log_command(ostream &logger);
+    void log_command(ostream &logger) override;
 };
 
 //---------------------------------------------------------------------------------------
@@ -1874,14 +1874,14 @@ public:
                        const string& name="Move object point");
     virtual ~CmdMoveObjectPoint() {};
 
-    int get_cursor_update_policy() { return k_do_nothing; }
-    int get_undo_policy() { return k_undo_policy_specific; }
-    int get_selection_update_policy() { return k_sel_do_nothing; }
+    int get_cursor_update_policy() override { return k_do_nothing; }
+    int get_undo_policy() override { return k_undo_policy_specific; }
+    int get_selection_update_policy() override { return k_sel_do_nothing; }
 
     ///@cond INTERNALS
-    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection);
-    int perform_action(Document* pDoc, DocCursor* pCursor);
-    void undo_action(Document* pDoc, DocCursor* pCursor);
+    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection) override;
+    int perform_action(Document* pDoc, DocCursor* pCursor) override;
+    void undo_action(Document* pDoc, DocCursor* pCursor) override;
     ///@endcond
 };
 
@@ -1960,14 +1960,14 @@ public:
     //CmdSelection(DocCursorState& state, const string& name="");
     virtual ~CmdSelection() {};
 
-    int get_cursor_update_policy() { return k_do_nothing; }
-    int get_undo_policy() { return k_undo_policy_specific; }
-    int get_selection_update_policy() { return k_sel_do_nothing; }
+    int get_cursor_update_policy() override { return k_do_nothing; }
+    int get_undo_policy() override { return k_undo_policy_specific; }
+    int get_selection_update_policy() override { return k_sel_do_nothing; }
 
     ///@cond INTERNALS
-    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection);
-    int perform_action(Document* pDoc, DocCursor* pCursor);
-    void undo_action(Document* pDoc, DocCursor* pCursor);
+    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection) override;
+    int perform_action(Document* pDoc, DocCursor* pCursor) override;
+    void undo_action(Document* pDoc, DocCursor* pCursor) override;
     ///@endcond
 
 protected:
@@ -2026,14 +2026,14 @@ public:
 
     virtual ~CmdTranspose() {};
 
-    int get_cursor_update_policy() { return k_do_nothing; }
-    int get_undo_policy() { return k_undo_policy_specific; }
-    int get_selection_update_policy() { return k_sel_do_nothing; }
+    int get_cursor_update_policy() override { return k_do_nothing; }
+    int get_undo_policy() override { return k_undo_policy_specific; }
+    int get_selection_update_policy() override { return k_sel_do_nothing; }
 
     ///@cond INTERNALS
-    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection);
-    int perform_action(Document* pDoc, DocCursor* pCursor);
-    void undo_action(Document* pDoc, DocCursor* pCursor);
+    int set_target(Document* pDoc, DocCursor* pCursor, SelectionSet* pSelection) override;
+    int perform_action(Document* pDoc, DocCursor* pCursor) override;
+    void undo_action(Document* pDoc, DocCursor* pCursor) override;
     ///@endcond
 
 protected:

--- a/include/lomse_control.h
+++ b/include/lomse_control.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -126,20 +126,20 @@ public:
     inline void set_style(ImoStyle* pStyle) { m_style = pStyle; }
 
     //mandatory overrides from Observable
-    EventNotifier* get_event_notifier() { return m_pDoc->get_event_notifier(); }
+    EventNotifier* get_event_notifier() override { return m_pDoc->get_event_notifier(); }
 
     //overrides for Observable children
-    void add_event_handler(int eventType, EventHandler* pHandler)
+    void add_event_handler(int eventType, EventHandler* pHandler) override
     {
         m_pDoc->add_event_handler(Observable::k_control, m_id, eventType, pHandler);
     }
     void add_event_handler(int eventType, void* pThis,
-                           void (*pt2Func)(void* pObj, SpEventInfo event) )
+                           void (*pt2Func)(void* pObj, SpEventInfo event) ) override
     {
         m_pDoc->add_event_handler(Observable::k_control, m_id, eventType,
                                   pThis, pt2Func);
     }
-    void add_event_handler(int eventType, void (*pt2Func)(SpEventInfo event) )
+    void add_event_handler(int eventType, void (*pt2Func)(SpEventInfo event) ) override
     {
         m_pDoc->add_event_handler(Observable::k_control, m_id, eventType, pt2Func);
     }

--- a/include/lomse_document_cursor.h
+++ b/include/lomse_document_cursor.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -177,7 +177,7 @@ public:
     ~ScoreCursorState() {}
 
     //mandatory overrides
-    ImoId pointee_id() { return id(); }
+    ImoId pointee_id() override { return id(); }
 
     //getters
     inline int instrument() { return m_instr; }
@@ -406,23 +406,23 @@ public:
 
     //mandatory overrides from ElementCursor
         //positioning
-    void point_to(ImoObj* pImo);
-    void point_to(ImoId nId);
-    void move_next() { to_next_staffobj(); }
-    void move_prev() { to_prev_staffobj(); }
-    void move_up();
-    void move_down();
+    void point_to(ImoObj* pImo) override;
+    void point_to(ImoId nId) override;
+    void move_next() override { to_next_staffobj(); }
+    void move_prev() override { to_prev_staffobj(); }
+    void move_up() override;
+    void move_down() override;
         //saving/restoring state
-    SpElementCursorState get_state();
-    void restore_state(SpElementCursorState spState);
+    SpElementCursorState get_state() override;
+    void restore_state(SpElementCursorState spState) override;
         //info
     inline ImoObj* operator *() { return staffobj(); }
-    inline ImoObj* get_pointee() { return staffobj(); }
-    inline ImoId get_pointee_id() { return staffobj_id(); }
-    SpElementCursorState find_previous_pos_state();
+    ImoObj* get_pointee() override { return staffobj(); }
+    ImoId get_pointee_id() override { return staffobj_id(); }
+    SpElementCursorState find_previous_pos_state() override;
         //special operations for restoring cursor validity after Document modification
-    void reset_and_point_to(ImoId nId);
-    void reset_and_point_after(ImoId id);
+    void reset_and_point_to(ImoId nId) override;
+    void reset_and_point_after(ImoId id) override;
 
     //specific methods
 
@@ -483,7 +483,7 @@ public:
     void change_voice_to(int voice);
 
     //debug & unit tests
-    string dump_cursor();
+    string dump_cursor() override;
 
 protected:
     //support: related to time info

--- a/include/lomse_document_iterator.h
+++ b/include/lomse_document_iterator.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -167,8 +167,8 @@ public:
 protected:
     //ScoreElmIterator* m_pScoreElmIterator;
 
-    void next();
-    void prev();
+    void next() override;
+    void prev() override;
     void point_to_current();
 
 };

--- a/include/lomse_document_layouter.h
+++ b/include/lomse_document_layouter.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -70,14 +70,14 @@ public:
     void layout_empty_document();
 
     //implementation of virtual methods in Layouter base class
-    void layout_in_box() {}
+    void layout_in_box() override {}
     void create_main_box(GmoBox* UNUSED(pParentBox), UPoint UNUSED(pos),
-                         LUnits UNUSED(width), LUnits UNUSED(height)) {}
-    GmoBox* start_new_page();
+                         LUnits UNUSED(width), LUnits UNUSED(height)) override {}
+    GmoBox* start_new_page() override;
 
     //only for unit tests
     ScoreLayouter* get_score_layouter();
-    void save_score_layouter(Layouter* pLayouter);
+    void save_score_layouter(Layouter* pLayouter) override;
 
 protected:
     int layout_content();

--- a/include/lomse_engrouters.h
+++ b/include/lomse_engrouters.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -160,8 +160,8 @@ public:
         : Engrouter(pCreatorImo, libraryScope) {}
     virtual ~BoxEngrouter();
 
-    void measure();
-    GmoObj* create_gm_object(UPoint pos, LineReferences& refs);
+    void measure() override;
+    GmoObj* create_gm_object(UPoint pos, LineReferences& refs) override;
     void layout_and_measure();
     void update_measures(LUnits lineHeight);
 
@@ -191,8 +191,8 @@ public:
         : Engrouter(pCreatorImo, libraryScope) {}
     virtual ~ImageEngrouter() {}
 
-    void measure();
-    GmoObj* create_gm_object(UPoint pos, LineReferences& refs);
+    void measure() override;
+    GmoObj* create_gm_object(UPoint pos, LineReferences& refs) override;
 };
 
 //---------------------------------------------------------------------------------------
@@ -216,8 +216,8 @@ public:
     inline const wstring& get_text() { return m_text; }
     inline const string& get_font_file() { return m_fontFile; }
 
-    void measure();
-    GmoObj* create_gm_object(UPoint pos, LineReferences& refs);
+    void measure() override;
+    GmoObj* create_gm_object(UPoint pos, LineReferences& refs) override;
 
     //info
     inline LUnits get_descent() { return m_descent; }
@@ -238,8 +238,8 @@ public:
     InlineWrapperEngrouter(ImoContentObj* pCreatorImo, LibraryScope& libraryScope);
     virtual ~InlineWrapperEngrouter() {}
 
-    virtual void measure() = 0;
-    virtual GmoObj* create_gm_object(UPoint pos, LineReferences& refs);
+    virtual void measure() override = 0;
+    virtual GmoObj* create_gm_object(UPoint pos, LineReferences& refs) override;
 
 protected:
     LUnits add_engrouters_to_box(GmoBox* pBox, LineReferences& refs);
@@ -274,8 +274,8 @@ public:
     virtual ~ControlEngrouter() {}
 
     //implementation of Engrouter virtual pure methods
-    void measure();
-    GmoObj* create_gm_object(UPoint pos, LineReferences& refs);
+    void measure() override;
+    GmoObj* create_gm_object(UPoint pos, LineReferences& refs) override;
 };
 
 
@@ -291,8 +291,8 @@ public:
     virtual ~NullEngrouter() {}
 
     //implementation of Engrouter virtual pure methods
-    void measure() {}
-    GmoObj* create_gm_object(UPoint UNUSED(pos), LineReferences& UNUSED(refs))
+    void measure() override {}
+    GmoObj* create_gm_object(UPoint UNUSED(pos), LineReferences& UNUSED(refs)) override
     {
         return nullptr;
     }

--- a/include/lomse_events.h
+++ b/include/lomse_events.h
@@ -760,7 +760,7 @@ public:
     /** Returns a pointer to the Observable object (an ImoContentObj) related to the
         event. It is either the mouse pointed object or the first ancestor of type
         ImoContentObj in the internal model hierarchy. */
-    Observable* get_source();
+    Observable* get_source() override;
 
     /** Returns the ID of the Document object (ImoObj) affected by the event. For
         instance, for a mouse click event this object will be the ID of the ImoObj

--- a/include/lomse_file_system.h
+++ b/include/lomse_file_system.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -154,7 +154,7 @@ public:
     }
 
     //operations
-    string get_locator_for_image(const string& imagename);
+    string get_locator_for_image(const string& imagename) override;
 
 };
 
@@ -199,11 +199,11 @@ public:
 	LocalInputStream(const std::string& filelocator);
 	virtual ~LocalInputStream() {}
 
-    char get_char();
-    void unget();
-    bool is_open();
-    bool eof();
-    long read(unsigned char* pDestBuffer, long nBytesToRead);
+    char get_char() override;
+    void unget() override;
+    bool is_open() override;
+    bool eof() override;
+    long read(unsigned char* pDestBuffer, long nBytesToRead) override;
 };
 
 

--- a/include/lomse_fragment_mark.h
+++ b/include/lomse_fragment_mark.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -81,8 +81,8 @@ public:
         : VisualEffect(view, libraryScope) {}
 
     //mandatory overrides from VisualEffect
-    void on_draw(ScreenDrawer* pDrawer)=0;
-    URect get_bounds()=0;
+    void on_draw(ScreenDrawer* pDrawer) override =0;
+    URect get_bounds() override =0;
 
 protected:
     friend class OverlaysGenerator;
@@ -353,8 +353,8 @@ public:
     FragmentMark(GraphicView* view, LibraryScope& libraryScope);
 
     //mandatory overrides from VisualEffect
-    void on_draw(ScreenDrawer* pDrawer);
-    URect get_bounds();
+    void on_draw(ScreenDrawer* pDrawer) override;
+    URect get_bounds() override;
 
     //initial data for position and context
     void initialize(LUnits xPos, GmoBoxSystem* pBoxSystem, bool fBarline=false);

--- a/include/lomse_gm_basic.h
+++ b/include/lomse_gm_basic.h
@@ -365,8 +365,8 @@ public:
     GmoShape* find_related_shape(int type);
 
     //other flags
-    void set_hover(bool value) { value ? m_flags |= k_hover : m_flags &= ~k_hover; }
-    void set_in_link(bool value) { value ? m_flags |= k_in_link : m_flags &= ~k_in_link; }
+    void set_hover(bool value) override { value ? m_flags |= k_hover : m_flags &= ~k_hover; }
+    void set_in_link(bool value) override { value ? m_flags |= k_in_link : m_flags &= ~k_in_link; }
     void set_flag_value(bool value, unsigned int flag) {
         value ? m_flags |= flag : m_flags &= ~flag;
     }
@@ -386,7 +386,7 @@ public:
     static ShapeId generate_main_or_implicity_shape_id(int iStaff) { return iStaff; }
 
     //test and debug
-    void dump(ostream& outStream, int level);
+    void dump(ostream& outStream, int level) override;
     void set_color(Color color) { m_color = color; }
 
 protected:
@@ -431,8 +431,8 @@ public:
     GmoShape* get_shape(int i);  //i = 0..n-1
 
     //flags
-    void set_hover(bool value) { set_flag_value(value, k_hover); }
-    void set_in_link(bool value) { set_flag_value(value, k_in_link); }
+    void set_hover(bool value) override { set_flag_value(value, k_hover); }
+    void set_in_link(bool value) override { set_flag_value(value, k_in_link); }
     void set_has_edit_focus(bool value) { set_flag_value(value, k_has_edit_focus); }
     void set_flag_value(bool value, unsigned int flag);
 
@@ -514,7 +514,7 @@ public:
     int get_page_number(GmoBoxDocPage* pBoxPage);
 
     //overrides
-    GraphicModel* get_graphic_model() { return m_pGModel; }
+    GraphicModel* get_graphic_model() override { return m_pGModel; }
 
 };
 
@@ -534,7 +534,7 @@ public:
     inline int get_number() { return m_numPage; }
 
     //renderization
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 
     //shapes
     void add_to_tables(GmoShape* pShape);
@@ -652,14 +652,14 @@ public:
     void notify_event(SpEventInfo pEvent);
 
     //GmoBox override
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 
     //accessors
     inline Control* get_creator_control() { return m_pControl; }
 
 protected:
     //overrides
-    ImoStyle* get_style() { return m_pStyle; }
+    ImoStyle* get_style() override { return m_pStyle; }
 };
 
 //---------------------------------------------------------------------------------------

--- a/include/lomse_handler.h
+++ b/include/lomse_handler.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -79,12 +79,12 @@ public:
     virtual ~HandlerCircle();
 
     //mandatory overrides from VisualEffect
-    void on_draw(ScreenDrawer* pDrawer);
-    URect get_bounds();
+    void on_draw(ScreenDrawer* pDrawer) override;
+    URect get_bounds() override;
 
     //mandatory overrides from Handler
-    bool hit_test(LUnits x, LUnits y);
-    void move_to(UPoint pos);
+    bool hit_test(LUnits x, LUnits y) override;
+    void move_to(UPoint pos) override;
 
 
 protected:

--- a/include/lomse_hyperlink_ctrl.h
+++ b/include/lomse_hyperlink_ctrl.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -62,16 +62,16 @@ public:
     virtual ~HyperlinkCtrl() {}
 
     //Control mandatory overrides
-    USize measure();
-    GmoBoxControl* layout(LibraryScope& libraryScope, UPoint pos);
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
-    void handle_event(SpEventInfo pEvent);
-    LUnits width() { return m_width; }
-    LUnits height() { return m_height; }
-    LUnits top() { return m_pos.y; }
-    LUnits bottom() { return m_pos.y + m_height; }
-    LUnits left() { return m_pos.x; }
-    LUnits right() { return m_pos.x + m_width; }
+    USize measure() override;
+    GmoBoxControl* layout(LibraryScope& libraryScope, UPoint pos) override;
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
+    void handle_event(SpEventInfo pEvent) override;
+    LUnits width() override { return m_width; }
+    LUnits height() override { return m_height; }
+    LUnits top() override { return m_pos.y; }
+    LUnits bottom() override { return m_pos.y + m_height; }
+    LUnits left() override { return m_pos.x; }
+    LUnits right() override { return m_pos.x + m_width; }
 
     //specific methods
     void set_text(const string& text);

--- a/include/lomse_im_note.h
+++ b/include/lomse_im_note.h
@@ -134,9 +134,9 @@ public:
     ImoTuplet* get_first_tuplet();
 
     //IM attributes interface
-    virtual void set_int_attribute(TIntAttribute attrib, int value);
-    virtual int get_int_attribute(TIntAttribute attrib);
-    virtual list<TIntAttribute> get_supported_attributes();
+    void set_int_attribute(TIntAttribute attrib, int value) override;
+    int get_int_attribute(TIntAttribute attrib) override;
+    list<TIntAttribute> get_supported_attributes() override;
 
 protected:
 
@@ -162,9 +162,9 @@ protected:
     inline void mark_as_full_measure(bool value) { m_fFullMeasureRest = value; }
 
     //IM attributes interface
-    virtual void set_int_attribute(TIntAttribute attrib, int value);
-    virtual int get_int_attribute(TIntAttribute attrib);
-    virtual list<TIntAttribute> get_supported_attributes();
+    void set_int_attribute(TIntAttribute attrib, int value) override;
+    int get_int_attribute(TIntAttribute attrib) override;
+    list<TIntAttribute> get_supported_attributes() override;
 
 public:
     virtual ~ImoRest() {}
@@ -204,9 +204,9 @@ protected:
             int dots=0, int staff=0, int voice=0, int stem=k_stem_default);
 
     //IM attributes interface
-    virtual void set_int_attribute(TIntAttribute attrib, int value);
-    virtual int get_int_attribute(TIntAttribute attrib);
-    virtual list<TIntAttribute> get_supported_attributes();
+    void set_int_attribute(TIntAttribute attrib, int value) override;
+    int get_int_attribute(TIntAttribute attrib) override;
+    list<TIntAttribute> get_supported_attributes() override;
 
 public:
     virtual ~ImoNote();

--- a/include/lomse_image_reader.h
+++ b/include/lomse_image_reader.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -70,8 +70,8 @@ public:
     virtual ~JpgImageDecoder() {}
 
     //mandatory overrides
-    bool can_decode(InputStream* file);
-    SpImage decode_file(InputStream* file);
+    bool can_decode(InputStream* file) override;
+    SpImage decode_file(InputStream* file) override;
 };
 
 #if (LOMSE_ENABLE_PNG == 1)
@@ -84,8 +84,8 @@ public:
     virtual ~PngImageDecoder() {}
 
     //mandatory overrides
-    bool can_decode(InputStream* file);
-    SpImage decode_file(InputStream* file);
+    bool can_decode(InputStream* file) override;
+    SpImage decode_file(InputStream* file) override;
 
 };
 #endif // LOMSE_ENABLE_PNG

--- a/include/lomse_inlines_container_layouter.h
+++ b/include/lomse_inlines_container_layouter.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -79,9 +79,9 @@ public:
     virtual ~InlinesContainerLayouter();
 
     //mandatory overrides
-    void layout_in_box();
-    void create_main_box(GmoBox* pParentBox, UPoint pos, LUnits width, LUnits height);
-    void prepare_to_start_layout();
+    void layout_in_box() override;
+    void create_main_box(GmoBox* pParentBox, UPoint pos, LUnits width, LUnits height) override;
+    void prepare_to_start_layout() override;
 
     //other
     inline LineReferences& get_line_refs() { return m_lineRefs; }

--- a/include/lomse_interactor.h
+++ b/include/lomse_interactor.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -1566,13 +1566,13 @@ public:
     inline std::shared_ptr<Interactor> get_shared_ptr_from_this() { return shared_from_this(); }
 
     //mandatory override required by EventHandler
-	void handle_event(SpEventInfo pEvent);
+	void handle_event(SpEventInfo pEvent) override;
 
     //Deprecated ?
     virtual void highlight_voice(int voice);
 
     //mandatory overrides from Observable
-    EventNotifier* get_event_notifier() { return this; }
+    EventNotifier* get_event_notifier() override { return this; }
 
     //for auto-scroll during playback
     virtual void change_viewport_if_necessary(ImoId id);

--- a/include/lomse_ldp_analyser.h
+++ b/include/lomse_ldp_analyser.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -88,7 +88,7 @@ public:
         : RelationBuilder<ImoTieDto, LdpAnalyser>(reporter, pAnalyser, "tie", "Tie") {}
     virtual ~TiesBuilder() {}
 
-    void add_relation_to_staffobjs(ImoTieDto* pEndDto);
+    void add_relation_to_staffobjs(ImoTieDto* pEndDto) override;
 
 protected:
     bool notes_can_be_tied(ImoNote* pStartNote, ImoNote* pEndNote);
@@ -106,7 +106,7 @@ public:
         : RelationBuilder<ImoBeamDto, LdpAnalyser>(reporter, pAnalyser, "beam", "Beam") {}
     virtual ~BeamsBuilder() {}
 
-    void add_relation_to_staffobjs(ImoBeamDto* pEndInfo);
+    void add_relation_to_staffobjs(ImoBeamDto* pEndInfo) override;
 };
 
 
@@ -119,7 +119,7 @@ public:
         : RelationBuilder<ImoSlurDto, LdpAnalyser>(reporter, pAnalyser, "slur", "Slur") {}
     virtual ~SlursBuilder() {}
 
-    void add_relation_to_staffobjs(ImoSlurDto* pEndInfo);
+    void add_relation_to_staffobjs(ImoSlurDto* pEndInfo) override;
 };
 
 
@@ -167,7 +167,7 @@ public:
     }
     virtual ~TupletsBuilder() {}
 
-    void add_relation_to_staffobjs(ImoTupletDto* pEndInfo);
+    void add_relation_to_staffobjs(ImoTupletDto* pEndInfo) override;
     inline bool is_tuplet_open() { return m_pendingItems.size() > 0; }
 
     inline ImoTuplet* get_last_created_tuplet() { return m_pTuplet; }

--- a/include/lomse_ldp_compiler.h
+++ b/include/lomse_ldp_compiler.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -65,8 +65,8 @@ public:
     LdpCompiler(LibraryScope& libraryScope, Document* pDoc);
 
     //compilation
-    ImoDocument* compile_file(const std::string& filename);
-    ImoDocument* compile_string(const std::string& source);
+    ImoDocument* compile_file(const std::string& filename) override;
+    ImoDocument* compile_string(const std::string& source) override;
     ImoDocument* compile_input(LdpReader& reader);
     ImoDocument* create_empty();
     ImoDocument* create_with_empty_score();

--- a/include/lomse_ldp_elements.h
+++ b/include/lomse_ldp_elements.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -309,7 +309,7 @@ public:
     virtual ~LdpElement();
 
     //overrides to Visitable class members
-	virtual void accept_visitor(BaseVisitor& v);
+	virtual void accept_visitor(BaseVisitor& v) override;
 
     //getters and setters
 	inline void set_value(const std::string& value) { m_value = value; }
@@ -364,7 +364,7 @@ class LdpObject : public LdpElement
 			{ LdpObject<type>* o = LOMSE_NEW LdpObject<type>; assert(o!=0); return o; }
 
         //! implementation of Visitable interface
-        virtual void accept_visitor(BaseVisitor& v) {
+        void accept_visitor(BaseVisitor& v) override {
 			if (Visitor<LdpObject<type> >* p = dynamic_cast<Visitor<LdpObject<type> >*>(&v))
             {
 				p->start_visit(this);

--- a/include/lomse_ldp_parser.h
+++ b/include/lomse_ldp_parser.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -60,8 +60,8 @@ public:
 //    //setings and options
 //    inline void SetIgnoreList(std::set<long>* pSet) { m_pIgnoreSet = pSet; }
 //
-    void parse_file(const std::string& filename, bool fErrorMsg = true);
-    void parse_text(const std::string& sourceText);
+    void parse_file(const std::string& filename, bool fErrorMsg = true) override;
+    void parse_text(const std::string& sourceText) override;
     void parse_input(LdpReader& reader);
 
     //access to parser result

--- a/include/lomse_lmd_analyser.h
+++ b/include/lomse_lmd_analyser.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -87,7 +87,7 @@ public:
         : RelationBuilder<ImoTieDto, LmdAnalyser>(reporter, pAnalyser, "tie", "Tie") {}
     virtual ~LmdTiesBuilder() {}
 
-    void add_relation_to_staffobjs(ImoTieDto* pEndDto);
+    void add_relation_to_staffobjs(ImoTieDto* pEndDto) override;
 
 protected:
     bool notes_can_be_tied(ImoNote* pStartNote, ImoNote* pEndNote);
@@ -105,7 +105,7 @@ public:
         : RelationBuilder<ImoBeamDto, LmdAnalyser>(reporter, pAnalyser, "beam", "Beam") {}
     virtual ~LmdBeamsBuilder() {}
 
-    void add_relation_to_staffobjs(ImoBeamDto* pEndInfo);
+    void add_relation_to_staffobjs(ImoBeamDto* pEndInfo) override;
 };
 
 
@@ -118,7 +118,7 @@ public:
         : RelationBuilder<ImoSlurDto, LmdAnalyser>(reporter, pAnalyser, "slur", "Slur") {}
     virtual ~LmdSlursBuilder() {}
 
-    void add_relation_to_staffobjs(ImoSlurDto* pEndInfo);
+    void add_relation_to_staffobjs(ImoSlurDto* pEndInfo) override;
 };
 
 
@@ -160,7 +160,7 @@ public:
         : RelationBuilder<ImoTupletDto, LmdAnalyser>(reporter, pAnalyser, "tuplet", "Tuplet") {}
     virtual ~LmdTupletsBuilder() {}
 
-    void add_relation_to_staffobjs(ImoTupletDto* pEndInfo);
+    void add_relation_to_staffobjs(ImoTupletDto* pEndInfo) override;
     inline bool is_tuplet_open() { return m_pendingItems.size() > 0; }
 };
 

--- a/include/lomse_lmd_compiler.h
+++ b/include/lomse_lmd_compiler.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -61,8 +61,8 @@ public:
     LmdCompiler(LibraryScope& libraryScope, Document* pDoc);
 
     //compilation
-    ImoDocument* compile_file(const std::string& filename);
-    ImoDocument* compile_string(const std::string& source);
+    ImoDocument* compile_file(const std::string& filename) override;
+    ImoDocument* compile_string(const std::string& source) override;
     ImoDocument* create_empty();
     ImoDocument* create_with_empty_score();
 

--- a/include/lomse_mnx_analyser.h
+++ b/include/lomse_mnx_analyser.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -63,7 +63,7 @@ public:
         : RelationBuilder<ImoTieDto, MnxAnalyser>(reporter, pAnalyser, "tie", "Tie") {}
     virtual ~MnxTiesBuilder() {}
 
-    void add_relation_to_staffobjs(ImoTieDto* pEndDto);
+    void add_relation_to_staffobjs(ImoTieDto* pEndDto) override;
 
 protected:
     bool notes_can_be_tied(ImoNote* pStartNote, ImoNote* pEndNote);
@@ -81,7 +81,7 @@ public:
         : RelationBuilder<ImoBeamDto, MnxAnalyser>(reporter, pAnalyser, "beam", "Beam") {}
     virtual ~MnxBeamsBuilder() {}
 
-    void add_relation_to_staffobjs(ImoBeamDto* pEndInfo);
+    void add_relation_to_staffobjs(ImoBeamDto* pEndInfo) override;
 };
 
 
@@ -122,7 +122,7 @@ public:
         : RelationBuilder<ImoSlurDto, MnxAnalyser>(reporter, pAnalyser, "slur", "Slur") {}
     virtual ~MnxSlursBuilder() {}
 
-    void add_relation_to_staffobjs(ImoSlurDto* pEndInfo);
+    void add_relation_to_staffobjs(ImoSlurDto* pEndInfo) override;
 };
 
 
@@ -135,7 +135,7 @@ public:
         : RelationBuilder<ImoTupletDto, MnxAnalyser>(reporter, pAnalyser, "tuplet", "Tuplet") {}
     virtual ~MnxTupletsBuilder() {}
 
-    void add_relation_to_staffobjs(ImoTupletDto* pEndInfo);
+    void add_relation_to_staffobjs(ImoTupletDto* pEndInfo) override;
     inline bool is_tuplet_open() { return m_pendingItems.size() > 0; }
     void add_to_open_tuplets(ImoNoteRest* pNR);
     void get_factors_from_nested_tuplets(int* pTop, int* pBottom);
@@ -154,7 +154,7 @@ public:
     {}
     virtual ~MnxVoltasBuilder() {}
 
-    void add_relation_to_staffobjs(ImoVoltaBracketDto* pEndInfo);
+    void add_relation_to_staffobjs(ImoVoltaBracketDto* pEndInfo) override;
 };
 
 

--- a/include/lomse_mnx_compiler.h
+++ b/include/lomse_mnx_compiler.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -62,8 +62,8 @@ public:
     MnxCompiler(LibraryScope& libraryScope, Document* pDoc);
 
     //compilation
-    ImoDocument* compile_file(const std::string& filename);
-    ImoDocument* compile_string(const std::string& source);
+    ImoDocument* compile_file(const std::string& filename) override;
+    ImoDocument* compile_string(const std::string& source) override;
 
 protected:
     ImoDocument* compile_parsed_tree(XmlNode* root);

--- a/include/lomse_mxl_analyser.h
+++ b/include/lomse_mxl_analyser.h
@@ -62,7 +62,7 @@ public:
         : RelationBuilder<ImoTieDto, MxlAnalyser>(reporter, pAnalyser, "tie", "Tie") {}
     virtual ~MxlTiesBuilder() {}
 
-    void add_relation_to_staffobjs(ImoTieDto* pEndDto);
+    void add_relation_to_staffobjs(ImoTieDto* pEndDto) override;
 
 protected:
     bool notes_can_be_tied(ImoNote* pStartNote, ImoNote* pEndNote);
@@ -80,7 +80,7 @@ public:
         : RelationBuilder<ImoBeamDto, MxlAnalyser>(reporter, pAnalyser, "beam", "Beam") {}
     virtual ~MxlBeamsBuilder() {}
 
-    void add_relation_to_staffobjs(ImoBeamDto* pEndInfo);
+    void add_relation_to_staffobjs(ImoBeamDto* pEndInfo) override;
 };
 
 
@@ -93,7 +93,7 @@ public:
         : RelationBuilder<ImoSlurDto, MxlAnalyser>(reporter, pAnalyser, "slur", "Slur") {}
     virtual ~MxlSlursBuilder() {}
 
-    void add_relation_to_staffobjs(ImoSlurDto* pEndInfo);
+    void add_relation_to_staffobjs(ImoSlurDto* pEndInfo) override;
 };
 
 
@@ -106,7 +106,7 @@ public:
         : RelationBuilder<ImoTupletDto, MxlAnalyser>(reporter, pAnalyser, "tuplet", "Tuplet") {}
     virtual ~MxlTupletsBuilder() {}
 
-    void add_relation_to_staffobjs(ImoTupletDto* pEndInfo);
+    void add_relation_to_staffobjs(ImoTupletDto* pEndInfo) override;
     inline bool is_tuplet_open() { return m_pendingItems.size() > 0; }
     void add_to_open_tuplets(ImoNoteRest* pNR);
     void get_factors_from_nested_tuplets(int* pTop, int* pBottom);
@@ -130,7 +130,7 @@ public:
     }
     virtual ~MxlVoltasBuilder() {}
 
-    void add_relation_to_staffobjs(ImoVoltaBracketDto* pEndInfo);
+    void add_relation_to_staffobjs(ImoVoltaBracketDto* pEndInfo) override;
 };
 
 
@@ -146,7 +146,7 @@ public:
     }
     virtual ~MxlWedgesBuilder() {}
 
-    void add_relation_to_staffobjs(ImoWedgeDto* pEndInfo);
+    void add_relation_to_staffobjs(ImoWedgeDto* pEndInfo) override;
 };
 
 
@@ -162,7 +162,7 @@ public:
     }
     virtual ~MxlOctaveShiftBuilder() {}
 
-    void add_relation_to_staffobjs(ImoOctaveShiftDto* pEndInfo);
+    void add_relation_to_staffobjs(ImoOctaveShiftDto* pEndInfo) override;
     void add_to_open_octave_shifts(ImoNote* pNote);
 };
 

--- a/include/lomse_mxl_compiler.h
+++ b/include/lomse_mxl_compiler.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -62,8 +62,8 @@ public:
     MxlCompiler(LibraryScope& libraryScope, Document* pDoc);
 
     //compilation
-    ImoDocument* compile_file(const std::string& filename);
-    ImoDocument* compile_string(const std::string& source);
+    ImoDocument* compile_file(const std::string& filename) override;
+    ImoDocument* compile_string(const std::string& source) override;
 
 protected:
     ImoDocument* compile_parsed_tree(XmlNode* root);

--- a/include/lomse_player_gui.h
+++ b/include/lomse_player_gui.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -92,12 +92,12 @@ public:
     virtual ~PlayerNoGui() {}
 
     //mandatory overrides
-    virtual void on_end_of_playback() {}
-    virtual int get_play_mode() { return m_playMode; }
-    virtual int get_metronome_mm() { return m_metronomeMM; }
-    virtual Metronome* get_metronome() { return NULL; }
-    virtual bool countoff_status() { return m_countoffStatus; }
-    virtual bool metronome_status() { return m_metronomeStatus; }
+    void on_end_of_playback() override {}
+    int get_play_mode() override { return m_playMode; }
+    int get_metronome_mm() override { return m_metronomeMM; }
+    Metronome* get_metronome() override { return nullptr; }
+    bool countoff_status() override { return m_countoffStatus; }
+    bool metronome_status() override { return m_metronomeStatus; }
 
     //setters
     inline void set_play_mode(int value) { m_playMode = value; };

--- a/include/lomse_progress_bar_ctrl.h
+++ b/include/lomse_progress_bar_ctrl.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -65,16 +65,16 @@ public:
     virtual ~ProgressBarCtrl() {}
 
     //Control mandatory overrides
-    USize measure();
-    GmoBoxControl* layout(LibraryScope& libraryScope, UPoint pos);
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
-    void handle_event(SpEventInfo pEvent);
-    LUnits width() { return m_width; }
-    LUnits height() { return m_height; }
-    LUnits top() { return m_pos.y; }
-    LUnits bottom() { return m_pos.y + m_height; }
-    LUnits left() { return m_pos.x; }
-    LUnits right() { return m_pos.x + m_width; }
+    USize measure() override;
+    GmoBoxControl* layout(LibraryScope& libraryScope, UPoint pos) override;
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
+    void handle_event(SpEventInfo pEvent) override;
+    LUnits width() override { return m_width; }
+    LUnits height() override { return m_height; }
+    LUnits top() override { return m_pos.y; }
+    LUnits bottom() override { return m_pos.y + m_height; }
+    LUnits left() override { return m_pos.x; }
+    LUnits right() override { return m_pos.x + m_width; }
 
     //specific methods
     void set_value(float value);

--- a/include/lomse_reader.h
+++ b/include/lomse_reader.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -82,12 +82,12 @@ public:
     LdpFileReader(const std::string& locator);
     virtual ~LdpFileReader();
 
-    virtual char get_next_char();
-    virtual void repeat_last_char();
-    virtual bool is_ready();
-    virtual bool end_of_data();
-    virtual int get_line_number() { return m_numLine; }
-    virtual string get_locator() { return m_locator; }
+    char get_next_char() override;
+    void repeat_last_char() override;
+    bool is_ready() override;
+    bool end_of_data() override;
+    int get_line_number() override { return m_numLine; }
+    string get_locator() override { return m_locator; }
 
 };
 
@@ -100,12 +100,12 @@ public:
     LdpTextReader(const std::string& sourceText);
     virtual ~LdpTextReader() {}
 
-    virtual char get_next_char();
-    virtual void repeat_last_char();
-    virtual bool is_ready();
-    virtual bool end_of_data();
-    virtual int get_line_number() { return 0; }
-    virtual string get_locator() { return "string:"; }
+    char get_next_char() override;
+    void repeat_last_char() override;
+    bool is_ready() override;
+    bool end_of_data() override;
+    int get_line_number() override { return 0; }
+    string get_locator() override { return "string:"; }
 
 private:
     stringstream   m_stream;

--- a/include/lomse_renderer.h
+++ b/include/lomse_renderer.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -231,7 +231,7 @@ public:
     ~RendererTemplate() {}
 
     //-----------------------------------------------------------------------------------
-    void initialize(RenderingBuffer& buf, Color bgcolor)
+    void initialize(RenderingBuffer& buf, Color bgcolor) override
     {
         m_rbuf.attach(buf.buf(), buf.width(), buf.height(), buf.stride());
         m_renBase.reset_clipping(true);
@@ -243,7 +243,7 @@ public:
     }
 
     //-----------------------------------------------------------------------------------
-    void render()
+    void render() override
     {
         agg::rasterizer_scanline_aa<> ras;
         agg::scanline_p8 sl;
@@ -273,7 +273,7 @@ public:
     }
 
     //-----------------------------------------------------------------------------------
-    void render_gsv_text(double x, double y, const char* str)
+    void render_gsv_text(double x, double y, const char* str) override
     {
         agg::gsv_text t;
         t.size(10.0);
@@ -295,7 +295,7 @@ public:
     }
 
     //-----------------------------------------------------------------------------------
-    void render(FontRasterizer& ras, FontScanline& sl, Color color)
+    void render(FontRasterizer& ras, FontScanline& sl, Color color) override
     {
         m_renSolid.color( to_rgba(color) );
         agg::render_scanlines(ras, sl, m_renSolid);
@@ -303,24 +303,24 @@ public:
 
     //-----------------------------------------------------------------------------------
     // Expand all polygons
-    void expand(double value) { m_curved_trans_contour.width(value); }
+    void expand(double value) override { m_curved_trans_contour.width(value); }
 
     //-----------------------------------------------------------------------------------
-    void get_bounding_rect(double* x1, double* y1, double* x2, double* y2)
+    void get_bounding_rect(double* x1, double* y1, double* x2, double* y2) override
     {
         agg::conv_transform<agg::path_storage> trans(m_path, m_transform);
         agg::bounding_rect(trans, *this, 0, m_attr_storage.size(), x1, y1, x2, y2);
     }
 
     //-----------------------------------------------------------------------------------
-    void copy_from(RenderingBuffer& bmap, const AggRectInt* srcRect, int xDest, int yDest)
+    void copy_from(RenderingBuffer& bmap, const AggRectInt* srcRect, int xDest, int yDest) override
     {
         m_renBase.copy_from(bmap, srcRect, xDest, yDest);
     }
 
     //-----------------------------------------------------------------------------------
     void blend_from(RenderingBuffer& bmap, const AggRectInt* srcRect, int xShift,
-                    int yShift, unsigned alpha)
+                    int yShift, unsigned alpha) override
     {
         typedef agg::pixfmt_rgba32   ImgPixFmt;
         ImgPixFmt img_pixf(bmap);
@@ -333,7 +333,7 @@ public:
                        double srcX1, double srcY1, double srcX2, double srcY2,
                        double dstX1, double dstY1, double dstX2, double dstY2,
                        EResamplingQuality resamplingMode,
-                       double alpha)
+                       double alpha) override
     {
         //set affine transformation (rotation, scale, translation, skew)
         set_transformation();

--- a/include/lomse_score_layouter.h
+++ b/include/lomse_score_layouter.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -179,9 +179,9 @@ public:
                   LibraryScope& libraryScope);
     virtual ~ScoreLayouter();
 
-    void prepare_to_start_layout();
-    void layout_in_box();
-    void create_main_box(GmoBox* pParentBox, UPoint pos, LUnits width, LUnits height);
+    void prepare_to_start_layout() override;
+    void layout_in_box() override;
+    void create_main_box(GmoBox* pParentBox, UPoint pos, LUnits width, LUnits height) override;
 
     //info
     virtual int get_num_columns();
@@ -437,7 +437,7 @@ public:
                        SpacingAlgorithm* pSpAlgorithm, std::vector<int>& breaks);
     virtual ~LinesBreakerSimple() {}
 
-    void decide_line_breaks();
+    void decide_line_breaks() override;
 };
 
 
@@ -450,7 +450,7 @@ public:
                         SpacingAlgorithm* pSpAlgorithm, std::vector<int>& breaks);
     virtual ~LinesBreakerOptimal() {}
 
-    void decide_line_breaks();
+    void decide_line_breaks() override;
 
     //support for debug and tests
     void dump_entries(ostream& outStream=logger.get_stream());

--- a/include/lomse_score_player_ctrl.h
+++ b/include/lomse_score_player_ctrl.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -66,24 +66,24 @@ public:
     virtual ~ScorePlayerCtrl() {}
 
     //Control mandatory overrides
-    USize measure();
-    GmoBoxControl* layout(LibraryScope& libraryScope, UPoint pos);
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
-    void handle_event(SpEventInfo pEvent);
-    LUnits width() { return m_width; }
-    LUnits height() { return m_height; }
-    LUnits top() { return m_pos.y; }
-    LUnits bottom() { return m_pos.y + m_height; }
-    LUnits left() { return m_pos.x; }
-    LUnits right() { return m_pos.x + m_width; }
+    USize measure() override;
+    GmoBoxControl* layout(LibraryScope& libraryScope, UPoint pos) override;
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
+    void handle_event(SpEventInfo pEvent) override;
+    LUnits width() override { return m_width; }
+    LUnits height() override { return m_height; }
+    LUnits top() override { return m_pos.y; }
+    LUnits bottom() override { return m_pos.y + m_height; }
+    LUnits left() override { return m_pos.x; }
+    LUnits right() override { return m_pos.x + m_width; }
 
     //PlayerGui mandatory overrides
-    void on_end_of_playback();
-    int get_play_mode();
-    int get_metronome_mm();
-    Metronome* get_metronome();
-    bool countoff_status();
-    bool metronome_status();
+    void on_end_of_playback() override;
+    int get_play_mode() override;
+    int get_metronome_mm() override;
+    Metronome* get_metronome() override;
+    bool countoff_status() override;
+    bool metronome_status() override;
 
     //specific methods
     void set_text(const string& UNUSED(text)) {}

--- a/include/lomse_screen_drawer.h
+++ b/include/lomse_screen_drawer.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -76,78 +76,78 @@ public:
 
     // SVG path commands
     // http://www.w3.org/TR/SVG/paths.html#PathData
-    void begin_path();                                  //SVG: <path>
-    void end_path();                                    //SVG: </path>
-    void close_subpath();                               //SVG: Z, z
-    void move_to(double x, double y);                   //SVG: M
-    void move_to_rel(double x, double y);               //SVG: m
-    void line_to(double x,  double y);                  //SVG: L
-    void line_to_rel(double x,  double y);              //SVG: l
-    void hline_to(double x);                            //SVG: H
-    void hline_to_rel(double x);                        //SVG: h
-    void vline_to(double y);                            //SVG: V
-    void vline_to_rel(double y);                        //SVG: v
-    void cubic_bezier(double x1, double y1,             //SVG: Q
-                      double x, double y);
-    void cubic_bezier_rel(double x1, double y1,         //SVG: q
-                          double x, double y);
-    void cubic_bezier(double x, double y);              //SVG: T
-    void cubic_bezier_rel(double x, double y);          //SVG: t
-    void quadratic_bezier(double x1, double y1,         //SVG: C
+    void begin_path() override;                                  //SVG: <path>
+    void end_path() override;                                    //SVG: </path>
+    void close_subpath() override;                               //SVG: Z, z
+    void move_to(double x, double y) override;                   //SVG: M
+    void move_to_rel(double x, double y) override;               //SVG: m
+    void line_to(double x,  double y) override;                  //SVG: L
+    void line_to_rel(double x,  double y) override;              //SVG: l
+    void hline_to(double x) override;                            //SVG: H
+    void hline_to_rel(double x) override;                        //SVG: h
+    void vline_to(double y) override;                            //SVG: V
+    void vline_to_rel(double y) override;                        //SVG: v
+    void cubic_bezier(double x1, double y1,                      //SVG: Q
+                      double x, double y) override;
+    void cubic_bezier_rel(double x1, double y1,                  //SVG: q
+                          double x, double y) override;
+    void cubic_bezier(double x, double y) override;              //SVG: T
+    void cubic_bezier_rel(double x, double y) override;          //SVG: t
+    void quadratic_bezier(double x1, double y1,                  //SVG: C
                           double x2, double y2,
-                          double x, double y);
-    void quadratic_bezier_rel(double x1, double y1,     //SVG: c
+                          double x, double y) override;
+    void quadratic_bezier_rel(double x1, double y1,              //SVG: c
                               double x2, double y2,
-                              double x, double y);
-    void quadratic_bezier(double x2, double y2,         //SVG: S
-                          double x, double y);
-    void quadratic_bezier_rel(double x2, double y2,     //SVG: s
-                              double x, double y);
+                              double x, double y) override;
+    void quadratic_bezier(double x2, double y2,                  //SVG: S
+                          double x, double y) override;
+    void quadratic_bezier_rel(double x2, double y2,              //SVG: s
+                              double x, double y) override;
 
 
     // SVG basic shapes commands
-    void rect(UPoint pos, USize size, LUnits radius);               //SVG: <rect>                                      //SVG: <rect>
-    void circle(LUnits xCenter, LUnits yCenter, LUnits radius);     //SVG: <circle>
+    void rect(UPoint pos, USize size, LUnits radius) override;               //SVG: <rect>                                      //SVG: <rect>
+    void circle(LUnits xCenter, LUnits yCenter, LUnits radius) override;     //SVG: <circle>
     //virtual void ellipse() = 0;                                   //SVG: <ellipse>
     void line(LUnits x1, LUnits y1, LUnits x2, LUnits y2,
-              LUnits width, ELineEdge nEdge=k_edge_normal);         //SVG: <line>
+              LUnits width, ELineEdge nEdge=k_edge_normal) override;         //SVG: <line>
     //virtual void polyline() = 0;                                  //SVG: <polyline>
-    virtual void polygon(int n, UPoint points[]);                   //SVG: <polygon>
+    virtual void polygon(int n, UPoint points[]) override;                   //SVG: <polygon>
 
     // not the same but similar to SVG path command
-    void add_path(VertexSource& vs, unsigned path_id = 0, bool solid_path = true);
+    void add_path(VertexSource& vs, unsigned path_id = 0, bool solid_path = true) override;
 
 
     // Attribute setting functions.
-    void fill(Color color);
-    void stroke(Color color);
-    void even_odd(bool flag);
-    void stroke_width(double w);
-    void fill_none();
-    void stroke_none();
-    void fill_opacity(unsigned op);
-    void stroke_opacity(unsigned op);
-    void line_join(line_join_e join);
-    void line_cap(line_cap_e cap);
-    void miter_limit(double ml);
-    void fill_linear_gradient(LUnits x1, LUnits y1, LUnits x2, LUnits y2);
-    void gradient_color(Color c1, Color c2, double start, double stop);
-    void gradient_color(Color c1, double start, double stop);
+    void fill(Color color) override;
+    void stroke(Color color) override;
+    void even_odd(bool flag) override;
+    void stroke_width(double w) override;
+    void fill_none() override;
+    void stroke_none() override;
+    void fill_opacity(unsigned op) override;
+    void stroke_opacity(unsigned op) override;
+    void line_join(line_join_e join) override;
+    void line_cap(line_cap_e cap) override;
+    void miter_limit(double ml) override;
+    void fill_linear_gradient(LUnits x1, LUnits y1, LUnits x2, LUnits y2) override;
+    void gradient_color(Color c1, Color c2, double start, double stop) override;
+    void gradient_color(Color c1, double start, double stop) override;
 
 
     // current font
     bool select_font(const std::string& language,
                      const std::string& fontFile,
                      const std::string& fontName, double height,
-                     bool fBold=false, bool fItalic=false);
+                     bool fBold=false, bool fItalic=false) override;
     bool select_raster_font(const std::string& language,
                             const std::string& fontFile,
                             const std::string& fontName, double height,
-                            bool fBold=false, bool fItalic=false);
+                            bool fBold=false, bool fItalic=false) override;
     bool select_vector_font(const std::string& language,
                             const std::string& fontFile,
                             const std::string& fontName, double height,
-                            bool fBold=false, bool fItalic=false);
+                            bool fBold=false, bool fItalic=false) override;
 
     //inline void FtSetFontSize(double rPoints) { return m_pMFM->SetFontSize(rPoints); }
     //inline void FtSetFontHeight(double rPoints) { return m_pMFM->SetFontHeight(rPoints); }
@@ -169,9 +169,9 @@ public:
 
     // text rederization
     void gsv_text(double x, double y, const char* str);
-    int draw_text(double x, double y, const std::string& str);
-    int draw_text(double x, double y, const wstring& str);
-    void draw_glyph(double x, double y, unsigned int ch);
+    int draw_text(double x, double y, const std::string& str) override;
+    int draw_text(double x, double y, const wstring& str) override;
+    void draw_glyph(double x, double y, unsigned int ch) override;
 
     //void FtSetTextPosition(lmLUnits uxPos, lmLUnits uyPos);
     //void FtSetTextPositionPixels(lmPixels vxPos, lmPixels vyPos);
@@ -182,21 +182,21 @@ public:
 
     //copy/blend a bitmap
     //-----------------------
-    void copy_bitmap(RenderingBuffer& bmap, UPoint pos);
+    void copy_bitmap(RenderingBuffer& bmap, UPoint pos) override;
     void copy_bitmap(RenderingBuffer& bmap,
                      Pixels srcX1, Pixels srcY1, Pixels srcX2, Pixels srcY2,
-                     UPoint dest);
+                     UPoint dest) override;
     void draw_bitmap(RenderingBuffer& bmap, bool hasAlpha,
                      Pixels srcX1, Pixels srcY1, Pixels srcX2, Pixels srcY2,
                      LUnits dstX1, LUnits dstY1, LUnits dstX2, LUnits dstY2,
                      EResamplingQuality resamplingMode,
-                     double alpha=1.0);
+                     double alpha=1.0) override;
 
 
     //SVG line with start/end markers
     //-----------------------
     void line_with_markers(UPoint start, UPoint end, LUnits width,
-                           ELineCap startCap, ELineCap endCap);
+                           ELineCap startCap, ELineCap endCap) override;
 
 
     // point conversion
@@ -213,9 +213,9 @@ public:
     void reset(RenderingBuffer& buf, Color bgcolor);
     void set_viewport(Pixels x, Pixels y);
     void set_transform(TransAffine& transform);
-    void set_shift(LUnits x, LUnits y);
-    void remove_shift();
-    void render();
+    void set_shift(LUnits x, LUnits y) override;
+    void remove_shift() override;
+    void render() override;
     void render(FontRasterizer& ras, FontScanline& sl, Color color);
 
 

--- a/include/lomse_shape_beam.h
+++ b/include/lomse_shape_beam.h
@@ -60,7 +60,7 @@ public:
 
     void set_layout_data(std::list<LUnits>& segments, UPoint origin, USize size,
                          bool fCrossStaff, bool fChord, int beamPos, int staff);
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 
     //provide geometry reference info, for tuplets and other related shapes
     //Reference points are:

--- a/include/lomse_shape_brace_bracket.h
+++ b/include/lomse_shape_brace_bracket.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -57,10 +57,10 @@ protected:
 public:
 	virtual ~GmoShapeBracketBrace();
 
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 
     //VertexSource
-    void rewind(int UNUSED(pathId) = 0) { m_nCurVertex = 0; m_nContour = 0; }
+    void rewind(int UNUSED(pathId) = 0) override { m_nCurVertex = 0; m_nContour = 0; }
 
 
 protected:
@@ -82,10 +82,10 @@ public:
 	~GmoShapeBrace();
 
     //VertexSource
-    unsigned vertex(double* px, double* py);
+    unsigned vertex(double* px, double* py) override;
 
 protected:
-    void set_affine_transform();
+    void set_affine_transform() override;
 
 };
 
@@ -106,10 +106,10 @@ public:
     ~GmoShapeBracket();
 
     //VertexSource
-    unsigned vertex(double* px, double* py);
+    unsigned vertex(double* px, double* py) override;
 
 protected:
-    void set_affine_transform();
+    void set_affine_transform() override;
 
 };
 
@@ -130,7 +130,7 @@ public:
     ~GmoShapeSquaredBracket();
 
 	//implementation of pure virtual methods in base class
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 
 protected:
 

--- a/include/lomse_shape_line.h
+++ b/include/lomse_shape_line.h
@@ -97,7 +97,7 @@ public:
     inline void set_tail_type(ELineCap nHeadType) { m_nEndCap = nHeadType; }
 
     //implementation of virtual methods from base class
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 
     //overrides
     bool HitTest(UPoint& uPoint);

--- a/include/lomse_shape_note.h
+++ b/include/lomse_shape_note.h
@@ -259,7 +259,7 @@ public:     //TO_FIX: Constructor used in tests
                  LibraryScope& libraryScope);
 
 public:
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 };
 
 //---------------------------------------------------------------------------------------

--- a/include/lomse_shape_octave_shift.h
+++ b/include/lomse_shape_octave_shift.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -65,16 +65,16 @@ public:
     GmoShapeOctaveShift(ImoObj* pCreatorImo, ShapeId idx, Color color);
     virtual ~GmoShapeOctaveShift();
 
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 
     void set_layout_data(LUnits xStart, LUnits xEnd, LUnits yStart, LUnits yEnd,
                          LUnits uLineThick, bool fEndCorner);
 
     //support for handlers
-    int get_num_handlers();
-    UPoint get_handler_point(int i);
-    void on_handler_dragged(int iHandler, UPoint newPos);
-    void on_end_of_handler_drag(int iHandler, UPoint newPos);
+    int get_num_handlers() override;
+    UPoint get_handler_point(int i) override;
+    void on_handler_dragged(int iHandler, UPoint newPos) override;
+    void on_end_of_handler_drag(int iHandler, UPoint newPos) override;
 
 protected:
 

--- a/include/lomse_shape_staff.h
+++ b/include/lomse_shape_staff.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -56,7 +56,7 @@ public:
     ~GmoShapeStaff();
 
 	//implementation of pure virtual methods in base class
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 //    void Shift(LUnits xIncr, LUnits yIncr);
 
 	//ownership and related info

--- a/include/lomse_shape_text.h
+++ b/include/lomse_shape_text.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -65,14 +65,14 @@ protected:
 
 public:
 
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 
     //dynamic modification
     void set_text(const std::string& text);
 
 protected:
     void select_font();
-    Color get_normal_color();
+    Color get_normal_color() override;
 
 };
 
@@ -95,7 +95,7 @@ protected:
 
 public:
 
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 
     //for unit tests
     inline LUnits get_top_line() { return m_origin.y + m_halfLeading; }
@@ -104,7 +104,7 @@ public:
 
 protected:
     void select_font();
-    Color get_normal_color();
+    Color get_normal_color() override;
 
 };
 
@@ -155,7 +155,7 @@ public:
     virtual ~GmoShapeTextBox();
 
     //implementation of virtual methods from base class
-    virtual void on_draw(Drawer* pDrawer, RenderOptions& opt);
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 
 //    //other
 //    string dump(int nIndent);

--- a/include/lomse_shape_tuplet.h
+++ b/include/lomse_shape_tuplet.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -77,7 +77,7 @@ public:
 
     void add_label(GmoShapeText* pShape);
 
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 
 protected:
     void compute_horizontal_position();

--- a/include/lomse_shape_volta_bracket.h
+++ b/include/lomse_shape_volta_bracket.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -68,7 +68,7 @@ public:
     GmoShapeVoltaBracket(ImoObj* pCreatorImo, ShapeId idx, Color color);
     virtual ~GmoShapeVoltaBracket();
 
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 
 
     void set_layout_data(LUnits xStart, LUnits xEnd, LUnits yPos, LUnits uBracketDistance,
@@ -80,10 +80,10 @@ public:
     inline void set_two_brackets() { m_fTwoBrackets = true; }
 
     //support for handlers
-    int get_num_handlers();
-    UPoint get_handler_point(int i);
-    void on_handler_dragged(int iHandler, UPoint newPos);
-    void on_end_of_handler_drag(int iHandler, UPoint newPos);
+    int get_num_handlers() override;
+    UPoint get_handler_point(int i) override;
+    void on_handler_dragged(int iHandler, UPoint newPos) override;
+    void on_end_of_handler_drag(int iHandler, UPoint newPos) override;
 
 protected:
     void compute_bounds(LUnits xStart, LUnits xEnd, LUnits yPos);

--- a/include/lomse_shape_wedge.h
+++ b/include/lomse_shape_wedge.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -72,7 +72,7 @@ public:
                   Color color, int niente, LUnits radius);
     virtual ~GmoShapeWedge();
 
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 
     //construction
     enum {
@@ -82,10 +82,10 @@ public:
     };
 
     //support for handlers
-    int get_num_handlers();
-    UPoint get_handler_point(int i);
-    void on_handler_dragged(int iHandler, UPoint newPos);
-    void on_end_of_handler_drag(int iHandler, UPoint newPos);
+    int get_num_handlers() override;
+    UPoint get_handler_point(int i) override;
+    void on_handler_dragged(int iHandler, UPoint newPos) override;
+    void on_end_of_handler_drag(int iHandler, UPoint newPos) override;
 
 protected:
     void save_points_and_compute_bounds(UPoint* points);

--- a/include/lomse_shapes.h
+++ b/include/lomse_shapes.h
@@ -60,7 +60,7 @@ protected:
 public:
     virtual ~GmoShapeGlyph() {}
 
-    virtual void on_draw(Drawer* pDrawer, RenderOptions& opt);
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 
 protected:
     GmoShapeGlyph(ImoObj* pCreatorImo, int type, ShapeId idx, unsigned int nGlyph,
@@ -197,7 +197,7 @@ public:
     void set_image(SpImage image);
 
 public:
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 };
 
 //---------------------------------------------------------------------------------------
@@ -208,7 +208,7 @@ protected:
     GmoShapeInvisible(ImoObj* pCreatorImo, ShapeId idx, UPoint uPos, USize uSize);
 
 public:
-    virtual void on_draw(Drawer* pDrawer, RenderOptions& opt);
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 };
 
 //---------------------------------------------------------------------------------------
@@ -302,7 +302,7 @@ public:
 
 
     //implementation of virtual methods from base class
-    virtual void on_draw(Drawer* pDrawer, RenderOptions& opt);
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 
     //settings
     inline void set_radius(LUnits radius) { m_radius = radius; }
@@ -321,7 +321,7 @@ public:
     virtual ~GmoShapeSimpleLine() {}
 
     //implementation of virtual methods from base class
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 
 protected:
     GmoShapeSimpleLine(ImoObj* pCreatorImo, int type, LUnits xStart, LUnits yStart,

--- a/include/lomse_sizers.h
+++ b/include/lomse_sizers.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -106,7 +106,7 @@ public:
     inline void set_orientation(int orientation) { m_orientation = orientation; }
     inline bool is_vertical() { return m_orientation == k_vertical; }
 
-    void layout(LUnits width, LUnits height);
+    void layout(LUnits width, LUnits height) override;
 
 protected:
     void layout_vertical(LUnits width, LUnits height);

--- a/include/lomse_spacing_algorithm.h
+++ b/include/lomse_spacing_algorithm.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -271,51 +271,51 @@ public:
     //------------------------------------------------------------------------------
 
     //collect content
-    void split_content_in_columns();
+    void split_content_in_columns() override;
     //spacing algorithm
-    void do_spacing_algorithm();
+    void do_spacing_algorithm() override;
     //boxes and shapes
-    virtual void add_shapes_to_boxes(int iCol, VerticalProfile* pVProfile);
-    virtual GmoBoxSliceInstr* get_slice_instr(int iCol, int iInstr);
-    virtual void set_slice_final_position(int iCol, LUnits left, LUnits top);
-    virtual void create_boxes_for_column(int iCol, LUnits left, LUnits top);
-    LUnits get_staves_height();
+    void add_shapes_to_boxes(int iCol, VerticalProfile* pVProfile) override;
+    GmoBoxSliceInstr* get_slice_instr(int iCol, int iInstr) override;
+    void set_slice_final_position(int iCol, LUnits left, LUnits top) override;
+    void create_boxes_for_column(int iCol, LUnits left, LUnits top) override;
+    LUnits get_staves_height() override;
     ///store slice box for column iCol and access it
-    virtual void use_this_slice_box(int iCol, GmoBoxSlice* pBoxSlice);
-    virtual GmoBoxSlice* get_slice_box(int iCol);
-    virtual bool has_system_break(int iCol);
-    virtual void delete_box_and_shapes(int iCol);
+    void use_this_slice_box(int iCol, GmoBoxSlice* pBoxSlice) override;
+    GmoBoxSlice* get_slice_box(int iCol) override;
+    bool has_system_break(int iCol) override;
+    void delete_box_and_shapes(int iCol) override;
     //other
-    virtual TypeMeasureInfo* get_measure_info_for_column(int iCol);
-    virtual GmoShapeBarline* get_start_barline_shape_for_column(int iCol);
+    TypeMeasureInfo* get_measure_info_for_column(int iCol) override;
+    GmoShapeBarline* get_start_barline_shape_for_column(int iCol) override;
 
 
     //methods in base class SpacingAlgorithm that still need to be created
     //------------------------------------------------------------------------
 
-    virtual void reposition_slices_and_staffobjs(int iFirstCol, int iLastCol,
-            LUnits yShift,
-            LUnits* yMin, LUnits* yMax) = 0;
-    virtual void justify_system(int iFirstCol, int iLastCol, LUnits uSpaceIncrement) = 0;
-
-    //for line break algorithm
-    virtual bool is_empty_column(int iCol) = 0;
-
-    //information about a column
-    virtual LUnits get_column_width(int iCol) = 0;
-    virtual int get_column_barlines_information(int iCol) = 0;
-
-    //methods to compute results
-    virtual TimeGridTable* create_time_grid_table_for_column(int iCol) = 0;
-
-    //methods for line break
-    virtual float determine_penalty_for_line(int iSystem, int i, int j) = 0;
-    virtual bool is_better_option(float prevPenalty, float newPenalty, float nextPenalty,
-                                  int i, int j) = 0;
-
-    //debug
-    virtual void dump_column_data(int iCol, ostream& outStream) = 0;
-    virtual ColumnData* get_column(int i);
+//    virtual void reposition_slices_and_staffobjs(int iFirstCol, int iLastCol,
+//            LUnits yShift,
+//            LUnits* yMin, LUnits* yMax) = 0;
+//    virtual void justify_system(int iFirstCol, int iLastCol, LUnits uSpaceIncrement) = 0;
+//
+//    //for line break algorithm
+//    virtual bool is_empty_column(int iCol) = 0;
+//
+//    //information about a column
+//    virtual LUnits get_column_width(int iCol) = 0;
+//    virtual int get_column_barlines_information(int iCol) = 0;
+//
+//    //methods to compute results
+//    virtual TimeGridTable* create_time_grid_table_for_column(int iCol) = 0;
+//
+//    //methods for line break
+//    virtual float determine_penalty_for_line(int iSystem, int i, int j) = 0;
+//    virtual bool is_better_option(float prevPenalty, float newPenalty, float nextPenalty,
+//                                  int i, int j) = 0;
+//
+//    //debug
+//    virtual void dump_column_data(int iCol, ostream& outStream) = 0;
+    ColumnData* get_column(int i) override;
 
 
     //new methods to be implemented by derived classes (apart from previous methods)
@@ -343,21 +343,21 @@ public:
     virtual void add_shapes_to_box(int iCol, GmoBoxSliceInstr* pSliceInstrBox,
                                    int iInstr) = 0;
 
-    virtual void delete_shapes(int iCol) = 0;
+//    virtual void delete_shapes(int iCol) = 0;
 
 
     //new methods for this class, normally no need to override
     //-------------------------------------------------------------------------
 
     ///Returns the number of columns in which the content has been split
-    virtual int get_num_columns();
+    int get_num_columns() override;
 
     ///save context information (clef, key) for iCol, and access it
     virtual void save_context(int iCol, int iInstr, int iStaff,
                               ColStaffObjsEntry* pClefEntry,
                               ColStaffObjsEntry* pKeyEntry);
-    virtual ColStaffObjsEntry* get_prolog_clef(int iCol, ShapeId idx);
-    virtual ColStaffObjsEntry* get_prolog_key(int iCol, ShapeId idx);
+    ColStaffObjsEntry* get_prolog_clef(int iCol, ShapeId idx) override;
+    ColStaffObjsEntry* get_prolog_key(int iCol, ShapeId idx) override;
 
     ///system break found while collecting content for iCol
     virtual void set_system_break(int iCol, bool value);
@@ -373,7 +373,7 @@ public:
     virtual void set_slice_width(int iCol, LUnits width);
 
     ///activate trace for iCol at level traceLevel
-    virtual void set_trace_level(int iCol, int nTraceLevel);
+    void set_trace_level(int iCol, int nTraceLevel) override;
 
 
 };

--- a/include/lomse_spacing_algorithm_gourlay.h
+++ b/include/lomse_spacing_algorithm_gourlay.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -110,39 +110,39 @@ public:
 
 
     //spacing algorithm main actions
-    void do_spacing(int iCol, bool fTrace=false);
-    void justify_system(int iFirstCol, int iLastCol, LUnits uSpaceIncrement);
+    void do_spacing(int iCol, bool fTrace=false) override;
+    void justify_system(int iFirstCol, int iLastCol, LUnits uSpaceIncrement) override;
 
     //for lines break algorithm
-    float determine_penalty_for_line(int iSystem, int i, int j);
+    float determine_penalty_for_line(int iSystem, int i, int j) override;
     bool is_better_option(float prevPenalty, float newPenalty, float nextPenalty,
-                          int i, int j);
+                          int i, int j) override;
 
     //information about a column
-    bool is_empty_column(int iCol);
-    LUnits get_column_width(int iCol);
-    virtual int get_column_barlines_information(int iCol);
+    bool is_empty_column(int iCol) override;
+    LUnits get_column_width(int iCol) override;
+    int get_column_barlines_information(int iCol) override;
 
     //methods to compute results
-    TimeGridTable* create_time_grid_table_for_column(int iCol);
+    TimeGridTable* create_time_grid_table_for_column(int iCol) override;
 
     //debug
-    void dump_column_data(int iCol, ostream& outStream);
+    void dump_column_data(int iCol, ostream& outStream) override;
 
     //column creation: collecting content
-    void start_column_measurements(int iCol);
+    void start_column_measurements(int iCol) override;
     void include_object(ColStaffObjsEntry* pCurEntry, int iCol, int iInstr, int iStaff,
-                        ImoStaffObj* pSO, GmoShape* pShape, bool fInProlog=false);
+                        ImoStaffObj* pSO, GmoShape* pShape, bool fInProlog=false) override;
     void include_full_measure_rest(GmoShape* pRestShape, ColStaffObjsEntry* pCurEntry,
-                                   GmoShape* pNonTimedShape);
-    void finish_column_measurements(int iCol);
+                                   GmoShape* pNonTimedShape) override;
+    void finish_column_measurements(int iCol) override;
 
     //auxiliary: shapes and boxes
-    void add_shapes_to_box(int iCol, GmoBoxSliceInstr* pSliceInstrBox, int iInstr);
-    void delete_shapes(int iCol);
+    void add_shapes_to_box(int iCol, GmoBoxSliceInstr* pSliceInstrBox, int iInstr) override;
+    void delete_shapes(int iCol) override;
     void reposition_slices_and_staffobjs(int iFirstCol, int iLastCol,
-                                         LUnits yShift, LUnits* yMin, LUnits* yMax);
-    void reposition_full_measure_rests(int iFirstCol, int iLastCol, GmoBoxSystem* pBox);
+                                         LUnits yShift, LUnits* yMin, LUnits* yMax) override;
+    void reposition_full_measure_rests(int iFirstCol, int iLastCol, GmoBoxSystem* pBox) override;
 
 protected:
     void new_column(TimeSlice* pSlice);

--- a/include/lomse_static_text_ctrl.h
+++ b/include/lomse_static_text_ctrl.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -55,16 +55,16 @@ public:
     virtual ~StaticTextCtrl() {}
 
     //Control mandatory overrides
-    USize measure();
-    GmoBoxControl* layout(LibraryScope& libraryScope, UPoint pos);
-    void on_draw(Drawer* pDrawer, RenderOptions& opt);
-    void handle_event(SpEventInfo pEvent);
-    LUnits width() { return m_width; }
-    LUnits height() { return m_height; }
-    LUnits top() { return m_pos.y; }
-    LUnits bottom() { return m_pos.y + m_height; }
-    LUnits left() { return m_pos.x; }
-    LUnits right() { return m_pos.x + m_width; }
+    USize measure() override;
+    GmoBoxControl* layout(LibraryScope& libraryScope, UPoint pos) override;
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
+    void handle_event(SpEventInfo pEvent) override;
+    LUnits width() override { return m_width; }
+    LUnits height() override { return m_height; }
+    LUnits top() override { return m_pos.y; }
+    LUnits bottom() override { return m_pos.y + m_height; }
+    LUnits left() override { return m_pos.x; }
+    LUnits right() override { return m_pos.x + m_width; }
 
     //specific methods
     void set_text(const string& text);

--- a/include/lomse_table_layouter.h
+++ b/include/lomse_table_layouter.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -86,9 +86,9 @@ public:
     virtual ~TableLayouter();
 
     //mandatory overrides
-    void layout_in_box();
-    void create_main_box(GmoBox* pParentBox, UPoint pos, LUnits width, LUnits height);
-    void prepare_to_start_layout();
+    void layout_in_box() override;
+    void create_main_box(GmoBox* pParentBox, UPoint pos, LUnits width, LUnits height) override;
+    void prepare_to_start_layout() override;
 
 protected:
     void create_sections_layouters();
@@ -127,9 +127,9 @@ public:
     virtual ~TableSectionLayouter();
 
     //mandatory overrides
-    void layout_in_box();
-    void create_main_box(GmoBox* pParentBox, UPoint pos, LUnits width, LUnits height);
-    void prepare_to_start_layout();
+    void layout_in_box() override;
+    void create_main_box(GmoBox* pParentBox, UPoint pos, LUnits width, LUnits height) override;
+    void prepare_to_start_layout() override;
 
     //specific
     inline void set_origin(UPoint pos) { m_pageCursor = pos; }
@@ -167,8 +167,8 @@ public:
     virtual ~TableRowLayouter();
 
     //implementation of Layouter virtual methods
-    void layout_in_box();
-    void create_main_box(GmoBox* pParentBox, UPoint pos, LUnits width, LUnits height);
+    void layout_in_box() override;
+    void create_main_box(GmoBox* pParentBox, UPoint pos, LUnits width, LUnits height) override;
 
 protected:
     LUnits layout_cell(TableCellLayouter* pCellLayouter, GmoBox* pParentBox, UPoint pos);

--- a/include/lomse_tasks.h
+++ b/include/lomse_tasks.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -137,8 +137,8 @@ public:
     }
     ~TaskDragView() {}
 
-    void init_task();
-    void process_event(Event event);
+    void init_task() override;
+    void process_event(Event event) override;
 
 protected:
     //actions
@@ -156,7 +156,7 @@ public:
     TaskNull(Interactor* pIntor) : Task(TaskFactory::k_task_null, pIntor) {}
     ~TaskNull() {}
 
-    void process_event(Event UNUSED(event)) {}
+    void process_event(Event UNUSED(event)) override {}
 
 };
 
@@ -177,8 +177,8 @@ public:
     TaskOnlyClicks(Interactor* pIntor);
     ~TaskOnlyClicks() {}
 
-    void init_task();
-    void process_event(Event event);
+    void init_task() override;
+    void process_event(Event event) override;
 
 protected:
     //actions
@@ -203,8 +203,8 @@ public:
     TaskSelection(Interactor* pIntor);
     ~TaskSelection() {}
 
-    void init_task();
-    void process_event(Event event);
+    void init_task() override;
+    void process_event(Event event) override;
 
 protected:
     //actions
@@ -268,8 +268,8 @@ public:
     TaskSelectionRectangle(Interactor* pIntor);
     ~TaskSelectionRectangle() {}
 
-    void init_task();
-    void process_event(Event event);
+    void init_task() override;
+    void process_event(Event event) override;
     void set_first_point(Pixels xStart, Pixels yStart);
 
 protected:
@@ -295,8 +295,8 @@ public:
     TaskMoveObject(Interactor* pIntor);
     ~TaskMoveObject() {}
 
-    void init_task();
-    void process_event(Event event);
+    void init_task() override;
+    void process_event(Event event) override;
     void set_first_point(Pixels xStart, Pixels yStart);
 
 protected:
@@ -323,8 +323,8 @@ public:
     TaskDataEntry(Interactor* pIntor);
     ~TaskDataEntry() {}
 
-    void init_task();
-    void process_event(Event event);
+    void init_task() override;
+    void process_event(Event event) override;
 
 protected:
     //actions
@@ -350,8 +350,8 @@ public:
     TaskMoveHandler(Interactor* pIntor);
     ~TaskMoveHandler() {}
 
-    void init_task();
-    void process_event(Event event);
+    void init_task() override;
+    void process_event(Event event) override;
     void set_first_point(Pixels xStart, Pixels yStart);
 
 protected:

--- a/include/lomse_tempo_line.h
+++ b/include/lomse_tempo_line.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2018. All rights reserved.
+// Lomse is copyrighted work (c) 2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -94,8 +94,8 @@ public:
     void remove_tempo_line();
 
     //mandatory overrides from VisualEffect
-    void on_draw(ScreenDrawer* pDrawer);
-    URect get_bounds() { return m_bounds; }
+    void on_draw(ScreenDrawer* pDrawer) override;
+    URect get_bounds() override { return m_bounds; }
 
 protected:
 

--- a/include/lomse_text_splitter.h
+++ b/include/lomse_text_splitter.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -82,8 +82,8 @@ public:
     DefaultTextSplitter(ImoTextItem* pText, LibraryScope& libraryScope);
     ~DefaultTextSplitter() {}
 
-    Engrouter* get_next_text_engrouter(LUnits maxSpace, bool fRemoveLeftSpaces);
-    bool more_text();
+    Engrouter* get_next_text_engrouter(LUnits maxSpace, bool fRemoveLeftSpaces) override;
+    bool more_text() override;
 
 protected:
 
@@ -102,8 +102,8 @@ public:
     ChineseTextSplitter(ImoTextItem* pText, LibraryScope& libraryScope);
     ~ChineseTextSplitter() {}
 
-    Engrouter* get_next_text_engrouter(LUnits maxSpace, bool fRemoveLeftSpaces);
-    bool more_text();
+    Engrouter* get_next_text_engrouter(LUnits maxSpace, bool fRemoveLeftSpaces) override;
+    bool more_text() override;
 
 };
 

--- a/include/lomse_time_grid.h
+++ b/include/lomse_time_grid.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -62,8 +62,8 @@ public:
     virtual ~TimeGrid() {}
 
     //operations
-    void on_draw(ScreenDrawer* pDrawer);
-    URect get_bounds() { return m_bounds; }
+    void on_draw(ScreenDrawer* pDrawer) override;
+    URect get_bounds() override { return m_bounds; }
 
     //getters
     inline Color get_color() const { return m_color; }

--- a/include/lomse_visual_effect.h
+++ b/include/lomse_visual_effect.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -123,8 +123,8 @@ public:
     void move_to(LUnits x, LUnits y);
 
     //mandatory overrides from VisualEffect
-    void on_draw(ScreenDrawer* pDrawer);
-    URect get_bounds();
+    void on_draw(ScreenDrawer* pDrawer) override;
+    URect get_bounds() override;
 
 protected:
     void delete_shape();
@@ -152,8 +152,8 @@ public:
     void set_end_point(LUnits x, LUnits y);
 
     //mandatory overrides from VisualEffect
-    void on_draw(ScreenDrawer* pDrawer);
-    URect get_bounds();
+    void on_draw(ScreenDrawer* pDrawer) override;
+    URect get_bounds() override;
 };
 ///@endcond
 
@@ -192,8 +192,8 @@ public:
     void remove_all_highlight();
 
     //mandatory overrides from VisualEffect
-    void on_draw(ScreenDrawer* pDrawer);
-    URect get_bounds();
+    void on_draw(ScreenDrawer* pDrawer) override;
+    URect get_bounds() override;
 
 ///@endcond
 };
@@ -215,8 +215,8 @@ public:
     virtual ~SelectionHighlight() {}
 
     //mandatory overrides from VisualEffect
-    void on_draw(ScreenDrawer* pDrawer);
-    URect get_bounds();
+    void on_draw(ScreenDrawer* pDrawer) override;
+    URect get_bounds() override;
 
     //other
     bool are_handlers_needed();

--- a/include/lomse_xml_parser.h
+++ b/include/lomse_xml_parser.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -127,8 +127,8 @@ public:
     XmlParser(ostream& reporter=cout);
     ~XmlParser();
 
-    void parse_file(const std::string& filename, bool fErrorMsg = true);
-    void parse_text(const std::string& sourceText);
+    void parse_file(const std::string& filename, bool fErrorMsg = true) override;
+    void parse_text(const std::string& sourceText) override;
     void parse_cstring(char* sourceText);
 
     inline const string& get_error() { return m_errorMsg; }

--- a/include/lomse_zip_stream.h
+++ b/include/lomse_zip_stream.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -121,11 +121,11 @@ public:
 	virtual ~ZipInputStream();
 
     //mandatory overrides inherited from InputStream
-    char get_char();
-    void unget();
-    bool is_open();
-    bool eof();
-    long read(unsigned char* pDestBuffer, long nBytesToRead);
+    char get_char() override;
+    void unget() override;
+    bool is_open() override;
+    bool eof() override;
+    long read(unsigned char* pDestBuffer, long nBytesToRead) override;
 
     //operations
     unsigned char* get_as_string();

--- a/include/private/lomse_document_p.h
+++ b/include/private/lomse_document_p.h
@@ -596,9 +596,9 @@ public:
         this Observable object. For %Document class the EventNotifier is itself, so
         this method returns the <i>this</i> pointer.
     */
-    EventNotifier* get_event_notifier() { return this; }
+    EventNotifier* get_event_notifier() override { return this; }
 
-    Observable* get_observable_child(int childType, ImoId childId);
+    Observable* get_observable_child(int childType, ImoId childId) override;
 
 
     //internal model and ID management

--- a/include/private/lomse_internal_model_p.h
+++ b/include/private/lomse_internal_model_p.h
@@ -1341,7 +1341,7 @@ public:
     }
 
     //required by Visitable parent class
-    virtual void accept_visitor(BaseVisitor& v);
+    virtual void accept_visitor(BaseVisitor& v) override;
     virtual bool has_visitable_children()
     {
         return has_children();
@@ -2355,12 +2355,12 @@ public:
     ImoAuxObj* find_attachment(int type);
 
     //overrides for Observable children
-    EventNotifier* get_event_notifier();
-    void add_event_handler(int eventType, EventHandler* pHandler);
+    EventNotifier* get_event_notifier() override;
+    void add_event_handler(int eventType, EventHandler* pHandler) override;
     void add_event_handler(int eventType, void* pThis,
-                           void (*pt2Func)(void* pObj, SpEventInfo event) );
+                           void (*pt2Func)(void* pObj, SpEventInfo event) ) override;
     void add_event_handler(int eventType,
-                           void (*pt2Func)(SpEventInfo event) );
+                           void (*pt2Func)(SpEventInfo event) ) override;
 
     //style
     virtual ImoStyle* get_style(bool fInherit=true);
@@ -2388,15 +2388,15 @@ public:
     }
 
     //IM attributes interface
-    void set_int_attribute(TIntAttribute attrib, int value);
-    int get_int_attribute(TIntAttribute attrib);
-    void set_bool_attribute(TIntAttribute attrib, bool value);
-    bool get_bool_attribute(TIntAttribute attrib);
-    void set_double_attribute(TIntAttribute attrib, double value);
-    double get_double_attribute(TIntAttribute attrib);
-    void set_string_attribute(TIntAttribute attrib, const std::string& value);
-    std::string get_string_attribute(TIntAttribute attrib);
-    list<TIntAttribute> get_supported_attributes();
+    void set_int_attribute(TIntAttribute attrib, int value) override;
+    int get_int_attribute(TIntAttribute attrib) override;
+    void set_bool_attribute(TIntAttribute attrib, bool value) override;
+    bool get_bool_attribute(TIntAttribute attrib) override;
+    void set_double_attribute(TIntAttribute attrib, double value) override;
+    double get_double_attribute(TIntAttribute attrib) override;
+    void set_string_attribute(TIntAttribute attrib, const std::string& value) override;
+    std::string get_string_attribute(TIntAttribute attrib) override;
+    list<TIntAttribute> get_supported_attributes() override;
 
 };
 
@@ -2438,11 +2438,8 @@ public:
     virtual ~ImoRelations();
 
     //overrides, to traverse this special node
-    void accept_visitor(BaseVisitor& v);
-    bool has_visitable_children()
-    {
-        return get_num_items() > 0;
-    }
+    void accept_visitor(BaseVisitor& v) override;
+    bool has_visitable_children() override { return get_num_items() > 0; }
 
     //contents
     ImoRelObj* get_item(int iItem);   //iItem = 0..n-1
@@ -2706,11 +2703,11 @@ public:
     inline void set_color(Color color) { m_color = color; }
 
     //IM attributes interface
-    void set_int_attribute(TIntAttribute attrib, int value);
-    int get_int_attribute(TIntAttribute attrib);
-    void set_color_attribute(TIntAttribute attrib, Color value);
-    Color get_color_attribute(TIntAttribute attrib);
-    list<TIntAttribute> get_supported_attributes();
+    void set_int_attribute(TIntAttribute attrib, int value) override;
+    int get_int_attribute(TIntAttribute attrib) override;
+    void set_color_attribute(TIntAttribute attrib, Color value) override;
+    Color get_color_attribute(TIntAttribute attrib) override;
+    list<TIntAttribute> get_supported_attributes() override;
 
 
 };
@@ -2761,9 +2758,9 @@ public:
     ImoScore* get_score();
 
     //IM attributes interface
-    virtual void set_int_attribute(TIntAttribute attrib, int value);
-    virtual int get_int_attribute(TIntAttribute attrib);
-    virtual list<TIntAttribute> get_supported_attributes();
+    virtual void set_int_attribute(TIntAttribute attrib, int value) override;
+    virtual int get_int_attribute(TIntAttribute attrib) override;
+    virtual list<TIntAttribute> get_supported_attributes() override;
 
 };
 
@@ -3665,7 +3662,7 @@ public:
     virtual ~ImoAnonymousBlock() {}
 
     //required by Visitable parent class
-    virtual void accept_visitor(BaseVisitor& v);
+    virtual void accept_visitor(BaseVisitor& v) override;
 };
 
 //---------------------------------------------------------------------------------------
@@ -3720,12 +3717,12 @@ public:
     inline void set_measure_info(TypeMeasureInfo* pInfo) { m_pMeasureInfo = pInfo; }
 
     //overrides: barlines always in staff 0
-    void set_staff(int UNUSED(staff)) { m_staff = 0; }
+    void set_staff(int UNUSED(staff)) override { m_staff = 0; }
 
     //IM attributes interface
-    virtual void set_int_attribute(TIntAttribute attrib, int value);
-    virtual int get_int_attribute(TIntAttribute attrib);
-    virtual list<TIntAttribute> get_supported_attributes();
+    virtual void set_int_attribute(TIntAttribute attrib, int value) override;
+    virtual int get_int_attribute(TIntAttribute attrib) override;
+    virtual list<TIntAttribute> get_supported_attributes() override;
 
 };
 
@@ -3966,10 +3963,7 @@ public:
     }
 
     //properties
-    bool can_generate_secondary_shapes()
-    {
-        return true;
-    }
+    bool can_generate_secondary_shapes() override { return true; }
 
 };
 
@@ -5152,16 +5146,10 @@ public:
     void transpose(const int semitones);
 
     //overrides: key signatures always in staff 0
-    void set_staff(int UNUSED(staff))
-    {
-        m_staff = 0;
-    }
+    void set_staff(int UNUSED(staff)) override { m_staff = 0; }
 
     //properties
-    bool can_generate_secondary_shapes()
-    {
-        return true;
-    }
+    bool can_generate_secondary_shapes() override { return true; }
 
 };
 
@@ -5488,7 +5476,7 @@ public:
     virtual ~ImoParagraph() {}
 
     //required by Visitable parent class
-    virtual void accept_visitor(BaseVisitor& v);
+    virtual void accept_visitor(BaseVisitor& v) override;
 };
 
 //---------------------------------------------------------------------------------------
@@ -5555,7 +5543,7 @@ public:
     }
 
     //required by Visitable parent class
-    virtual void accept_visitor(BaseVisitor& v);
+    virtual void accept_visitor(BaseVisitor& v) override;
 
 };
 
@@ -5893,7 +5881,7 @@ public:
     SoundEventsTable* get_midi_table();
 
     //required by Visitable parent class
-    void accept_visitor(BaseVisitor& v);
+    void accept_visitor(BaseVisitor& v) override;
 
     //instruments
     void add_instrument(ImoInstrument* pInstr, const std::string& partId="");
@@ -6289,11 +6277,8 @@ public:
     virtual ~ImoStyles();
 
     //overrides, to traverse this special node
-    void accept_visitor(BaseVisitor& v);
-    bool has_visitable_children()
-    {
-        return m_nameToStyle.size() > 0;
-    }
+    void accept_visitor(BaseVisitor& v) override;
+    bool has_visitable_children() override { return m_nameToStyle.size() > 0; }
 
     //styles
     void add_style(ImoStyle* pStyle);
@@ -6774,16 +6759,10 @@ public:
     }
 
     //overrides: time signatures always in staff 0
-    void set_staff(int UNUSED(staff))
-    {
-        m_staff = 0;
-    }
+    void set_staff(int UNUSED(staff)) override { m_staff = 0; }
 
     //properties
-    bool can_generate_secondary_shapes()
-    {
-        return true;
-    }
+    bool can_generate_secondary_shapes() override { return true; }
 
     //other
     bool is_compound_meter();

--- a/src/document/lomse_document.cpp
+++ b/src/document/lomse_document.cpp
@@ -93,7 +93,7 @@ public:
     int num_out_nodes() { return m_nodesOut; }
     int max_depth() { return m_maxDepth; }
 
-    void start_visit(ImoObj* pImo)
+    void start_visit(ImoObj* pImo) override
     {
         int type = pImo->get_obj_type();
         const string& name = pImo->get_name();
@@ -115,7 +115,7 @@ public:
             m_maxDepth = m_indent;
     }
 
-	void end_visit(ImoObj* pImo)
+	void end_visit(ImoObj* pImo) override
     {
         m_indent--;
         m_nodesOut++;

--- a/src/exporters/lomse_ldp_exporter.cpp
+++ b/src/exporters/lomse_ldp_exporter.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -128,7 +128,7 @@ public:
         //m_pObj = static_cast<ImoXXXXX*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         //start_element("xxxxx", m_pObj->get_id());
         end_element();
@@ -149,7 +149,7 @@ public:
         m_pObj = static_cast<ImoArticulationSymbol*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         start_articulation();
         if (m_pObj->is_accent() || m_pObj->is_stress())
@@ -326,7 +326,7 @@ public:
         m_pObj = static_cast<ImoBarline*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         start_element("barline", m_pObj->get_id());
         add_barline_type_and_middle();
@@ -375,7 +375,7 @@ public:
     {
     }
 
-    string generate_source(ImoObj* pParent=nullptr)
+    string generate_source(ImoObj* pParent=nullptr) override
     {
         m_pNR = static_cast<ImoNoteRest*>( pParent );
 
@@ -461,7 +461,7 @@ public:
         m_pObj = static_cast<ImoClef*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         start_element("clef", m_pObj->get_id());
         add_type();
@@ -511,7 +511,7 @@ public:
         m_pObj = static_cast<ImoContentObj*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         add_user_location();
         add_attachments();
@@ -587,7 +587,7 @@ public:
         m_pObj = static_cast<ImoStyle*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         start_element("defineStyle", k_no_imoid, k_in_new_line);
         add_name();
@@ -865,7 +865,7 @@ public:
         m_pObj = static_cast<ImoDirection*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         if (m_pObj->has_attachments() || m_pObj->get_num_relations() > 0)
             start_element("dir", m_pObj->get_id());
@@ -918,7 +918,7 @@ public:
         m_pObj = static_cast<ImoDynamicsMark*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         start_element("dyn", m_pObj->get_id());
         add_dynamics_string();
@@ -951,7 +951,7 @@ public:
     {
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         start_element("TODO: ", m_pImo->get_id());
         m_source << " No LdpGenerator for Imo. Imo name=" << m_pImo->get_name()
@@ -974,7 +974,7 @@ public:
         m_pObj = static_cast<ImoFermata*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         start_element("fermata", m_pObj->get_id());
         add_symbol();
@@ -1029,7 +1029,7 @@ public:
         m_pObj = pImo;
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         return m_source.str();
     }
@@ -1049,7 +1049,7 @@ public:
 
     //TODO: This exporter must generate 2.0 code. Therefore, it is invalid to generate
     // goBack. Instead must convert it to 2.0
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         empty_line();
         bool fFwd = m_pObj->is_forward();
@@ -1091,7 +1091,7 @@ public:
         m_pObj = static_cast<ImoInstrument*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         start_element("instrument", m_pObj->get_id());
         add_part_id();
@@ -1270,7 +1270,7 @@ public:
         m_pObj = static_cast<ImoKeySignature*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         start_element("key", m_pObj->get_id());
 
@@ -1304,7 +1304,7 @@ public:
         m_pObj = static_cast<ImoDocument*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         start_element("lenmusdoc", m_pObj->get_id());
         m_source << " ";
@@ -1368,7 +1368,7 @@ public:
         m_pObj = static_cast<ImoLyric*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         start_element("lyric", m_pObj->get_id());
         add_lyric_number();
@@ -1429,7 +1429,7 @@ public:
         m_pScore = pExporter->get_current_score();
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         start_element("musicData", m_pObj->get_id());
         space_needed();
@@ -1773,7 +1773,7 @@ public:
         m_pImo = static_cast<ImoMetronomeMark*>( pImo );
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         start_element("metronome", m_pImo->get_id());
         add_marks();
@@ -1839,7 +1839,7 @@ public:
         m_pObj = static_cast<ImoNote*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         if (m_pObj->is_start_of_chord())
         {
@@ -2001,7 +2001,7 @@ public:
         m_pObj = static_cast<ImoScoreObj*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         add_user_location();
         add_visible( m_pObj->is_visible() );
@@ -2041,7 +2041,7 @@ public:
         m_pObj = static_cast<ImoRest*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         if (is_rest())
             generate_rest();
@@ -2101,7 +2101,7 @@ public:
         m_pObj = static_cast<ImoScoreLine*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         start_element("line", m_pObj->get_id());
         add_start_point();
@@ -2215,7 +2215,7 @@ public:
         m_pObj = static_cast<ImoScoreObj*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         add_visible( m_pObj->is_visible() );
         add_color_if_not_black( m_pObj->get_color() );
@@ -2237,7 +2237,7 @@ public:
         m_pObj = static_cast<ImoScoreText*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         start_element("text", m_pObj->get_id());
         add_text();
@@ -2273,7 +2273,7 @@ public:
     {
     }
 
-    string generate_source(ImoObj* pParent =nullptr)
+    string generate_source(ImoObj* pParent =nullptr) override
     {
         m_pNote = static_cast<ImoNote*>( pParent );
 
@@ -2355,7 +2355,7 @@ public:
         m_pObj = static_cast<ImoStaffObj*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         add_staff_num();
         add_relobjs();
@@ -2423,7 +2423,7 @@ public:
         m_pObj = static_cast<ImoStaffObj*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         add_staff_num();
         source_for_print_options(m_pObj);
@@ -2460,7 +2460,7 @@ public:
         m_pImo = static_cast<ImoSystemBreak*>( pImo );
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         start_element("newSystem", m_pImo->get_id());
         end_element(k_in_same_line);
@@ -2483,7 +2483,7 @@ public:
     {
     }
 
-    string generate_source(ImoObj* pParent=nullptr)
+    string generate_source(ImoObj* pParent=nullptr) override
     {
         m_pNote = static_cast<ImoNote*>( pParent );
 
@@ -2565,7 +2565,7 @@ public:
         m_pObj = static_cast<ImoTimeSignature*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         start_element("time", m_pObj->get_id());
         add_content();
@@ -2607,7 +2607,7 @@ public:
         m_pObj = static_cast<ImoScoreTitle*>(pImo);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         start_element("title", m_pObj->get_id());
         add_text();
@@ -2642,7 +2642,7 @@ public:
     {
     }
 
-    string generate_source(ImoObj* pParent=nullptr)
+    string generate_source(ImoObj* pParent=nullptr) override
     {
         m_pNR = static_cast<ImoNoteRest*>( pParent );
 
@@ -2754,7 +2754,7 @@ public:
         pExporter->set_current_score(m_pObj);
     }
 
-    string generate_source(ImoObj* UNUSED(pParent) =nullptr)
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
     {
         //TODO: commented elements
 

--- a/src/exporters/lomse_lmd_exporter.cpp
+++ b/src/exporters/lomse_lmd_exporter.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -111,7 +111,7 @@ public:
         //m_pObj = static_cast<ImoXXXXX*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         //start_element("xxxxx", m_pObj);
         close_start_tag();
@@ -133,7 +133,7 @@ public:
         m_pObj = static_cast<ImoBarline*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("barline", m_pObj);
         close_start_tag();
@@ -165,7 +165,7 @@ public:
         m_pObj = static_cast<ImoClef*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("clef", m_pObj);
         close_start_tag();
@@ -197,7 +197,7 @@ public:
         m_pObj = static_cast<ImoContent*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("content", m_pObj);
         add_optional_style(m_pObj);
@@ -235,7 +235,7 @@ public:
         m_pObj = static_cast<ImoControl*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("control", m_pObj);
         add_optional_style(m_pObj);
@@ -274,7 +274,7 @@ public:
         m_pObj = static_cast<ImoContentObj*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         add_user_location();
         add_attachments();
@@ -364,7 +364,7 @@ public:
         m_pObj = static_cast<ImoStyle*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("defineStyle", m_pObj);
         close_start_tag();
@@ -661,7 +661,7 @@ public:
         m_pObj = static_cast<ImoDynamic*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("dynamic", m_pObj);
         add_optional_style(m_pObj);
@@ -700,7 +700,7 @@ public:
     {
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("TODO", m_pImo);
         close_start_tag();
@@ -725,7 +725,7 @@ public:
         m_pObj = pImo;
     }
 
-    string generate_source()
+    string generate_source() override
     {
         return m_source.str();
     }
@@ -744,7 +744,7 @@ public:
         m_pObj = static_cast<ImoInstrument*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("instrument", m_pObj);
         close_start_tag();
@@ -808,7 +808,7 @@ public:
         m_pObj = static_cast<ImoKeySignature*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("key", m_pObj);
         close_start_tag();
@@ -873,7 +873,7 @@ public:
         m_pObj = static_cast<ImoDocument*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         m_source << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
         start_element("lenmusdoc", m_pObj);
@@ -942,7 +942,7 @@ public:
         m_pObj = static_cast<ImoMusicData*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("musicData", m_pObj);
         close_start_tag();
@@ -1079,7 +1079,7 @@ public:
         m_pObj = static_cast<ImoNote*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("note", m_pObj);
         close_start_tag();
@@ -1144,7 +1144,7 @@ public:
         m_pObj = static_cast<ImoParagraph*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("para", m_pObj);
         add_optional_style(m_pObj);
@@ -1185,7 +1185,7 @@ public:
         m_pObj = static_cast<ImoRest*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("rest", m_pObj);
         close_start_tag();
@@ -1210,7 +1210,7 @@ public:
         m_pObj = static_cast<ImoScore*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         int format = m_pExporter->get_score_format();
         switch(format)
@@ -1441,7 +1441,7 @@ public:
         m_pObj = static_cast<ImoScoreObj*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         add_visible();
         add_color();
@@ -1479,7 +1479,7 @@ public:
         m_pObj = static_cast<ImoHeading*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("section", m_pObj);
         add_level();
@@ -1524,7 +1524,7 @@ public:
         m_pObj = static_cast<ImoDirection*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("spacer", m_pObj);
         close_start_tag();
@@ -1547,7 +1547,7 @@ public:
         m_pObj = static_cast<ImoStaffObj*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         add_staff_num();
         source_for_base_scoreobj(m_pObj);
@@ -1586,7 +1586,7 @@ public:
         m_pObj = static_cast<ImoStyles*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         if (there_is_any_non_default_style())
         {

--- a/src/exporters/lomse_mnx_exporter.cpp
+++ b/src/exporters/lomse_mnx_exporter.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -110,7 +110,7 @@ public:
         //m_pObj = static_cast<ImoXXXXX*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         //start_element("xxxxx", m_pObj);
         close_start_tag();
@@ -132,7 +132,7 @@ public:
         m_pObj = static_cast<ImoBarline*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("barline", m_pObj);
         close_start_tag();
@@ -164,7 +164,7 @@ public:
         m_pObj = static_cast<ImoClef*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         if (m_pExporter->current_open_tag() != "directions")
         {
@@ -207,7 +207,7 @@ public:
         m_pObj = static_cast<ImoContentObj*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         add_user_location();
         add_attachments();
@@ -297,7 +297,7 @@ public:
         m_pObj = static_cast<ImoStyle*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("defineStyle", m_pObj);
         close_start_tag();
@@ -595,7 +595,7 @@ public:
     {
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("TODO", m_pImo);
         close_start_tag();
@@ -620,7 +620,7 @@ public:
         m_pObj = pImo;
     }
 
-    string generate_source()
+    string generate_source() override
     {
         return m_source.str();
     }
@@ -639,7 +639,7 @@ public:
         m_pObj = static_cast<ImoInstrument*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("part", m_pObj);
         close_start_tag();
@@ -704,7 +704,7 @@ public:
         m_pObj = static_cast<ImoKeySignature*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("key", m_pObj);
         close_start_tag();
@@ -769,7 +769,7 @@ public:
         m_pObj = static_cast<ImoDocument*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         m_source << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
         add_comment();
@@ -841,7 +841,7 @@ public:
         m_pObj = static_cast<ImoMusicData*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         add_staffobjs();
         empty_line();
@@ -990,7 +990,7 @@ public:
         m_pObj = static_cast<ImoNote*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         if (m_pExporter->current_open_tag() == "directions")
             end_element();
@@ -1083,7 +1083,7 @@ public:
         m_pObj = static_cast<ImoRest*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         if (m_pExporter->current_open_tag() == "directions")
             end_element();
@@ -1123,7 +1123,7 @@ public:
         m_pObj = static_cast<ImoScore*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("score", m_pObj);
         close_start_tag();
@@ -1273,7 +1273,7 @@ public:
         m_pObj = static_cast<ImoScoreObj*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         add_visible();
         add_color();
@@ -1311,7 +1311,7 @@ public:
         m_pObj = static_cast<ImoDirection*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         start_element("spacer", m_pObj);
         close_start_tag();
@@ -1334,7 +1334,7 @@ public:
         m_pObj = static_cast<ImoStaffObj*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         add_staff_num();
         source_for_base_scoreobj(m_pObj);
@@ -1373,7 +1373,7 @@ public:
         m_pObj = static_cast<ImoStyles*>(pImo);
     }
 
-    string generate_source()
+    string generate_source() override
     {
         if (there_is_any_non_default_style())
         {

--- a/src/internal_model/lomse_model_builder.cpp
+++ b/src/internal_model/lomse_model_builder.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -69,10 +69,10 @@ public:
     }
 	virtual ~VisitorForStructurizables() {}
 
-    void start_visit(ImoScore* pImo) { m_builder->structurize(pImo); }
+    void start_visit(ImoScore* pImo) override { m_builder->structurize(pImo); }
     //void start_visit(ImoOtherStructurizable* pImo) { m_builder->structurize(pImo); }
 
-	void end_visit(ImoScore* UNUSED(pImo)) {}
+	void end_visit(ImoScore* UNUSED(pImo)) override {}
     //void end_visit(ImoOtherStructurizable* pImo) {}
 
 };

--- a/src/parser/ldp/lomse_ldp_analyser.cpp
+++ b/src/parser/ldp/lomse_ldp_analyser.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -780,7 +780,7 @@ public:
     NullAnalyser(LdpAnalyser* pAnalyser, ostream& reporter, LibraryScope& libraryScope)
         : ElementAnalyser(pAnalyser, reporter, libraryScope) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         string name = m_pLdpFactory->get_name( m_pAnalysedNode->get_type() );
         m_reporter << "Missing analyser for element '" << name << "'. Node ignored." << endl;
@@ -801,7 +801,7 @@ public:
                        ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoLineStyle* pLine = static_cast<ImoLineStyle*>(
@@ -862,7 +862,7 @@ public:
                          LibraryScope& libraryScope, ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoArticulationSymbol* pImo = static_cast<ImoArticulationSymbol*>(
@@ -929,7 +929,7 @@ public:
                     ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoBarline* pBarline = static_cast<ImoBarline*>(
@@ -1032,7 +1032,7 @@ public:
                     ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoBeamDto* pInfo = static_cast<ImoBeamDto*>(
@@ -1104,7 +1104,7 @@ public:
                    ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoBezierInfo* pBezier = static_cast<ImoBezierInfo*>(
@@ -1166,7 +1166,7 @@ public:
                    ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         ImoBorderDto* border = LOMSE_NEW ImoBorderDto();
 
@@ -1215,7 +1215,7 @@ public:
                          LibraryScope& libraryScope, ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoArticulationSymbol* pImo = static_cast<ImoArticulationSymbol*>(
@@ -1298,7 +1298,7 @@ public:
                   ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoChord* pChord = static_cast<ImoChord*>(
@@ -1357,7 +1357,7 @@ public:
                  ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoClef* pClef = static_cast<ImoClef*>(
@@ -1429,7 +1429,7 @@ public:
     ColorAnalyser(LdpAnalyser* pAnalyser, ostream& reporter, LibraryScope& libraryScope)
         : ElementAnalyser(pAnalyser, reporter, libraryScope) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
 
         if (!get_optional(k_label) || !set_color())
@@ -1465,7 +1465,7 @@ public:
                     ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoContent* pContent = static_cast<ImoContent*>(
@@ -1509,7 +1509,7 @@ public:
                     ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoSystemBreak* pCtrl = static_cast<ImoSystemBreak*>(
@@ -1533,7 +1533,7 @@ public:
                    ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoCursorInfo* pCursor = static_cast<ImoCursorInfo*>(
@@ -1585,7 +1585,7 @@ public:
                         ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         ImoStyle* pStyle;
         string name;
@@ -1869,7 +1869,7 @@ public:
                       LibraryScope& libraryScope, ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoDirection* pDir = static_cast<ImoDirection*>(
@@ -1927,7 +1927,7 @@ public:
                      ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoDynamic* pDyn = static_cast<ImoDynamic*>(
@@ -1970,7 +1970,7 @@ public:
                      ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         // <string>
         if (!get_mandatory(k_string))
@@ -2055,7 +2055,7 @@ public:
                     ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoFermata* pImo = static_cast<ImoFermata*>(
@@ -2207,7 +2207,7 @@ public:
                         ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
 
         // <figuredBassSymbols> (string)
@@ -2327,7 +2327,7 @@ public:
                  ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         ImoFontStyleDto* pFont = LOMSE_NEW ImoFontStyleDto();
 
@@ -2405,7 +2405,7 @@ public:
                       ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         if (m_pAnalyser->get_score_version() < 200)
             do_analysis_v1();
@@ -2603,7 +2603,7 @@ public:
                     ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         // "line"
         if (get_optional(k_label))
@@ -2662,7 +2662,7 @@ public:
                   ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         ImoScore* pScore = m_pAnalyser->get_score_being_analysed();
 
@@ -2775,7 +2775,7 @@ public:
                     ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         // <level> (num)
         if (get_mandatory(k_number))
@@ -2811,7 +2811,7 @@ public:
                   ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoImage* pImg = static_cast<ImoImage*>(
@@ -2854,7 +2854,7 @@ public:
                        ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoSoundInfo* pInfo = static_cast<ImoSoundInfo*>(
@@ -2920,7 +2920,7 @@ public:
                        ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         m_pAnalyser->clear_pending_relations();
         m_pAnalyser->reset_defaults_for_instrument();
@@ -3054,7 +3054,7 @@ public:
                          ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoKeySignature* pKey = static_cast<ImoKeySignature*>(
@@ -3098,7 +3098,7 @@ public:
     LanguageAnalyser(LdpAnalyser* pAnalyser, ostream& reporter, LibraryScope& libraryScope)
         : ElementAnalyser(pAnalyser, reporter, libraryScope) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
     }
 };
@@ -3113,7 +3113,7 @@ public:
     LenmusdocAnalyser(LdpAnalyser* pAnalyser, ostream& reporter, LibraryScope& libraryScope)
         : ElementAnalyser(pAnalyser, reporter, libraryScope) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         ImoDocument* pImoDoc = nullptr;
 
@@ -3209,7 +3209,7 @@ public:
                  ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoScoreLine* pLine = static_cast<ImoScoreLine*>(
@@ -3263,7 +3263,7 @@ public:
                  ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoLink* pLink = static_cast<ImoLink*>(
@@ -3312,7 +3312,7 @@ public:
                  ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         ELdpElement type = m_pAnalysedNode->get_type();
 
@@ -3343,7 +3343,7 @@ public:
                      ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoListItem* pListItem = static_cast<ImoListItem*>(
@@ -3374,7 +3374,7 @@ public:
                   ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         ImoNote* pNote = nullptr;
         if (m_pAnchor && m_pAnchor->is_note())
@@ -3514,7 +3514,7 @@ public:
                       ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoMetronomeMark* pMtr = static_cast<ImoMetronomeMark*>(
@@ -3606,7 +3606,7 @@ public:
                       ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoMusicData* pMD = static_cast<ImoMusicData*>(
@@ -3706,7 +3706,7 @@ public:
     {
     }
 
-    void do_analysis()
+    void do_analysis() override
     {
         bool fIsRest = m_pAnalysedNode->is_type(k_rest);
         bool fInChord = !fIsRest && m_pAnalysedNode->is_type(k_na);
@@ -4209,7 +4209,7 @@ public:
                 ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         // <name> (label)
         string name;
@@ -4378,7 +4378,7 @@ public:
                        ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoPageInfo* pInfo = static_cast<ImoPageInfo*>(
@@ -4435,7 +4435,7 @@ public:
                         ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         //Document* pDoc = m_pAnalyser->get_document_being_analysed();
         //ImoPageInfo dto;
@@ -4480,7 +4480,7 @@ public:
                      ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         //Document* pDoc = m_pAnalyser->get_document_being_analysed();
         //ImoPageInfo dto;
@@ -4511,7 +4511,7 @@ public:
                     ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoParagraph* pPara = static_cast<ImoParagraph*>(
@@ -4538,7 +4538,7 @@ public:
                     ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         string name;
         string value = "";
@@ -4584,7 +4584,7 @@ public:
                   ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         ImoScore* pScore = m_pAnalyser->get_score_being_analysed();
 
@@ -4638,7 +4638,7 @@ public:
                   ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         //Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoPointDto point;
@@ -4667,7 +4667,7 @@ public:
                      ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         // [<cursor>]
         analyse_optional(k_cursor, m_pAnchor);
@@ -4691,7 +4691,7 @@ public:
                   ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoScore* pScore = static_cast<ImoScore*>(
@@ -4825,7 +4825,7 @@ public:
                         ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoScorePlayer* pSP = static_cast<ImoScorePlayer*>(
@@ -4879,7 +4879,7 @@ public:
                  ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         //Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoSizeDto size;
@@ -4914,7 +4914,7 @@ public:
                 ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         ImoSlurDto* pInfo = LOMSE_NEW ImoSlurDto();
         pInfo->set_id( get_node_id() );
@@ -4972,7 +4972,7 @@ public:
                    ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoDirection* pSpacer = static_cast<ImoDirection*>(
@@ -5024,7 +5024,7 @@ public:
                   ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoStaffInfo* pInfo = static_cast<ImoStaffInfo*>(
@@ -5124,7 +5124,7 @@ public:
                    ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoStyles* pStyles = static_cast<ImoStyles*>(
@@ -5150,7 +5150,7 @@ public:
                          ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoSystemInfo* pInfo = static_cast<ImoSystemInfo*>(
@@ -5195,7 +5195,7 @@ public:
                           ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         ImoSystemInfo* pDto;
         if (m_pAnchor && m_pAnchor->is_system_info())
@@ -5231,7 +5231,7 @@ public:
                   ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoTable* pTable= static_cast<ImoTable*>(
@@ -5266,7 +5266,7 @@ public:
                       ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoTableBody* pBody = static_cast<ImoTableBody*>(
@@ -5296,7 +5296,7 @@ public:
                       ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoTableCell* pImo = static_cast<ImoTableCell*>(
@@ -5338,7 +5338,7 @@ public:
                         LibraryScope& libraryScope, ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         // <style>
         if (get_optional(k_style) && m_pAnchor->is_table())
@@ -5364,7 +5364,7 @@ public:
                       ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoTableHead* pHead = static_cast<ImoTableHead*>(
@@ -5391,7 +5391,7 @@ public:
                      ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoTableRow* pRow = static_cast<ImoTableRow*>(
@@ -5443,7 +5443,7 @@ public:
                     ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoTextBlockInfo box;
@@ -5535,7 +5535,7 @@ public:
     {
     }
 
-    void do_analysis()
+    void do_analysis() override
     {
         string styleName = "Default style";
 
@@ -5611,7 +5611,7 @@ public:
     {
     }
 
-    void do_analysis()
+    void do_analysis() override
     {
         // <string>
         if (get_mandatory(k_string))
@@ -5675,7 +5675,7 @@ public:
                 ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         //AWARE: ImoTieDto will be discarded. So no ID will be assigned to avoid
         //problems with undo/redo
@@ -5731,7 +5731,7 @@ public:
                           ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoTimeModificationDto* pTime = static_cast<ImoTimeModificationDto*>(
@@ -5787,7 +5787,7 @@ public:
                           ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoTimeSignature* pTime = static_cast<ImoTimeSignature*>(
@@ -5882,7 +5882,7 @@ public:
                   ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         // [<h-align>]
         int nAlignment = k_halign_left;
@@ -5954,7 +5954,7 @@ public:
                    ImoObj* pAnchor)
         : ElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    void do_analysis()
+    void do_analysis() override
     {
         ImoTupletDto* pInfo = LOMSE_NEW ImoTupletDto();
         pInfo->set_id( get_node_id() );

--- a/src/parser/lmd/lomse_lmd_analyser.cpp
+++ b/src/parser/lmd/lomse_lmd_analyser.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -828,7 +828,7 @@ public:
         {
         }
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         cout << "Missing analyser for element '" << m_tag << "'. Node ignored." << endl;
         return nullptr;
@@ -849,7 +849,7 @@ public:
                        ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoLineStyle* pLine = static_cast<ImoLineStyle*>(
@@ -902,7 +902,7 @@ public:
                     ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoBarline* pBarline = static_cast<ImoBarline*>(
@@ -982,7 +982,7 @@ public:
                     ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoBeamDto* pInfo = static_cast<ImoBeamDto*>(
@@ -1053,7 +1053,7 @@ public:
                    ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoBezierInfo* pBezier = static_cast<ImoBezierInfo*>(
@@ -1116,7 +1116,7 @@ public:
                    ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoBorderDto* border = LOMSE_NEW ImoBorderDto();
 
@@ -1161,7 +1161,7 @@ public:
                   ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoChord* pChord = static_cast<ImoChord*>( ImFactory::inject(k_imo_chord, pDoc) );
@@ -1215,7 +1215,7 @@ public:
                  ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoClef* pClef = static_cast<ImoClef*>(
@@ -1285,7 +1285,7 @@ public:
     ColorLmdAnalyser(LmdAnalyser* pAnalyser, ostream& reporter, LibraryScope& libraryScope)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         string value = m_analysedNode.value();
         ImoColorDto* pColor = LOMSE_NEW ImoColorDto();
@@ -1308,7 +1308,7 @@ public:
                     ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoContent* pContent = static_cast<ImoContent*>(
@@ -1356,7 +1356,7 @@ public:
                     ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoSystemBreak* pCtrl = static_cast<ImoSystemBreak*>(
@@ -1381,7 +1381,7 @@ public:
                    ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoCursorInfo* pCursor = static_cast<ImoCursorInfo*>(
@@ -1416,7 +1416,7 @@ public:
                         ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoStyle* pStyle;
         string name;
@@ -1697,7 +1697,7 @@ public:
                      ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         // <classid>
         if (!has_attribute("classid"))
@@ -1739,7 +1739,7 @@ public:
                     ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoFermata* pImo = static_cast<ImoFermata*>(
@@ -1814,7 +1814,7 @@ public:
                         ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
 
         // <figuredBassSymbols> (string)
@@ -1937,7 +1937,7 @@ public:
                  ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoFontStyleDto* pFont = LOMSE_NEW ImoFontStyleDto();
 
@@ -2012,7 +2012,7 @@ public:
                       ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoGoBackFwd* pImo = static_cast<ImoGoBackFwd*>(
@@ -2115,7 +2115,7 @@ public:
                     ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         // "line"
         if (get_optional(k_label))
@@ -2179,7 +2179,7 @@ public:
                   ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoScore* pScore = m_pAnalyser->get_score_being_analysed();
 
@@ -2301,7 +2301,7 @@ public:
                   ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoImage* pImg = static_cast<ImoImage*>( ImFactory::inject(k_imo_image, pDoc) );
@@ -2342,7 +2342,7 @@ public:
                        ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoSoundInfo* pInfo = static_cast<ImoSoundInfo*>(
@@ -2409,7 +2409,7 @@ public:
                        ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         m_pAnalyser->clear_pending_relations();
 
@@ -2546,7 +2546,7 @@ public:
                          ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoKeySignature* pKey = static_cast<ImoKeySignature*>(
@@ -2588,7 +2588,7 @@ public:
                         ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         string src = m_analysedNode.value();
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
@@ -2613,7 +2613,7 @@ public:
     LenmusdocLmdAnalyser(LmdAnalyser* pAnalyser, ostream& reporter, LibraryScope& libraryScope)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoDocument* pImoDoc = nullptr;
 
@@ -2697,7 +2697,7 @@ public:
                  ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoScoreLine* pLine = static_cast<ImoScoreLine*>(
@@ -2756,7 +2756,7 @@ public:
                  ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoLink* pLink = static_cast<ImoLink*>(
@@ -2796,7 +2796,7 @@ public:
                  ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         string type = m_analysedNode.name();
 
@@ -2829,7 +2829,7 @@ public:
                      ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoListItem* pListItem = static_cast<ImoListItem*>(
@@ -2865,7 +2865,7 @@ public:
                       ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoMetronomeMark* pMtr = static_cast<ImoMetronomeMark*>(
@@ -2954,7 +2954,7 @@ public:
                       ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoMusicData* pMD = static_cast<ImoMusicData*>(
@@ -3033,7 +3033,7 @@ public:
     {
     }
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         bool fIsRest = is_type(&m_analysedNode, k_rest);
         bool fInChord = !fIsRest && is_type(&m_analysedNode, k_na);
@@ -3559,7 +3559,7 @@ public:
                 ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoOptionInfo* pOpt = nullptr;
 
@@ -3732,7 +3732,7 @@ public:
                        ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoPageInfo* pInfo = static_cast<ImoPageInfo*>(
@@ -3790,7 +3790,7 @@ public:
                         ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         //Document* pDoc = m_pAnalyser->get_document_being_analysed();
         //ImoPageInfo dto;
@@ -3836,7 +3836,7 @@ public:
                      ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         //Document* pDoc = m_pAnalyser->get_document_being_analysed();
         //ImoPageInfo dto;
@@ -3883,7 +3883,7 @@ public:
                     ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoParagraph* pPara = static_cast<ImoParagraph*>(
@@ -3911,7 +3911,7 @@ public:
                     ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         if (!has_attribute("name"))
         {
@@ -3942,7 +3942,7 @@ public:
                      ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoScore* pScore = m_pAnalyser->get_score_being_analysed();
 
@@ -3996,7 +3996,7 @@ public:
                   ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         //Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoPointDto point;
@@ -4025,7 +4025,7 @@ public:
                     ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         // <level> (num)
         int level;
@@ -4065,7 +4065,7 @@ public:
                      ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         //TODO all
 
@@ -4095,7 +4095,7 @@ public:
                   ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoScore* pScore = static_cast<ImoScore*>(ImFactory::inject(k_imo_score, pDoc));
@@ -4232,7 +4232,7 @@ public:
                         ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoScorePlayer* pSP = static_cast<ImoScorePlayer*>(
@@ -4277,7 +4277,7 @@ public:
                  ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         //Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoSizeDto size;
@@ -4314,7 +4314,7 @@ public:
                 ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         //Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoSlurDto* pInfo = LOMSE_NEW ImoSlurDto();
@@ -4379,7 +4379,7 @@ public:
                    ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoDirection* pSpacer = static_cast<ImoDirection*>(
@@ -4432,7 +4432,7 @@ public:
                   ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoStaffInfo* pInfo = static_cast<ImoStaffInfo*>(
@@ -4531,7 +4531,7 @@ public:
                    ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoStyles* pStyles = static_cast<ImoStyles*>(ImFactory::inject(k_imo_styles, pDoc));
@@ -4557,7 +4557,7 @@ public:
                          ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoSystemInfo* pInfo = static_cast<ImoSystemInfo*>(
@@ -4603,7 +4603,7 @@ public:
                           ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         //Document* pDoc = m_pAnalyser->get_document_being_analysed();
         //ImoSystemInfo dto;
@@ -4643,7 +4643,7 @@ public:
                   ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoTable* pTable= static_cast<ImoTable*>(
@@ -4682,7 +4682,7 @@ public:
                       ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoTableBody* pBody = static_cast<ImoTableBody*>(
@@ -4714,7 +4714,7 @@ public:
                       ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoTableCell* pImo = static_cast<ImoTableCell*>(
@@ -4760,7 +4760,7 @@ public:
                         LibraryScope& libraryScope, ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         // <style>
         if (has_attribute("style") && m_pAnchor->is_table())
@@ -4786,7 +4786,7 @@ public:
                       ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoTableHead* pHead = static_cast<ImoTableHead*>(
@@ -4814,7 +4814,7 @@ public:
                      ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoTableRow* pRow = static_cast<ImoTableRow*>(
@@ -4868,7 +4868,7 @@ public:
                     ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoTextBlockInfo box;
@@ -4967,7 +4967,7 @@ public:
     {
     }
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         // [<style>]
         ImoStyle* pStyle = nullptr;
@@ -5015,7 +5015,7 @@ public:
     {
     }
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         // <string>
         if (get_mandatory(k_string))
@@ -5072,7 +5072,7 @@ public:
                 ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoTieDto* pInfo = static_cast<ImoTieDto*>(
@@ -5129,7 +5129,7 @@ public:
                           ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoTimeSignature* pTime = static_cast<ImoTimeSignature*>(
@@ -5173,7 +5173,7 @@ public:
                   ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         // [<h-alignment>]
         int nAlignment = k_halign_left;
@@ -5247,7 +5247,7 @@ public:
                    ImoObj* pAnchor)
         : LmdElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         //Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoTupletDto* pInfo = LOMSE_NEW ImoTupletDto();

--- a/src/parser/lomse_ldp_factory.cpp
+++ b/src/parser/lomse_ldp_factory.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -51,7 +51,7 @@ template<ELdpElement type>
 class LdpElementFunctor : public LdpFunctor
 {
 public:
-	LdpElement* operator ()() {  return LdpObject<type>::new_ldp_object(); }
+	LdpElement* operator ()() override {  return LdpObject<type>::new_ldp_object(); }
 };
 
 

--- a/src/parser/mnx/lomse_mnx_analyser.cpp
+++ b/src/parser/mnx/lomse_mnx_analyser.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -1367,7 +1367,7 @@ public:
         {
         }
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         error_msg("Missing analyser for element '" + m_tag + "'. Node ignored.");
         set_result(nullptr);
@@ -1392,7 +1392,7 @@ public:
                       LibraryScope& libraryScope, ImoObj* pAnchor)
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         // attrib: value - optional value of a beamed group within a parent
         //TODO
@@ -1448,7 +1448,7 @@ public:
         {}
 
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoClef* pClef = static_cast<ImoClef*>( ImFactory::inject(k_imo_clef, pDoc) );
@@ -1630,7 +1630,7 @@ public:
                      LibraryScope& libraryScope, ImoObj* pAnchor)
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         // attrb: profile
         if (get_attribute("profile") != "standard")
@@ -1680,7 +1680,7 @@ public:
                           LibraryScope& libraryScope, ImoObj* pAnchor)
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    bool do_analysis()
+    bool do_analysis() override
     {
 		//TODO: implement Analyser
         set_result(nullptr);
@@ -1717,7 +1717,7 @@ public:
         {}
 
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         //In MNX Clefs, time signatures and key signatures are
         //treated as attributes of a measure, not as objects and, therefore, ordering
@@ -1849,7 +1849,7 @@ public:
                         LibraryScope& libraryScope, ImoObj* pAnchor)
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         //TODO: implement Analyser
         set_result(nullptr);
@@ -1885,7 +1885,7 @@ public:
                      LibraryScope& libraryScope, ImoObj* pAnchor)
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         //First step: extract information -----------------------------------------------
 
@@ -2038,7 +2038,7 @@ public:
                           LibraryScope& libraryScope, ImoObj* pAnchor)
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         //TODO: implement Analyser
         set_result(nullptr);
@@ -2065,7 +2065,7 @@ public:
                       LibraryScope& libraryScope, ImoObj* pAnchor)
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         // attrib: parts
         string parts = get_optional_string_attribute("parts", "*$SINGLE-PART$*");
@@ -2130,7 +2130,7 @@ public:
                     LibraryScope& libraryScope, ImoObj* pAnchor)
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    bool do_analysis()
+    bool do_analysis() override
     {
 		//TODO: implement Analyser
         set_result(nullptr);
@@ -2154,7 +2154,7 @@ public:
                                LibraryScope& libraryScope, ImoObj* pAnchor)
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         //TODO: implement Analyser
         set_result(nullptr);
@@ -2180,7 +2180,7 @@ public:
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoKeySignature* pKey = static_cast<ImoKeySignature*>(
@@ -2347,7 +2347,7 @@ public:
     }
 
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         ImoMusicData* pMD = nullptr;
         if (m_pAnchor && m_pAnchor->is_music_data())
@@ -2486,7 +2486,7 @@ public:
                    LibraryScope& libraryScope, ImoObj* pAnchor)
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         ImoDocument* pImoDoc = nullptr;
 
@@ -2554,7 +2554,7 @@ public:
                     LibraryScope& libraryScope, ImoObj* pAnchor)
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         // attrib: pitch
         string pitch = get_mandatory_string_attribute("pitch", "", "note");
@@ -2697,7 +2697,7 @@ public:
                     LibraryScope& libraryScope, ImoObj* pAnchor)
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         ImoInstrument* pInstrument = create_instrument();
 
@@ -2807,7 +2807,7 @@ public:
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
 
-    bool do_analysis()
+    bool do_analysis() override
     {
 //        //attrb: print-object
 //        string print = get_optional_string_attribute("print-object", "yes");
@@ -2862,7 +2862,7 @@ public:
                     LibraryScope& libraryScope, ImoObj* pAnchor)
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         // attrib: pitch
         string pitch = get_optional_string_attribute("pitch", "");
@@ -2920,7 +2920,7 @@ public:
                      LibraryScope& libraryScope, ImoObj* pAnchor)
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoContent* pContent = static_cast<ImoContent*>(
@@ -3007,7 +3007,7 @@ public:
                         LibraryScope& libraryScope, ImoObj* pAnchor)
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         // attrib: orient
         //TODO
@@ -3062,7 +3062,7 @@ public:
     {
     }
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         //attrib: staff
         int staff = get_optional_int_attribute("staff", 1) - 1;
@@ -3215,7 +3215,7 @@ public:
                      LibraryScope& libraryScope, ImoObj* pAnchor)
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    bool do_analysis()
+    bool do_analysis() override
     {
 		//TODO: implement Analyser
         set_result(nullptr);
@@ -3241,7 +3241,7 @@ public:
                     LibraryScope& libraryScope, ImoObj* pAnchor)
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         //attrib: signature
         string signature = get_mandatory_string_attribute("signature", "4/4", "time");
@@ -3386,7 +3386,7 @@ public:
                       LibraryScope& libraryScope, ImoObj* pAnchor)
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         //TODO: implement Analyser
         set_result(nullptr);
@@ -3410,7 +3410,7 @@ public:
                         LibraryScope& libraryScope, ImoObj* pAnchor)
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         //TODO: implement Analyser
         set_result(nullptr);
@@ -3434,7 +3434,7 @@ public:
                         LibraryScope& libraryScope, ImoObj* pAnchor)
         : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    bool do_analysis()
+    bool do_analysis() override
     {
         //TODO: implement Analyser
         set_result(nullptr);

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -1594,7 +1594,7 @@ public:
         {
         }
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         error_msg("Missing analyser for element '" + m_tag + "'. Node ignored.");
         return nullptr;
@@ -1610,7 +1610,7 @@ public:
                                      LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
 		//TODO
         return nullptr;
@@ -1640,7 +1640,7 @@ public:
                             LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoNoteRest* pNR = nullptr;
         if (m_pAnchor && m_pAnchor->is_note_rest())
@@ -1856,7 +1856,7 @@ public:
         {}
 
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         //In MusicXML. Clefs, time signatures and key signatures are
         //treated as attributes of a measure, not as objects and, therefore, ordering
@@ -2002,7 +2002,7 @@ public:
     }
 
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         //ImoMusicData* pMD = dynamic_cast<ImoMusicData*>(m_pAnchor);
 
@@ -2268,7 +2268,7 @@ public:
                        LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
 		//TODO
         return nullptr;
@@ -2304,7 +2304,7 @@ public:
     }
 
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoClef* pClef = static_cast<ImoClef*>( ImFactory::inject(k_imo_clef, pDoc) );
@@ -2468,7 +2468,7 @@ public:
                             LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
 		//TODO
         return nullptr;
@@ -2492,7 +2492,7 @@ public:
                             LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoDirection* pDirection = nullptr;
         if (m_pAnchor && m_pAnchor->is_direction())
@@ -2528,7 +2528,7 @@ public:
                             LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
 		//TODO
         return nullptr;
@@ -2544,7 +2544,7 @@ public:
                             LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
 		//TODO
         return nullptr;
@@ -2568,7 +2568,7 @@ public:
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoDirection* pDirection = static_cast<ImoDirection*>(
@@ -2652,9 +2652,9 @@ public:
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
 
-    ImoObj* do_analysis() { return nullptr; }
+    ImoObj* do_analysis() override { return nullptr; }
 
-    bool do_analysis_bool()
+    bool do_analysis_bool() override
     {
         bool fSpanner = false;
         while (more_children_to_analyse())
@@ -2738,7 +2738,7 @@ public:
                         LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoStaffObj* pSO = nullptr;
         if (m_pAnchor && (m_pAnchor->is_note_rest() || m_pAnchor->is_direction()))
@@ -2835,7 +2835,7 @@ public:
     {
     }
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoBarline* pBarline = nullptr;
         if (m_pAnchor && m_pAnchor->is_barline())
@@ -2987,7 +2987,7 @@ public:
                             LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
 		//TODO
         return nullptr;
@@ -3020,7 +3020,7 @@ public:
                     ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoNoteRest* pNR = nullptr;
         if (m_pAnchor && m_pAnchor->is_note_rest())
@@ -3106,7 +3106,7 @@ public:
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         bool fFwd = (m_analysedNode.name() == "forward");
         ImoStaffObj* pSO = nullptr;
@@ -3167,7 +3167,7 @@ public:
                             LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
 		//TODO
         return nullptr;
@@ -3183,7 +3183,7 @@ public:
                      LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
 		//TODO
         return nullptr;
@@ -3234,7 +3234,7 @@ public:
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoKeySignature* pKey = static_cast<ImoKeySignature*>(
@@ -3396,7 +3396,7 @@ public:
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoNote* pNote = nullptr;
         if (m_pAnchor && m_pAnchor->is_note())
@@ -3512,7 +3512,7 @@ public:
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoMusicData* pMD = nullptr;
         if (m_pAnchor && m_pAnchor->is_music_data())
@@ -3640,7 +3640,7 @@ public:
                             LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         if (m_pAnchor == nullptr || !m_pAnchor->is_direction())
         {
@@ -3746,7 +3746,7 @@ public:
     }
 
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         //anchor parent is ImoSounds when analysing <score-instrument> or
         //ImoSoundChange when analysing <sound>
@@ -3891,7 +3891,7 @@ public:
                               LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         //anchor parent is ImoSounds when analysing <score-instrument> or
         //ImoSoundChange when analysing <sound>
@@ -4016,7 +4016,7 @@ public:
                      ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         // [{<xxxx>|<yyyy>|<zzzz>}*]    alternatives: zero or more
         while (more_children_to_analyse())
@@ -4081,7 +4081,7 @@ public:
     {
     }
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
             //attribs
 
@@ -4635,7 +4635,7 @@ public:
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         //attrb: id
         string id = get_optional_string_attribute("id", "");
@@ -4742,7 +4742,7 @@ public:
     {
     }
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoDirection* pDirection = nullptr;
         if (m_pAnchor && m_pAnchor->is_direction())
@@ -4871,7 +4871,7 @@ public:
                             LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoNoteRest* pNR = nullptr;
         if (m_pAnchor && m_pAnchor->is_note_rest())
@@ -5040,7 +5040,7 @@ public:
                          LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         //attrb: number
         int number = get_attribute_as_integer("number", -1);
@@ -5211,7 +5211,7 @@ public:
     PartListMxlAnalyser(MxlAnalyser* pAnalyser, ostream& reporter, LibraryScope& libraryScope)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         // part-group*
         while (analyse_optional("part-group"));
@@ -5256,7 +5256,7 @@ public:
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         //attrb: print-object
         string print = get_optional_string_attribute("print-object", "yes");
@@ -5303,7 +5303,7 @@ public:
                      LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
 		//TODO
         return nullptr;
@@ -5319,7 +5319,7 @@ public:
                           LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
 		//TODO
         return nullptr;
@@ -5338,7 +5338,7 @@ public:
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         //anchor object is ImoNote
         ImoNote* pNote = nullptr;
@@ -5453,7 +5453,7 @@ public:
                             LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
 		//TODO
         return nullptr;
@@ -5481,7 +5481,7 @@ public:
                      ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         //TODO: Finish this
 
@@ -5571,7 +5571,7 @@ public:
                          LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
 		//TODO
         return nullptr;
@@ -5605,7 +5605,7 @@ public:
                                LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoInstrument* pInstr = dynamic_cast<ImoInstrument*>(m_pAnchor);
         if (!pInstr)
@@ -5682,7 +5682,7 @@ public:
     ScorePartMxlAnalyser(MxlAnalyser* pAnalyser, ostream& reporter, LibraryScope& libraryScope)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         //attrb: id
         string id = get_mandatory_string_attribute("id", "", "score-part");
@@ -5772,7 +5772,7 @@ public:
     ScorePartwiseMxlAnalyser(MxlAnalyser* pAnalyser, ostream& reporter, LibraryScope& libraryScope)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoDocument* pImoDoc = nullptr;
 
@@ -5937,7 +5937,7 @@ public:
                           LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
 		//TODO
         return nullptr;
@@ -5961,7 +5961,7 @@ public:
                      LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoDirection* pDirection = nullptr;
         if (m_pAnchor && m_pAnchor->is_direction())
@@ -5997,7 +5997,7 @@ public:
                            LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
 		//TODO
         return nullptr;
@@ -6021,7 +6021,7 @@ public:
                         LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoNoteRest* pNR = nullptr;
         if (m_pAnchor && m_pAnchor->is_note_rest())
@@ -6152,7 +6152,7 @@ public:
     {
     }
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoNote* pNote = nullptr;
         if (m_pAnchor && m_pAnchor->is_note())
@@ -6301,7 +6301,7 @@ public:
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoSoundChange* pSC = static_cast<ImoSoundChange*>(
@@ -6493,7 +6493,7 @@ public:
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoLyricsTextInfo* pParent = nullptr;
         if (m_pAnchor && m_pAnchor->is_lyrics_text_info())
@@ -6564,7 +6564,7 @@ public:
     {
     }
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoNote* pNote = nullptr;
         if (m_pAnchor && m_pAnchor->is_note())
@@ -6698,7 +6698,7 @@ public:
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoTimeSignature* pTime = static_cast<ImoTimeSignature*>(
@@ -6766,7 +6766,7 @@ public:
         {
         }
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         if (m_pAnchor && m_pAnchor->is_note_rest())
             m_pNR = static_cast<ImoNote*>(m_pAnchor);
@@ -6864,7 +6864,7 @@ public:
         {
         }
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoNoteRest* pNR = nullptr;
         if (m_pAnchor && m_pAnchor->is_note_rest())
@@ -7063,7 +7063,7 @@ public:
     {
     }
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         if (m_pAnchor && m_pAnchor->is_tuplet_dto())
             m_pInfo = static_cast<ImoTupletDto*>(m_pAnchor);
@@ -7111,7 +7111,7 @@ public:
                                  LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoSoundInfo* pInfo = dynamic_cast<ImoSoundInfo*>(m_pAnchor);
         //ImoInstrument* pInstr = dynamic_cast<ImoInstrument*>(m_pAnchor);
@@ -7165,7 +7165,7 @@ public:
     {
     }
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoDirection* pDirection = nullptr;
         if (m_pAnchor && m_pAnchor->is_direction())
@@ -7294,7 +7294,7 @@ public:
                      LibraryScope& libraryScope, ImoObj* pAnchor)
         : MxlElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
 
-    ImoObj* do_analysis()
+    ImoObj* do_analysis() override
     {
         ImoDirection* pDirection = nullptr;
         if (m_pAnchor && m_pAnchor->is_direction())


### PR DESCRIPTION
Added 'override' marker to all overriding methods in lomse code, but not in third party code, such as UnitTest++.
