### PR TITLE
Support transpose in internal model, MusicXML, and playback.

### DIFF
--- a/include/lomse_midi_table.h
+++ b/include/lomse_midi_table.h
@@ -47,6 +47,7 @@ class ImoStaffObj;
 class ImoKeySignature;
 class ImoTimeSignature;
 class ImoNote;
+class ImoTranspose;
 class StaffObjsCursor;
 class SoundEvent;
 class SoundEventsTable;
@@ -208,6 +209,7 @@ protected:
     std::vector<SoundEvent*> m_events;
     std::vector<int> m_measures;
     std::vector<int> m_channels;
+    std::vector<int> m_semitones;       //transposition for each staff
     std::vector<JumpEntry*> m_jumps;
     std::vector<MeasuresJumpsEntry*> m_measuresJumps;
     std::vector< std::pair<int, std::string> > m_targets;          //pair measure, label
@@ -251,12 +253,13 @@ protected:
     void close_table();
     void sort_by_time();
     void create_measures_table();
+    void save_transposition_information(StaffObjsCursor& cursor, int iInstr, ImoTranspose* pTrp);
     void add_jumps_if_volta_bracket(StaffObjsCursor& cursor, ImoBarline* pBar,
                                     int measure);
     void add_events_to_jumps();
     void replace_label_in_jumps();
     int find_measure_for_label(const string& label);
-    void add_noterest_events(StaffObjsCursor& cursor, int channel, int measure);
+    void add_noterest_events(StaffObjsCursor& cursor, int measure);
     void add_rythm_change(int measure, ImoTimeSignature* pTS);
     void add_jump(StaffObjsCursor& cursor, int measure, JumpEntry* pJump);
     void delete_events_table();

--- a/include/private/lomse_internal_model_p.h
+++ b/include/private/lomse_internal_model_p.h
@@ -732,6 +732,7 @@ enum EImoObjType
     k_imo_sound_change,     ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Playback parameters
     k_imo_system_break,     ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; System break
     k_imo_time_signature,   ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Time signature
+    k_imo_transpose,        ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Transposition information
     k_imo_staffobj_last,
 
     // ImoAuxObj (A)
@@ -1550,6 +1551,7 @@ public:
     inline bool is_tie_dto() { return m_objtype == k_imo_tie_dto; }
     inline bool is_time_signature() { return m_objtype == k_imo_time_signature; }
     inline bool is_time_modification_dto() { return m_objtype == k_imo_time_modification_dto; }
+    inline bool is_transpose() { return m_objtype == k_imo_transpose; }
     inline bool is_tuplet() { return m_objtype == k_imo_tuplet; }
     inline bool is_tuplet_dto() { return m_objtype == k_imo_tuplet_dto; }
     inline bool is_volta_bracket() { return m_objtype == k_imo_volta_bracket; }
@@ -4760,6 +4762,57 @@ public:
     ImoMidiInfo* get_midi_info(const std::string& soundId);
 
 
+};
+
+//---------------------------------------------------------------------------------------
+/** ImoTranspose staffobj represents what must be added to the written pitch to get the
+    correct sounding pitch. The transposition is represented by:
+
+    - m_chromatic: the number of semitones needed to get from written to sounding
+        pitch. It does not include octaves
+    - m_octaveChange: how many octaves to add to get from written pitch to sounding pitch.
+    - m_diatonic: number of steps, for correct spelling of enharmonic transpositions.
+    - m_doubled: if @TRUE indicates that the music is doubled one octave down from what
+        is currently written (as is the case for mixed cello / bass parts in
+        orchestral literature).
+    - m_numStaff. If -1, this transposition applies to all staves in the instrument.
+      Otherwise, it applies only to the specified staff (0..n-1)
+*/
+class ImoTranspose : public ImoStaffObj
+{
+protected:
+    int m_numStaff;
+    int m_diatonic;
+    int m_chromatic;
+    int m_octaveChange;
+    bool m_doubled;
+
+    friend class ImFactory;
+    ImoTranspose()
+        : ImoStaffObj(k_imo_transpose)
+    {
+        init(-1, 0, 0, 0, false);
+    }
+
+public:
+    virtual ~ImoTranspose() {}
+
+    inline int get_applicable_staff() { return m_numStaff; }
+    inline int get_diatonic() { return m_diatonic; }
+    inline int get_chromatic() { return m_chromatic; }
+    inline int get_octave_change() { return m_octaveChange; }
+    inline bool get_doubled() { return m_doubled; }
+
+protected:
+    friend class TransposeMxlAnalyser;
+    void init(int iStaff, int chromatic, int diatonic, int octaves, bool doubled)
+    {
+        m_numStaff = iStaff;
+        m_diatonic = diatonic;
+        m_chromatic = chromatic;
+        m_octaveChange = octaves;
+        m_doubled = doubled;
+    }
 };
 
 //---------------------------------------------------------------------------------------

--- a/src/exporters/lomse_ldp_exporter.cpp
+++ b/src/exporters/lomse_ldp_exporter.cpp
@@ -2740,6 +2740,42 @@ protected:
 };
 
 //---------------------------------------------------------------------------------------
+//@ <transpose> = (transpose <staves><chromatic>[<diatonic>][<octaves>][<doubled>])
+class TransposeLdpGenerator : public LdpGenerator
+{
+protected:
+    ImoTranspose* m_pObj;
+
+public:
+    TransposeLdpGenerator(ImoObj* pImo, LdpExporter* pExporter) : LdpGenerator(pExporter)
+    {
+        m_pObj = static_cast<ImoTranspose*>(pImo);
+    }
+
+    string generate_source(ImoObj* UNUSED(pParent) =nullptr) override
+    {
+        start_element("transpose", m_pObj->get_id());
+        m_source << " " << m_pObj->get_applicable_staff();
+        m_source << " " << m_pObj->get_chromatic();
+        int value = m_pObj->get_diatonic();
+        if (value != 0)
+            m_source << " " << value;
+        value = m_pObj->get_octave_change();
+        if (value != 0)
+            m_source << " " << value;
+        bool doubled = m_pObj->get_doubled();
+        if (doubled != 0)
+            m_source << " true";
+
+        source_for_attachments(m_pObj);
+        end_element(k_in_same_line);
+        return m_source.str();
+    }
+
+protected:
+};
+
+//---------------------------------------------------------------------------------------
 //AWARE: Must be defined after TitleLdpGenerator and DefineStyleLdpGenerator as uses both
 
 class ScoreLdpGenerator : public LdpGenerator
@@ -3420,6 +3456,7 @@ LdpGenerator* LdpExporter::new_generator(ImoObj* pImo)
         case k_imo_slur:            return LOMSE_NEW SlurLdpGenerator(pImo, this);
         case k_imo_time_signature:  return LOMSE_NEW TimeSignatureLdpGenerator(pImo, this);
         case k_imo_tie:             return LOMSE_NEW TieLdpGenerator(pImo, this);
+        case k_imo_transpose:       return LOMSE_NEW TransposeLdpGenerator(pImo, this);
         default:
             return new ErrorLdpGenerator(pImo, this);
     }

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -1165,7 +1165,9 @@ GmoShape* ShapesCreator::create_staffobj_shape(ImoStaffObj* pSO, int iInstr, int
                                                             iInstr, iStaff);
             return create_invisible_shape(pSO, iInstr, iStaff, pos, space);
         }
+
         case k_imo_sound_change:
+        case k_imo_transpose:
         default:
             return create_invisible_shape(pSO, iInstr, iStaff, pos, 0.0f);
     }

--- a/src/graphic_model/layouters/lomse_spacing_algorithm_gourlay.cpp
+++ b/src/graphic_model/layouters/lomse_spacing_algorithm_gourlay.cpp
@@ -168,6 +168,7 @@ void SpAlgGourlay::include_object(ColStaffObjsEntry* pCurEntry, int iCol, int iI
             case k_imo_go_back_fwd:
             case k_imo_figured_bass:
             case k_imo_sound_change:
+            case k_imo_transpose:
             case k_imo_system_break:
                 curType = TimeSlice::k_non_timed;
                 break;

--- a/src/internal_model/lomse_im_factory.cpp
+++ b/src/internal_model/lomse_im_factory.cpp
@@ -139,6 +139,7 @@ ImoObj* ImFactory::inject(int type, Document* pDoc, ImoId id)
         case k_imo_tie_dto:             pObj = LOMSE_NEW ImoTieDto();             break;
         case k_imo_time_modification_dto:  pObj = LOMSE_NEW ImoTimeModificationDto();  break;
         case k_imo_time_signature:      pObj = LOMSE_NEW ImoTimeSignature();      break;
+        case k_imo_transpose:           pObj = LOMSE_NEW ImoTranspose();          break;
         case k_imo_tuplet:              pObj = LOMSE_NEW ImoTuplet();             break;
         case k_imo_tuplet_dto:          pObj = LOMSE_NEW ImoTupletDto();          break;
         case k_imo_volta_bracket:       pObj = LOMSE_NEW ImoVoltaBracket();       break;

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -509,6 +509,7 @@ const string& ImoObj::get_name(int type)
         m_TypeToName[k_imo_text_style] = "text-style";
         m_TypeToName[k_imo_tie_dto] = "tie-dto";
         m_TypeToName[k_imo_time_modification_dto] = "time-modificator-dto";
+        m_TypeToName[k_imo_transpose] = "transpose";
         m_TypeToName[k_imo_tuplet_dto] = "tuplet-dto";
         m_TypeToName[k_imo_volta_bracket_dto] = "volta_bracket_dto";
         m_TypeToName[k_imo_wedge_dto] = "wedge_dto";

--- a/src/internal_model/lomse_staffobjs_table.cpp
+++ b/src/internal_model/lomse_staffobjs_table.cpp
@@ -252,9 +252,9 @@ bool ColStaffObjs::is_lower_entry(ColStaffObjsEntry* b, ColStaffObjsEntry* a)
     if (pA->is_note_rest() && pB->get_duration() == 0.0f && !pB->is_grace_note())
         return true;    //B cannot go after A, Try with A-1
 
-    //R3. <direction> and <sound> can not go between clefs/key/time ==>
+    //R3. <direction>, <sound> and <transpose> can not go between clefs/key/time ==>
     //    clef/key/time can not go after direction. Missing: in other instruments/staves
-    if ((pA->is_direction() || pA->is_sound_change())
+    if ((pA->is_direction() || pA->is_sound_change() || pA->is_transpose())
         && (pB->is_clef() || pB->is_time_signature() || pB->is_key_signature()))
     {
         return true;    //move clef/key/time before 'A' object

--- a/src/tests/lomse_test_midi_table.cpp
+++ b/src/tests/lomse_test_midi_table.cpp
@@ -74,7 +74,7 @@ public:
         , m_pDoc(nullptr)
     {
         m_scores_path = TESTLIB_SCORES_PATH;
-        m_scores_path += "unit-tests/repeats/";
+        m_scores_path += "unit-tests/";
         m_libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
     }
 
@@ -590,7 +590,7 @@ SUITE(MidiTableTest)
         //  |    |    |    :|     |     |
         //  1    2    3     4     5
         //                 J 2,1
-        load_mxl_score_for_test("01-repeat-end-repetition-barline.xml");
+        load_mxl_score_for_test("repeats/01-repeat-end-repetition-barline.xml");
         //cout << m_pTable->dump_midi_events() << endl;
         CHECK( m_pTable->num_jumps() == 1 );
         CHECK( check_jump(0, 1,1,0,1) == true );
@@ -602,7 +602,7 @@ SUITE(MidiTableTest)
         //  |    |     |:    |    :|     |     |
         //  1    2     3     4     5     6
         //                       J 3,1
-        load_mxl_score_for_test("02-repeat-start-end-repetition-barlines.xml");
+        load_mxl_score_for_test("repeats/02-repeat-start-end-repetition-barlines.xml");
         //cout << m_pTable->dump_midi_events() << endl;
         CHECK( m_pTable->num_jumps() == 1 );
         CHECK( check_jump(0, 3,1,0,6) == true );
@@ -635,7 +635,7 @@ SUITE(MidiTableTest)
         //  |    |    :|:    |    :|     |     |
         //  1    2     3     4     5     6
         //            J 1,1       J 3,1
-        load_mxl_score_for_test("03-repeat-double-end-repetition-barlines.xml");
+        load_mxl_score_for_test("repeats/03-repeat-double-end-repetition-barlines.xml");
         //cout << m_pTable->dump_midi_events() << endl;
         CHECK( m_pTable->num_jumps() == 2 );
         CHECK( check_jump(0, 1,1,0,1) == true );
@@ -650,7 +650,7 @@ SUITE(MidiTableTest)
         //  1    2    3     4      5    6
         //                 J 4,1  J 1,1
         //                   5,0
-        load_mxl_score_for_test("04-repeat-barline-simple-volta.xml");
+        load_mxl_score_for_test("repeats/04-repeat-barline-simple-volta.xml");
         //cout << m_pTable->dump_midi_events() << endl;
         CHECK( m_pTable->num_jumps() == 3 );
         CHECK( check_jump(0, 4,1,0,10) == true );
@@ -666,7 +666,7 @@ SUITE(MidiTableTest)
         //  1    2    3     4      5    6
         //                 J4,2   J1,2
         //                 J5,0
-        load_mxl_score_for_test("05-repeat-barline-simple-volta-two-times.xml");
+        load_mxl_score_for_test("repeats/05-repeat-barline-simple-volta-two-times.xml");
         //cout << m_pTable->dump_midi_events() << endl;
         CHECK( m_pTable->num_jumps() == 3 );
         CHECK( check_jump(0, 4,2,0,10) == true );
@@ -683,7 +683,7 @@ SUITE(MidiTableTest)
         //           J3,1  J1,1   J1,1
         //           J4,1
         //           J5,0
-        load_mxl_score_for_test("07-repeat-barlines-three-volta.xml");
+        load_mxl_score_for_test("repeats/07-repeat-barlines-three-volta.xml");
         //cout << m_pTable->dump_midi_events() << endl;
         CHECK( m_pTable->num_jumps() == 5 );
         CHECK( check_jump(0, 3,1) == true );
@@ -702,7 +702,7 @@ SUITE(MidiTableTest)
         //           J3,1        J1,1        J1,1
         //           J5,1
         //           J7,0
-        load_mxl_score_for_test("08-repeat-barlines-three-volta-long.xml");
+        load_mxl_score_for_test("repeats/08-repeat-barlines-three-volta-long.xml");
         //cout << m_pTable->dump_midi_events() << endl;
         CHECK( m_pTable->num_jumps() == 5 );
         CHECK( check_jump(0, 3,1) == true );
@@ -721,7 +721,7 @@ SUITE(MidiTableTest)
         //           J3,2        J1,2        J1,2
         //           J5,2
         //           J7,0
-        load_mxl_score_for_test("09-repeat-barlines-three-volta-long-several-times.xml");
+        load_mxl_score_for_test("repeats/09-repeat-barlines-three-volta-long-several-times.xml");
         //cout << m_pTable->dump_midi_events() << endl;
         CHECK( m_pTable->num_jumps() == 5 );
         CHECK( check_jump(0, 3,2) == true );
@@ -738,7 +738,7 @@ SUITE(MidiTableTest)
         //  |      |      |      |      |
         //  1      2      3      4
         //                             J1,1
-        load_mxl_score_for_test("51-repeat-da-capo.xml");
+        load_mxl_score_for_test("repeats/51-repeat-da-capo.xml");
         //cout << m_pTable->dump_midi_events() << endl;
         CHECK( m_pTable->num_jumps() == 1 );
         CHECK( check_jump(0, 1,1) == true );
@@ -751,7 +751,7 @@ SUITE(MidiTableTest)
         //  |      |      |      |      |
         //  1      2      3      4
         //              J-1,1,1        J1,1
-        load_mxl_score_for_test("52-repeat-da-capo-al-fine.xml");
+        load_mxl_score_for_test("repeats/52-repeat-da-capo-al-fine.xml");
         //cout << m_pTable->dump_midi_events() << endl;
         CHECK( m_pTable->num_jumps() == 2);
         CHECK( check_jump(0, -1,1,1) == true );
@@ -765,7 +765,7 @@ SUITE(MidiTableTest)
 //        //  |      |      |      ||      |
 //        //  1      2      3       4
 //        //        J4,1,1                J1,1
-//        load_mxl_score_for_test("53-repeat-da-capo-al-segno.xml");
+//        load_mxl_score_for_test("repeats/53-repeat-da-capo-al-segno.xml");
 //        cout << m_pTable->dump_midi_events() << endl;
 //        CHECK( m_pTable->num_jumps() == 2);
 //        CHECK( check_jump(0, 4,1,1) == true );
@@ -779,7 +779,7 @@ SUITE(MidiTableTest)
         //  |      |      |      ||      |
         //  1      2      3       4
         //                     J-1,1,1   J2,1
-        load_mxl_score_for_test("54-repeat-dal-segno-al-fine.xml");
+        load_mxl_score_for_test("repeats/54-repeat-dal-segno-al-fine.xml");
         //cout << m_pTable->dump_midi_events() << endl;
         CHECK( m_pTable->num_jumps() == 2);
         CHECK( check_jump(0, -1,1,1) == true );
@@ -794,7 +794,7 @@ SUITE(MidiTableTest)
         //  |         |         |        |           ||         |
         //  1         2         3        4            5
         //                            J5,1,1        J2,1
-        load_mxl_score_for_test("55-repeat-dal-segno-al-coda.xml");
+        load_mxl_score_for_test("repeats/55-repeat-dal-segno-al-coda.xml");
         //cout << m_pTable->dump_midi_events() << endl;
         CHECK( m_pTable->num_jumps() == 2);
         CHECK( check_jump(0, 5,1,1) == true );
@@ -809,7 +809,7 @@ SUITE(MidiTableTest)
         //  |         |         |:      :|           ||         |
         //  1         2         3        4            5
         //                    J5,1,1   J3,1        J1,1
-        load_mxl_score_for_test("56-repeat-da-capo-al-coda.xml");
+        load_mxl_score_for_test("repeats/56-repeat-da-capo-al-coda.xml");
         //cout << m_pTable->dump_midi_events() << endl;
         CHECK( m_pTable->num_jumps() == 3);
         CHECK( check_jump(0, 5,1,1) == true );
@@ -824,7 +824,7 @@ SUITE(MidiTableTest)
         //  |         |         |:      :|           ||         |
         //  1         2         3        4            5
         //                             J3,1         J2,1
-        load_mxl_score_for_test("57-repeat-dal-segno.xml");
+        load_mxl_score_for_test("repeats/57-repeat-dal-segno.xml");
         //cout << m_pTable->dump_midi_events() << endl;
         CHECK( m_pTable->num_jumps() == 2);
         CHECK( check_jump(0, 3,1) == true );
@@ -839,7 +839,7 @@ SUITE(MidiTableTest)
         //  |         |         |:      :|           ||         |
         //  1         2         3        4            5
         //                    J5,1,1   J3,1        J2,1
-        load_mxl_score_for_test("58-repeat-dal-segno-al-coda.xml");
+        load_mxl_score_for_test("repeats/58-repeat-dal-segno-al-coda.xml");
         //cout << m_pTable->dump_midi_events() << endl;
         CHECK( m_pTable->num_jumps() == 3);
         CHECK( check_jump(0, 5,1,1) == true );
@@ -952,6 +952,76 @@ SUITE(MidiTableTest)
     }
 
 
+    //@ Transposition computation -------------------------------------------------------
+
+    TEST_FIXTURE(MidiTableTestFixture, transpose_01)
+    {
+        //01. Transpose information added to pitch
+
+        Document doc(m_libraryScope);
+        doc.from_string(
+            "<score-partwise version='3.0'><part-list>"
+            "<score-part id='P1'><part-name>Music</part-name></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "<attributes>"
+                "<key><fifths>2</fifths></key>"
+                "<time><beats>4</beats><beat-type>4</beat-type></time>"
+                "<clef><sign>G</sign><line>2</line></clef>"
+                "<transpose><diatonic>-1</diatonic><chromatic>-2</chromatic></transpose>"
+            "</attributes>"
+            "<note><pitch><step>D</step><octave>4</octave></pitch>"
+                "<duration>4</duration><type>16th</type></note>"
+            "</measure>"
+            "</part></score-partwise>"
+            , Document::k_format_mxl
+        );
+
+
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+        SoundEventsTable* pTable = pScore->get_midi_table();
+
+//        cout << test_name() << ". Num.events = " << pTable->num_events() << endl;
+//        cout << pTable->dump_midi_events() << endl;
+        CHECK( pTable && pTable->num_events() == 5 );
+        CHECK( pTable && pTable->get_anacruxis_missing_time() == 0.0 );
+        std::vector<SoundEvent*>& events = pTable->get_events();
+        CHECK( events[0]->EventType == SoundEvent::k_prog_instr );
+        CHECK( events[0]->DeltaTime == 0L );
+        CHECK( events[1]->EventType == SoundEvent::k_rhythm_change );
+        CHECK( events[1]->DeltaTime == 0L );
+        CHECK( events[2]->EventType == SoundEvent::k_note_on );
+        CHECK( events[2]->DeltaTime == 0L );
+        CHECK( events[2]->NotePitch == 60);
+    }
+
+    TEST_FIXTURE(MidiTableTestFixture, transpose_02)
+    {
+        //02. Transpose example
+
+        Document doc(m_libraryScope);
+        doc.from_file(m_scores_path + "transpose/001-transpose.xml",
+                      Document::k_format_mxl);
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+        SoundEventsTable* pTable = pScore->get_midi_table();
+
+//        cout << test_name() << ". Num.events = " << pTable->num_events() << endl;
+//        cout << pTable->dump_midi_events() << endl;
+        CHECK( pTable && pTable->num_events() == 13 );
+        CHECK( pTable && is_equal_time(pTable->get_anacruxis_missing_time(), 192.0) );
+        std::vector<SoundEvent*>& events = pTable->get_events();
+        CHECK( events[6]->EventType == SoundEvent::k_note_on );
+        CHECK( events[6]->DeltaTime == 0L );
+        CHECK( events[6]->NotePitch == 60);
+        CHECK( events[7]->EventType == SoundEvent::k_note_on );
+        CHECK( events[7]->DeltaTime == 0L );
+        CHECK( events[7]->NotePitch == 60);
+        CHECK( events[8]->EventType == SoundEvent::k_note_on );
+        CHECK( events[8]->DeltaTime == 0L );
+        CHECK( events[8]->NotePitch == 60);
+    }
+
+
     //@ Measures jumps table ------------------------------------------------------------
 
     TEST_FIXTURE(MidiTableTestFixture, measures_jumps_01)
@@ -975,7 +1045,7 @@ SUITE(MidiTableTest)
         //  |    |    |    :|     |     |
         //  1    2    3     4     5
         //                 J 2,1
-        load_mxl_score_for_test("01-repeat-end-repetition-barline.xml");
+        load_mxl_score_for_test("repeats/01-repeat-end-repetition-barline.xml");
         //cout << m_pTable->dump_midi_events() << endl;
 		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
         CHECK( jumps.size() == 2 );
@@ -989,7 +1059,7 @@ SUITE(MidiTableTest)
         //  |    |     |:    |    :|     |     |
         //  1    2     3     4     5     6
         //                       J 3,1
-        load_mxl_score_for_test("02-repeat-start-end-repetition-barlines.xml");
+        load_mxl_score_for_test("repeats/02-repeat-start-end-repetition-barlines.xml");
         //cout << m_pTable->dump_midi_events() << endl;
 		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
         CHECK( jumps.size() == 2 );
@@ -1003,7 +1073,7 @@ SUITE(MidiTableTest)
         //  |    |    :|:    |    :|     |     |
         //  1    2     3     4     5     6
         //            J 1,1       J 3,1
-        load_mxl_score_for_test("03-repeat-double-end-repetition-barlines.xml");
+        load_mxl_score_for_test("repeats/03-repeat-double-end-repetition-barlines.xml");
         //cout << m_pTable->dump_midi_events() << endl;
 		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
         CHECK( jumps.size() == 3 );
@@ -1020,7 +1090,7 @@ SUITE(MidiTableTest)
         //  1    2    3     4      5    6
         //                 J 4,1  J 1,1
         //                   5,0
-        load_mxl_score_for_test("04-repeat-barline-simple-volta.xml");
+        load_mxl_score_for_test("repeats/04-repeat-barline-simple-volta.xml");
         //cout << m_pTable->dump_midi_events() << endl;
 		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
         CHECK( jumps.size() == 4 );
@@ -1038,7 +1108,7 @@ SUITE(MidiTableTest)
         //  1    2    3     4      5    6
         //                 J4,2   J1,2
         //                 J5,0
-        load_mxl_score_for_test("05-repeat-barline-simple-volta-two-times.xml");
+        load_mxl_score_for_test("repeats/05-repeat-barline-simple-volta-two-times.xml");
         //cout << m_pTable->dump_midi_events() << endl;
 		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
         CHECK( jumps.size() == 6 );
@@ -1059,7 +1129,7 @@ SUITE(MidiTableTest)
         //           J3,1  J1,1   J1,1
         //           J4,1
         //           J5,0
-        load_mxl_score_for_test("07-repeat-barlines-three-volta.xml");
+        load_mxl_score_for_test("repeats/07-repeat-barlines-three-volta.xml");
         //cout << m_pTable->dump_midi_events() << endl;
 		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
         CHECK( jumps.size() == 6 );
@@ -1080,7 +1150,7 @@ SUITE(MidiTableTest)
         //           J3,1        J1,1        J1,1
         //           J5,1
         //           J7,0
-        load_mxl_score_for_test("08-repeat-barlines-three-volta-long.xml");
+        load_mxl_score_for_test("repeats/08-repeat-barlines-three-volta-long.xml");
         //cout << m_pTable->dump_midi_events() << endl;
 		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
         CHECK( jumps.size() == 6 );
@@ -1101,7 +1171,7 @@ SUITE(MidiTableTest)
         //           J3,2        J1,2        J1,2
         //           J5,2
         //           J7,0
-        load_mxl_score_for_test("09-repeat-barlines-three-volta-long-several-times.xml");
+        load_mxl_score_for_test("repeats/09-repeat-barlines-three-volta-long-several-times.xml");
         //cout << m_pTable->dump_midi_events() << endl;
 		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
         CHECK( jumps.size() == 10 );
@@ -1124,7 +1194,7 @@ SUITE(MidiTableTest)
         //  |      |      |      |      |
         //  1      2      3      4
         //                             J1,1
-        load_mxl_score_for_test("51-repeat-da-capo.xml");
+        load_mxl_score_for_test("repeats/51-repeat-da-capo.xml");
         //cout << m_pTable->dump_midi_events() << endl;
 		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
         CHECK( jumps.size() == 2 );
@@ -1139,7 +1209,7 @@ SUITE(MidiTableTest)
         //  |      |      |      |      |
         //  1      2      3      4
         //              J-1,1,1        J1,1
-        load_mxl_score_for_test("52-repeat-da-capo-al-fine.xml");
+        load_mxl_score_for_test("repeats/52-repeat-da-capo-al-fine.xml");
 		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
         //dump_measures_jumps(jumps);
         CHECK( jumps.size() == 2 );
@@ -1154,7 +1224,7 @@ SUITE(MidiTableTest)
 ////        //  |      |      |      ||      |
 ////        //  1      2      3       4
 ////        //        J4,1,1                J1,1
-////        load_mxl_score_for_test("53-repeat-da-capo-al-segno.xml");
+////        load_mxl_score_for_test("repeats/53-repeat-da-capo-al-segno.xml");
 ////        cout << m_pTable->dump_midi_events() << endl;
 ////        CHECK( m_pTable->num_jumps() == 2);
 ////        CHECK( check_jump(0, 4,1,1) == true );
@@ -1168,7 +1238,7 @@ SUITE(MidiTableTest)
         //  |      |      |      ||      |
         //  1      2      3       4
         //                     J-1,1,1   J2,1
-        load_mxl_score_for_test("54-repeat-dal-segno-al-fine.xml");
+        load_mxl_score_for_test("repeats/54-repeat-dal-segno-al-fine.xml");
 		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
         //dump_measures_jumps(jumps);
         CHECK( jumps.size() == 2 );
@@ -1184,7 +1254,7 @@ SUITE(MidiTableTest)
         //  |         |         |        |           ||         |
         //  1         2         3        4            5
         //                            J5,1,1        J2,1
-        load_mxl_score_for_test("55-repeat-dal-segno-al-coda.xml");
+        load_mxl_score_for_test("repeats/55-repeat-dal-segno-al-coda.xml");
 		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
         //dump_measures_jumps(jumps);
         CHECK( jumps.size() == 3 );
@@ -1201,7 +1271,7 @@ SUITE(MidiTableTest)
         //  |         |         |:      :|           ||         |
         //  1         2         3        4            5
         //                    J5,1,1   J3,1        J1,1
-        load_mxl_score_for_test("56-repeat-da-capo-al-coda.xml");
+        load_mxl_score_for_test("repeats/56-repeat-da-capo-al-coda.xml");
 		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
         //dump_measures_jumps(jumps);
         CHECK( jumps.size() == 4 );
@@ -1218,7 +1288,7 @@ SUITE(MidiTableTest)
         //  |         |         |:      :|           ||         |
         //  1         2         3        4            5
         //                             J3,1         J2,1
-        load_mxl_score_for_test("57-repeat-dal-segno.xml");
+        load_mxl_score_for_test("repeats/57-repeat-dal-segno.xml");
 		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
         //dump_measures_jumps(jumps);
         CHECK( jumps.size() == 3 );
@@ -1235,7 +1305,7 @@ SUITE(MidiTableTest)
         //  |         |         |:      :|           ||         |
         //  1         2         3        4            5
         //                    J5,1,1   J3,1        J2,1
-        load_mxl_score_for_test("58-repeat-dal-segno-al-coda.xml");
+        load_mxl_score_for_test("repeats/58-repeat-dal-segno-al-coda.xml");
 		std::vector<MeasuresJumpsEntry*> jumps = m_pTable->get_measures_jumps();
         //dump_measures_jumps(jumps);
         CHECK( jumps.size() == 4 );

--- a/src/tests/lomse_test_mxl_analyser.cpp
+++ b/src/tests/lomse_test_mxl_analyser.cpp
@@ -4630,6 +4630,189 @@ SUITE(MxlAnalyserTest)
         delete pRoot;
     }
 
+
+    //@ transpose -----------------------------------------------------------------------
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, transpose_01)
+    {
+        //@01 transpose parsed. Minimum content
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        parser.parse_text(
+            "<transpose><chromatic>-2</chromatic></transpose>"
+        );
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot =  a.analyse_tree(tree, "string:");
+
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pRoot != nullptr);
+        CHECK( pRoot && pRoot->is_transpose() == true );
+        ImoTranspose* pSO = dynamic_cast<ImoTranspose*>( pRoot );
+        CHECK( pSO != nullptr );
+        CHECK( pSO && pSO->get_chromatic() == -2 );
+        CHECK( pSO && pSO->get_diatonic() == 0 );
+        CHECK( pSO && pSO->get_doubled() == false );
+        CHECK( pSO && pSO->get_applicable_staff() == -1 );
+        CHECK( pSO && pSO->get_octave_change() == 0 );
+
+        a.do_not_delete_instruments_in_destructor();
+        delete pRoot;
+    }
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, transpose_02)
+    {
+        //@02 transpose parsed. All elements
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        parser.parse_text(
+            "<transpose number='2'>"
+                "<diatonic>-4</diatonic>"
+                "<chromatic>-7</chromatic>"
+                "<octave-change>1</octave-change>"
+                "<double/>"
+            "</transpose>"
+        );
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot =  a.analyse_tree(tree, "string:");
+
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pRoot != nullptr);
+        CHECK( pRoot && pRoot->is_transpose() == true );
+        ImoTranspose* pSO = dynamic_cast<ImoTranspose*>( pRoot );
+        CHECK( pSO != nullptr );
+        CHECK( pSO && pSO->get_chromatic() == -7 );
+        CHECK( pSO && pSO->get_diatonic() == -4 );
+        CHECK( pSO && pSO->get_doubled() == true );
+        CHECK( pSO && pSO->get_applicable_staff() == 1 );
+        CHECK( pSO && pSO->get_octave_change() == 1 );
+
+        a.do_not_delete_instruments_in_destructor();
+        delete pRoot;
+    }
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, transpose_03)
+    {
+        //@03 transpose parsed. Error missing mandatory 'chromatic' element
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        expected << "Line 0. <transpose>: missing mandatory element <chromatic>."
+                 << endl;
+        parser.parse_text(
+            "<transpose>"
+                "<diatonic>-4</diatonic>"
+            "</transpose>"
+        );
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot =  a.analyse_tree(tree, "string:");
+
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pRoot != nullptr);
+        CHECK( pRoot && pRoot->is_transpose() == true );
+        ImoTranspose* pSO = dynamic_cast<ImoTranspose*>( pRoot );
+        CHECK( pSO != nullptr );
+        CHECK( pSO && pSO->get_chromatic() == 0 );
+        CHECK( pSO && pSO->get_diatonic() == -4 );
+        CHECK( pSO && pSO->get_doubled() == false );
+        CHECK( pSO && pSO->get_applicable_staff() == -1 );
+        CHECK( pSO && pSO->get_octave_change() == 0 );
+
+        a.do_not_delete_instruments_in_destructor();
+        delete pRoot;
+    }
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, transpose_04)
+    {
+        //@04 transpose added to MusicData in right order
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        parser.parse_text(
+            "<score-partwise version='3.0'><part-list>"
+            "<score-part id='P1'><part-name>Music</part-name></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "<attributes>"
+                "<key><fifths>2</fifths></key>"
+                "<time><beats>4</beats><beat-type>4</beat-type></time>"
+                "<clef><sign>G</sign><line>2</line></clef>"
+                "<transpose><diatonic>-4</diatonic><chromatic>-7</chromatic></transpose>"
+            "</attributes>"
+            "</measure>"
+            "</part></score-partwise>"
+        );
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot =  a.analyse_tree(tree, "string:");
+
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        CHECK( pRoot != nullptr);
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
+        CHECK( pDoc != nullptr );
+        if (pDoc)
+        {
+            CHECK( pDoc->get_num_content_items() == 1 );
+            ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+            CHECK( pScore != nullptr );
+            if (pScore)
+            {
+                CHECK( pScore->get_num_instruments() == 1 );
+                ImoInstrument* pInstr = pScore->get_instrument(0);
+                CHECK( pInstr != nullptr );
+                if (pInstr)
+                {
+                    CHECK( pInstr->get_num_staves() == 1 );
+                    ImoMusicData* pMD = pInstr->get_musicdata();
+                    CHECK( pMD != nullptr );
+                    CHECK( pMD->get_num_items() == 5 );
+                    ImoObj::children_iterator it = pMD->begin();
+                    CHECK( (*it)->is_clef() == true );
+//                    cout << (*it)->get_name() << endl;
+                    ++it;
+                    CHECK( (*it)->is_key_signature() == true );
+//                    cout << (*it)->get_name() << endl;
+                    ++it;
+                    CHECK( (*it)->is_time_signature() == true );
+//                    cout << (*it)->get_name() << endl;
+                    ++it;
+                    CHECK( (*it)->is_transpose() == true );
+//                    cout << (*it)->get_name() << endl;
+                    ++it;
+                    CHECK( (*it)->is_barline() == true );
+//                    cout << (*it)->get_name() << endl;
+                }
+            }
+        }
+
+        delete pRoot;
+    }
+
+
     //@ tuplet --------------------------------------------------------------------------
 
     TEST_FIXTURE(MxlAnalyserTestFixture, tuplet_01)

--- a/src/tests/lomse_test_staffobjs_table.cpp
+++ b/src/tests/lomse_test_staffobjs_table.cpp
@@ -306,7 +306,7 @@ SUITE(ColStaffObjsBuilderTest)
 
     TEST_FIXTURE(ColStaffObjsBuilderTestFixture, lower_entry_04)
     {
-        //@04. R3. <direction> and <sound> can not go between clefs/key/time
+        //@04. R3. <direction>, <sound> and <transpose> can not go between clefs/key/time
         create_score(
             "(score (vers 2.0)"
             "(instrument (musicData "
@@ -527,6 +527,40 @@ SUITE(ColStaffObjsBuilderTest)
         CHECK_ENTRY0(it, 1,    0,      1,  32,     1, "(n c4 q v1 p1 (stem up))" );
         CHECK_ENTRY0(it, 0,    0,      1,  96,     0, "(barline simple)" );
         CHECK_ENTRY0(it, 1,    0,      1,  96,     1, "(barline simple)" );
+    }
+
+    TEST_FIXTURE(ColStaffObjsBuilderTestFixture, lower_entry_11)
+    {
+        //@11. R3. <transpose> can not go between clefs/key/time
+
+        Document doc(m_libraryScope);
+        doc.from_file(m_scores_path + "unit-tests/transpose/001-transpose.xml",
+                      Document::k_format_mxl);
+        ImoScore* pScore = dynamic_cast<ImoScore*>( doc.get_content_item(0) );
+        CHECK( pScore != nullptr );
+        ColStaffObjs* pTable = pScore->get_staffobjs_table();
+
+//        cout << test_name() << endl;
+//        cout << pTable->dump();
+
+        CHECK( pTable->num_lines() == 3 );
+        CHECK( pTable->num_entries() == 17 );
+        CHECK( is_equal_time(pTable->min_note_duration(), TimeUnits(k_duration_quarter)));
+
+        ColStaffObjsIterator it = pTable->begin();
+        //              instr, staff, meas. time, line, scr
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(key D)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(time common)" );
+        CHECK_ENTRY0(it, 1,    0,      0,   0,     1, "(clef G p1)" );
+        CHECK_ENTRY0(it, 1,    0,      0,   0,     1, "(key A)" );
+        CHECK_ENTRY0(it, 1,    0,      0,   0,     1, "(time common)" );
+        CHECK_ENTRY0(it, 2,    0,      0,   0,     2, "(clef G p1)" );
+        CHECK_ENTRY0(it, 2,    0,      0,   0,     2, "(key C)" );
+        CHECK_ENTRY0(it, 2,    0,      0,   0,     2, "(time common)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(transpose -1 -2 -1)" );
+        CHECK_ENTRY0(it, 1,    0,      0,   0,     1, "(transpose -1 -9 -5)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n d4 q v1 p1)" );
     }
 
     TEST_FIXTURE(ColStaffObjsBuilderTestFixture, playback_time_200)

--- a/test-scores/unit-tests/transpose/001-transpose.xml
+++ b/test-scores/unit-tests/transpose/001-transpose.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 1.1 Partwise//EN"
+                                "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="1.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Trumpet in Bb</part-name>
+      <part-abbreviation>Bb Tpt.</part-abbreviation>
+    </score-part>
+    <score-part id="P2">
+      <part-name>Horn in Eb</part-name>
+      <part-abbreviation>Hn.</part-abbreviation>
+    </score-part>
+    <score-part id="P3">
+      <part-name>Piano</part-name>
+    </score-part>
+  </part-list>
+  <!--=========================================================-->
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>2</fifths>
+          <mode>major</mode>
+        </key>
+        <time symbol="common">
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+        <transpose>
+          <diatonic>-1</diatonic>
+          <chromatic>-2</chromatic>
+        </transpose>
+      </attributes>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+  <!--=========================================================-->
+  <part id="P2">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>3</fifths>
+          <mode>major</mode>
+        </key>
+        <time symbol="common">
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+        <transpose>
+          <diatonic>-5</diatonic>
+          <chromatic>-9</chromatic>
+        </transpose>
+      </attributes>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+  <!--=========================================================-->
+  <part id="P3">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          <mode>major</mode>
+        </key>
+        <time symbol="common">
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+  <!--=========================================================-->
+</score-partwise>

--- a/test-scores/unit-tests/transpose/002-transpose-octave-change.xml
+++ b/test-scores/unit-tests/transpose/002-transpose-octave-change.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 1.1 Partwise//EN"
+                                "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="1.1">
+  <part-list>
+    <score-part id="P7">
+      <part-name>Trumpet in Bb</part-name>
+      <part-abbreviation>Bb Tpt.</part-abbreviation>
+    </score-part>
+    <score-part id="P8">
+      <part-name>Trumpet in C</part-name>
+      <part-abbreviation>C Tpt.</part-abbreviation>
+    </score-part>
+    <score-part id="P9">
+      <part-name>Trumpet in D</part-name>
+      <part-abbreviation>D Tpt.</part-abbreviation>
+    </score-part>
+    <score-part id="P10">
+      <part-name>F#1 sounds as C5</part-name>
+    </score-part>
+  </part-list>
+  <!--=========================================================-->
+  <part id="P7">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>3</fifths>
+          <mode>major</mode>
+        </key>
+        <time symbol="common">
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+        <transpose>
+          <diatonic>-1</diatonic>
+          <chromatic>-2</chromatic>
+        </transpose>
+      </attributes>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+  <!--=========================================================-->
+  <part id="P8">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>1</fifths>
+          <mode>major</mode>
+        </key>
+        <time symbol="common">
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+  <!--=========================================================-->
+  <part id="P9">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-1</fifths>
+          <mode>major</mode>
+        </key>
+        <time symbol="common">
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+        <transpose>
+          <diatonic>1</diatonic>
+          <chromatic>2</chromatic>
+        </transpose>
+      </attributes>
+      <note>
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+  <!--=========================================================-->
+  <part id="P10">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>7</fifths>
+          <mode>major</mode>
+        </key>
+        <time symbol="common">
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+          <clef-octave-change>-1</clef-octave-change>
+        </clef>
+        <transpose>
+          <diatonic>3</diatonic>
+          <chromatic>6</chromatic>
+          <octave-change>3</octave-change>
+        </transpose>
+      </attributes>
+      <note>
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>1</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+  <!--=========================================================-->
+</score-partwise>


### PR DESCRIPTION
This PR adds support for transposing instruments:
- The internal model now includes transposition information
- MusicXML importer now processes `<transpose>` elements
- Transposition information is now taken into account to build sound model and for playback

closes #93