### PR TITLE
Try to fix AppVeyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,7 +43,7 @@ build_script:
   # Compile Lomse
   - mkdir build
   - cd build
-  - cmake -DLOMSE_ENABLE_COMPRESSION=OFF -DLOMSE_ENABLE_PNG=OFF  -DFREETYPE_INCLUDE_DIRS=C:\projects\ExternalLibraries\freetype\include -DFREETYPE_LIBRARY=C:\projects\ExternalLibraries\freetype\win32\freetype.lib -DUNITTEST++_INCLUDE_DIR=C:\projects\ExternalLibraries\unittest-cpp-2.0.0\UnitTest++ -DUNITTEST++_LIBRARY=C:\projects\ExternalLibraries\unittest-cpp-2.0.0\Debug\UnitTest++.lib ../lomse
+  - cmake -DLOMSE_ENABLE_COMPRESSION=OFF -DLOMSE_ENABLE_PNG=OFF  -DFREETYPE_INCLUDE_DIRS=C:\projects\ExternalLibraries\freetype\include -DFREETYPE_LIBRARY=C:\projects\ExternalLibraries\freetype\win32\freetype.lib -DUNITTEST++_INCLUDE_DIR=C:\projects\ExternalLibraries\unittest-cpp-2.0.0\UnitTest++ -DUNITTEST++_LIBRARY=C:\projects\ExternalLibraries\unittest-cpp-2.0.0\Debug\UnitTest++.lib -DLOMSE_RUN_TESTS=OFF ../lomse
   - cmake --build .
   - copy ..\ExternalLibraries\freetype\win32\freetype.dll .\Debug
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,9 @@ option(LOMSE_BUILD_MONOLITHIC
 option(LOMSE_BUILD_TESTS
     "Build the unit tests runner program 'testlib'"
     ON)
+option(LOMSE_RUN_TESTS
+    "Run unit tests after building"
+    ON)
 option(LOMSE_BUILD_EXAMPLE
     "Build the tutorial_1 program"
     OFF)
@@ -328,6 +331,7 @@ message(STATUS "Build monolithic library = ${LOMSE_BUILD_MONOLITHIC}")
 message(STATUS "Build the static library = ${LOMSE_BUILD_STATIC_LIB}")
 message(STATUS "Build the shared library = ${LOMSE_BUILD_SHARED_LIB}")
 message(STATUS "Build testlib program = ${LOMSE_BUILD_TESTS}")
+message(STATUS "Run tests after building = ${LOMSE_RUN_TESTS}")
 message(STATUS "Build tutorial_1 program = ${LOMSE_BUILD_EXAMPLE}")
 message(STATUS "Create Debug build = ${LOMSE_DEBUG}")
 message(STATUS "Enable debug logs = ${LOMSE_ENABLE_DEBUG_LOGS}")
@@ -799,17 +803,19 @@ if(LOMSE_BUILD_TESTS)
     message("${TESTLIB} target properties=" ${VAR})
 
     # once generated, run tests
-    if(WIN32)
-        set(TESTLIB_EXECUTABLE ${EXECUTABLE_OUTPUT_PATH}/${TESTLIB}.exe )
-    else()
-        set(TESTLIB_EXECUTABLE ${EXECUTABLE_OUTPUT_PATH}/${TESTLIB} )
-    endif()
+    if (LOMSE_RUN_TESTS)
+        if(WIN32)
+            set(TESTLIB_EXECUTABLE ${EXECUTABLE_OUTPUT_PATH}/${TESTLIB}.exe )
+        else()
+            set(TESTLIB_EXECUTABLE ${EXECUTABLE_OUTPUT_PATH}/${TESTLIB} )
+        endif()
 
-    add_custom_command(
-        TARGET ${TESTLIB} POST_BUILD
-        COMMAND ${TESTLIB_EXECUTABLE}
-        WORKING_DIRECTORY ${EXECUTABLE_OUTPUT_PATH}
-    )
+        add_custom_command(
+            TARGET ${TESTLIB} POST_BUILD
+            COMMAND ${TESTLIB_EXECUTABLE}
+            WORKING_DIRECTORY ${EXECUTABLE_OUTPUT_PATH}
+        )
+    endif(LOMSE_RUN_TESTS)
 
 endif(LOMSE_BUILD_TESTS)
 


### PR DESCRIPTION
This PR tries to fix AppVeyor build which seems to be broken for a while in this repo.

The issue (possibly not the only one) seems to be that CMake build automatically tries to launch unit tests, but:
1. Path to the executable file seems to be determined incorrectly (this is something to be fixed separately though);
2. Correct libraries (at least `freetype.dll`) are not copied to the necessary location at that stage.

This makes build fail on `cmake --build .` execution stage, before AppVeyor build tries to copy the necessary libraries and launch the test executable.

This PR essentially restores `LOMSE_RUN_TESTS` option removed in cdc3a0fd171b58658ba2110f0b5b9bb5531d1f1b and turns it off in AppVeyor build to allow tests be launched as it is defined in `.appveyor.yml` configuration. I am not sure whether it helps to fully fix the build but at least chances are good that we get some new error messages to proceed with :)

If my guess is correct, 5ae011de16fbf69d1e3f4c9faeee6d4518e36853 might be the commit that triggered this build failure, since it enables `LOMSE_RUN_TESTS` option by default. However there might possibly be other relevant changes since then.