### PR TITLE
Fix a crash on reading MusicXML file with octave shift starting with a rest

### DIFF
--- a/include/lomse_mxl_analyser.h
+++ b/include/lomse_mxl_analyser.h
@@ -163,7 +163,7 @@ public:
     virtual ~MxlOctaveShiftBuilder() {}
 
     void add_relation_to_staffobjs(ImoOctaveShiftDto* pEndInfo) override;
-    void add_to_open_octave_shifts(ImoNote* pNote);
+    void add_to_open_octave_shifts(ImoNoteRest* pNR);
 };
 
 
@@ -448,8 +448,8 @@ public:
     }
 
     //interface for MxlOctaveShiftBuilder
-    inline void add_to_open_octave_shifts(ImoNote* pNote) {
-        m_pOctaveShiftBuilder->add_to_open_octave_shifts(pNote);
+    inline void add_to_open_octave_shifts(ImoNoteRest* pNR) {
+        m_pOctaveShiftBuilder->add_to_open_octave_shifts(pNR);
     }
 
     //information for reporting errors

--- a/include/private/lomse_internal_model_p.h
+++ b/include/private/lomse_internal_model_p.h
@@ -7225,7 +7225,7 @@ protected:
     bool m_fStart;
     int m_steps;
     int m_octaveShiftNum;
-    ImoNote* m_pNote;
+    ImoNoteRest* m_pNR;
     Color m_color;
     int m_lineNum;
     int m_iStaff;
@@ -7236,7 +7236,7 @@ public:
         , m_fStart(true)
         , m_steps(0)
         , m_octaveShiftNum(0)
-        , m_pNote(nullptr)
+        , m_pNR(nullptr)
         , m_color(Color(0,0,0))
         , m_lineNum(0)
         , m_iStaff(0)
@@ -7246,7 +7246,7 @@ public:
 
     //setters
     inline void set_line_number(int value) { m_lineNum = value; }
-    inline void set_staffobj(ImoNote* pNote) { m_pNote = pNote; }
+    inline void set_staffobj(ImoNoteRest* pNR) { m_pNR = pNR; }
     inline void set_shift_steps(int value) { m_steps = value; }
     inline void set_start(bool value) { m_fStart = value; }
     inline void set_octave_shift_number(int value) { m_octaveShiftNum = value; }
@@ -7265,7 +7265,7 @@ public:
     inline int get_item_number() { return get_octave_shift_number(); }
     bool is_start_of_relation() { return is_start(); }
     bool is_end_of_relation() { return !is_start(); }
-    inline ImoNote* get_staffobj() { return m_pNote; }
+    inline ImoNoteRest* get_staffobj() { return m_pNR; }
 };
 
 

--- a/src/graphic_model/layouters/lomse_staffobjs_cursor.cpp
+++ b/src/graphic_model/layouters/lomse_staffobjs_cursor.cpp
@@ -83,7 +83,7 @@ void StaffObjsCursor::move_next()
         save_time_signature();
     else if (pSO->is_barline())
         save_barline();
-    else if (pSO->is_note())
+    else if (pSO->is_note_rest())
         save_octave_shift_at_end( static_cast<ImoStaffObj*>(pSO) );
 
     ++m_scoreIt;
@@ -91,7 +91,7 @@ void StaffObjsCursor::move_next()
     if (!is_end())
     {
         pSO = imo_object();
-        if (pSO && pSO->is_note())
+        if (pSO && pSO->is_note_rest())
             save_octave_shift_at_start( static_cast<ImoStaffObj*>(pSO) );
     }
 }

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -4231,7 +4231,7 @@ public:
 
         pNR->set_visible(fVisible);
         add_to_model(pNR);
-        add_to_spanners(pNote);
+        add_to_spanners(pNR);
 
         //deal with grace notes
         ImoNote* pPrevNote = m_pAnalyser->get_last_note();
@@ -4569,9 +4569,9 @@ protected:
     }
 
     //----------------------------------------------------------------------------------
-    void add_to_spanners(ImoNote* pNote)
+    void add_to_spanners(ImoNoteRest* pNR)
     {
-        m_pAnalyser->add_to_open_octave_shifts(pNote);
+        m_pAnalyser->add_to_open_octave_shifts(pNR);
     }
 
     //----------------------------------------------------------------------------------
@@ -8327,7 +8327,7 @@ void MxlWedgesBuilder::add_relation_to_staffobjs(ImoWedgeDto* pEndDto)
 void MxlOctaveShiftBuilder::add_relation_to_staffobjs(ImoOctaveShiftDto* pEndDto)
 {
     ImoOctaveShiftDto* pStartDto = m_matches.front();
-    ImoNote* pStartNote = pStartDto->get_staffobj();
+    ImoNoteRest* pStartNR = pStartDto->get_staffobj();
     m_matches.push_back(pEndDto);
     Document* pDoc = m_pAnalyser->get_document_being_analysed();
 
@@ -8348,22 +8348,22 @@ void MxlOctaveShiftBuilder::add_relation_to_staffobjs(ImoOctaveShiftDto* pEndDto
     std::list<ImoOctaveShiftDto*>::iterator it;
     for (it = m_matches.begin(); it != m_matches.end(); ++it)
     {
-        ImoNote* pNote = (*it)->get_staffobj();
-        if ((*it)->is_end_of_relation() && pNote==nullptr)
+        ImoNoteRest* pNR = (*it)->get_staffobj();
+        if ((*it)->is_end_of_relation() && pNR==nullptr)
         {
             int iStaff = (*it)->get_staff();
-            pNote = m_pAnalyser->get_last_note_for(iStaff);
-            (*it)->set_staffobj(pNote);
-            if (pStartNote != pNote)
-                pNote->include_in_relation(pDoc, pOctave, nullptr);
+            pNR = m_pAnalyser->get_last_note_for(iStaff);
+            (*it)->set_staffobj(pNR);
+            if (pStartNR != pNR)
+                pNR->include_in_relation(pDoc, pOctave, nullptr);
         }
         else
-            pNote->include_in_relation(pDoc, pOctave, nullptr);
+            pNR->include_in_relation(pDoc, pOctave, nullptr);
     }
 }
 
 //---------------------------------------------------------------------------------------
-void MxlOctaveShiftBuilder::add_to_open_octave_shifts(ImoNote* pNote)
+void MxlOctaveShiftBuilder::add_to_open_octave_shifts(ImoNoteRest* pNR)
 {
     if (m_pendingItems.size() > 0)
     {
@@ -8373,10 +8373,10 @@ void MxlOctaveShiftBuilder::add_to_open_octave_shifts(ImoNote* pNote)
             ImoOctaveShiftDto* pInfo = *it;
             if (pInfo->is_start_of_relation()
                 && pInfo->get_staffobj() == nullptr
-                && pInfo->get_staff() == pNote->get_staff()
+                && pInfo->get_staff() == pNR->get_staff()
                )
             {
-                pInfo->set_staffobj(pNote);
+                pInfo->set_staffobj(pNR);
             }
         }
     }


### PR DESCRIPTION
Fixes #266.

This fix allows octave shifts start (and end) with `ImoNoteRest` rather than only `ImoNote`, and modifies the relevant places in the code (MusicXML reading and octave shifts handling in `StaffObjsCursor`) correspondingly. After these changes octave shifts starting with rests seem to be loaded and rendered correctly. However, I am not sure whether allowing octave shifts start only with notes was intentional, and whether I could miss something else with my changes.