### PR TITLE
Fix clef change incorrectly laid out

### DIFF
--- a/src/internal_model/lomse_staffobjs_table.cpp
+++ b/src/internal_model/lomse_staffobjs_table.cpp
@@ -260,6 +260,11 @@ bool ColStaffObjs::is_lower_entry(ColStaffObjsEntry* b, ColStaffObjsEntry* a)
         return true;    //move clef/key/time before 'A' object
     }
 
+    //R11. Clefs must go before barlines at the same timepos
+    if (pB->is_clef() && pA->is_barline())
+        return true;   //move B after A
+
+
     //R999. Both have equal time. If no other rule triggers preserve definition order
     return false;   //insert B after A
 }

--- a/src/tests/lomse_test_staffobjs_table.cpp
+++ b/src/tests/lomse_test_staffobjs_table.cpp
@@ -563,6 +563,34 @@ SUITE(ColStaffObjsBuilderTest)
         CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n d4 q v1 p1)" );
     }
 
+    TEST_FIXTURE(ColStaffObjsBuilderTestFixture, lower_entry_12)
+    {
+        //@12. R11. Clefs must go before barlines at the same timepos
+
+        Document doc(m_libraryScope);
+        doc.from_file(m_scores_path + "unit-tests/colstaffobjs/07-clef-change.lms");
+        ImoScore* pScore = dynamic_cast<ImoScore*>( doc.get_content_item(0) );
+        CHECK( pScore != nullptr );
+        ColStaffObjs* pTable = pScore->get_staffobjs_table();
+
+//        cout << test_name() << endl;
+//        cout << pTable->dump();
+
+        CHECK( pTable->num_lines() == 1 );
+        CHECK( pTable->num_entries() == 7 );
+        CHECK( is_equal_time(pTable->min_note_duration(), TimeUnits(k_duration_quarter)));
+
+        ColStaffObjsIterator it = pTable->begin();
+        //              instr, staff, meas. time, line, scr
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(key C)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(time 2 4)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(n e4 h v1 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      1,   128,   0, "(clef F4 p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   128,   0, "(barline simple)" );
+        CHECK_ENTRY0(it, 0,    0,      1,   128,   0, "(n c3 q v1 p1)" );
+    }
+
     TEST_FIXTURE(ColStaffObjsBuilderTestFixture, playback_time_200)
     {
         //@200. One grace. From previous 10%

--- a/test-scores/unit-tests/colstaffobjs/07-clef-change.lms
+++ b/test-scores/unit-tests/colstaffobjs/07-clef-change.lms
@@ -1,0 +1,14 @@
+(score
+   (vers 2.1)
+   (instrument
+      (musicData 
+        (clef G)
+        (key C)
+        (time 2 4)
+        (n e4 h)
+        (barline)
+        (clef F4)
+        (n c3 q)
+      )
+)) 
+


### PR DESCRIPTION
When a clef change after a barline Lomse renders the clef *after* the barline, preserving definition order:
![clef-change](https://user-images.githubusercontent.com/5238679/98662236-c7ff9c80-2347-11eb-8a44-95e679fa3386.png)

This PR fixes this bug, and now it renders this correctly:
![clef-change-after](https://user-images.githubusercontent.com/5238679/98662301-dd74c680-2347-11eb-8300-fd4d8a4f99f4.png)

