### PR TITLE
Correct engraving of volta located at the start of a system

### DIFF
--- a/include/lomse_volta_engraver.h
+++ b/include/lomse_volta_engraver.h
@@ -51,6 +51,7 @@ class VoltaBracketEngraver : public RelObjEngraver
 {
 protected:
     int m_numShapes;
+    bool m_fFirstShapeAtSystemStart = false;
     ImoVoltaBracket* m_pVolta;
     LUnits m_uStaffTop;             //top line of current staff
     LUnits m_uStaffLeft;

--- a/src/graphic_model/engravers/lomse_volta_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_volta_engraver.cpp
@@ -165,6 +165,13 @@ GmoShape* VoltaBracketEngraver::create_first_shape()
 {
     //first shape when there are more than one
 
+    if (!m_fFirstShapeAtSystemStart && m_pStartBarlineShape->get_x_right_line() - m_uStaffRight > -1.0f)
+    {
+        //start barline is at the end of a system, create first shape at next system start instead
+        m_fFirstShapeAtSystemStart = true;
+        return nullptr;
+    }
+
     GmoShapeVoltaBracket* pShape = LOMSE_NEW GmoShapeVoltaBracket(m_pVolta, m_numShapes, m_color);
     pShape->enable_final_jog(false);
 
@@ -212,23 +219,14 @@ void VoltaBracketEngraver::set_shape_details(GmoShapeVoltaBracket* pShape,
     LUnits xStart = m_uStaffLeft;
     LUnits xEnd = m_uStaffRight;
 
-    if (shapeType == k_single_shape)
+    if (!m_fFirstShapeAtSystemStart && (shapeType == k_single_shape || shapeType == k_first_shape))
     {
         xStart = m_pStartBarlineShape->get_x_right_line();
         if (m_pStartBarlineShape->get_width() < 40.0f)
             xStart += 30.0f;
+    }
 
-        xEnd = m_pStopBarlineShape->get_x_left_line();
-        if (m_pStopBarlineShape->get_width() < 40.0f)
-            xEnd -= 30.0f;
-    }
-    else if (shapeType == k_first_shape)
-    {
-        xStart = m_pStartBarlineShape->get_x_right_line();
-        if (m_pStartBarlineShape->get_width() < 40.0f)
-            xStart += 30.0f;
-    }
-    else if (shapeType == k_final_shape)
+    if (shapeType == k_single_shape || shapeType == k_final_shape)
     {
         xEnd = m_pStopBarlineShape->get_x_left_line();
         if (m_pStopBarlineShape->get_width() < 40.0f)


### PR DESCRIPTION
This pull request corrects appearance of volta which happen to start at the first measure of a system.

The issue can be reproduced, for example, on a score from [`test-scores/unit-tests/repeats/04-repeat-barline-simple-volta.xml`](https://github.com/lenmus/lomse/blob/1f7b2235e8690f6a4c3de4cfe1cf0ff27d3a3373/test-scores/unit-tests/repeats/04-repeat-barline-simple-volta.xml). If you open this file with Lomse and set page width so that the second volta starts on a new system, the score is rendered as follows (note that number `2` and some part of a bracket are drawn after the end of the first system):
![before](https://user-images.githubusercontent.com/6000747/101290432-59611200-3813-11eb-9312-e5bdd1ebb5f6.png)

The reason of this issue seems to be that volta brackets are bound to barlines in the internal model, and the relevant start barline for a volta is actually located at the end of the previous system. Volta engraver doesn't account for that though and starts rendering volta bracket from that point. The proposed commit avoids creating a volta bracket shape near the start barline in this case so volta brackets get rendered as expected:
![after](https://user-images.githubusercontent.com/6000747/101290560-253a2100-3814-11eb-8735-34841b823305.png)

The fact that the start barline is situated at system end is currently detected just by doing a (fuzzy) comparison of the corresponding shape coordinates with the right boundary of the current system. This works (at least in those cases I tested) but doesn't seem very robust in general, so please let me know if there is a better way to detect whether a particular barline is the last in the current system.