### PR TITLE
Fix intermediate shapes not created for spanner RelObjs

### DIFF
--- a/include/lomse_beam_engraver.h
+++ b/include/lomse_beam_engraver.h
@@ -131,7 +131,10 @@ public:
 
     //RelObjEngraver mandatory overrides
     void set_prolog_width(LUnits UNUSED(width)) override {}
-    GmoShape* create_first_or_intermediate_shape(Color color=Color(0,0,0)) override;
+    GmoShape* create_first_or_intermediate_shape(LUnits xStaffLeft, LUnits xStaffRight,
+                                                 LUnits yStaffTop, LUnits prologWidth,
+                                                 VerticalProfile* pVProfile,
+                                                 Color color=Color(0,0,0)) override;
     GmoShape* create_last_shape(Color color=Color(0,0,0)) override;
 
     //During layout, when more space is added between two staves, all shapes are shifted

--- a/include/lomse_engraver.h
+++ b/include/lomse_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -135,7 +135,12 @@ public:
                                   int idxStaff, VerticalProfile* pVProfile) = 0;
 
     virtual void set_prolog_width(LUnits UNUSED(width)) {}
-    virtual GmoShape* create_first_or_intermediate_shape(Color UNUSED(color)=Color(0,0,0)) { return nullptr; }
+    virtual GmoShape* create_first_or_intermediate_shape(LUnits UNUSED(xStaffLeft),
+                                            LUnits UNUSED(xStaffRight),
+                                            LUnits UNUSED(yStaffTop),
+                                            LUnits UNUSED(prologWidth),
+                                            VerticalProfile* UNUSED(pVProfile),
+                                            Color UNUSED(color)=Color(0,0,0)) { return nullptr; }
     virtual GmoShape* create_last_shape(Color UNUSED(color)=Color(0,0,0)) { return nullptr; }
 };
 

--- a/include/lomse_octave_shift_engraver.h
+++ b/include/lomse_octave_shift_engraver.h
@@ -52,6 +52,8 @@ class OctaveShiftEngraver : public RelObjEngraver
 protected:
     InstrumentEngraver* m_pInstrEngrv;
     LUnits m_uStaffTop;         //top line of current system
+    LUnits m_uStaffLeft;
+    LUnits m_uStaffRight;
 
     int m_numShapes;
     ImoOctaveShift* m_pOctaveShift;
@@ -108,6 +110,7 @@ protected:
 
     void compute_first_shape_position();
     void compute_second_shape_position();
+    void compute_intermediate_shape_position();
     //void add_user_displacements(int iOctaveShift, UPoint* points);
     LUnits determine_top_line_of_shape();
 

--- a/include/lomse_octave_shift_engraver.h
+++ b/include/lomse_octave_shift_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -85,7 +85,10 @@ public:
 
     //RelObjEngraver mandatory overrides
     void set_prolog_width(LUnits width) override;
-    GmoShape* create_first_or_intermediate_shape(Color color=Color(0,0,0)) override;
+    GmoShape* create_first_or_intermediate_shape(LUnits xStaffLeft, LUnits xStaffRight,
+                                                 LUnits yStaffTop, LUnits prologWidth,
+                                                 VerticalProfile* pVProfile,
+                                                 Color color=Color(0,0,0)) override;
     GmoShape* create_last_shape(Color color=Color(0,0,0)) override;
 
 protected:

--- a/include/lomse_score_layouter.h
+++ b/include/lomse_score_layouter.h
@@ -75,7 +75,7 @@ class GmoShapeNote;
 
 //---------------------------------------------------------------------------------------
 // helper struct to store data about aux objs to be engraved when the system is ready
-struct PendingAuxObjs
+struct PendingAuxObj
 {
     ImoStaffObj* m_pSO;
     GmoShape* m_pMainShape;
@@ -86,7 +86,7 @@ struct PendingAuxObjs
     int m_iLine;
     int m_idxStaff;
 
-    PendingAuxObjs(ImoStaffObj* pSO, GmoShape* pMainShape, int iInstr, int iStaff,
+    PendingAuxObj(ImoStaffObj* pSO, GmoShape* pMainShape, int iInstr, int iStaff,
                    int iCol, int iLine, ImoInstrument* pInstr, int idxStaff)
         : m_pSO(pSO)
         , m_pMainShape(pMainShape)
@@ -128,8 +128,8 @@ struct PendingLyrics
 };
 
 // some helper typedefs
-typedef std::pair<ImoRelObj*, PendingAuxObjs*> PendingRelObj;
-typedef std::pair<std::string, PendingAuxObjs*> PendingLyricsObj;
+typedef std::pair<ImoRelObj*, PendingAuxObj*> PendingRelObj;
+typedef std::pair<std::string, PendingAuxObj*> PendingLyricsObj;
 
 
 //---------------------------------------------------------------------------------------
@@ -281,7 +281,7 @@ protected:
     LUnits distance_to_top_of_system(int iSystem, bool fFirstInPage);
 
     //AuxObjs and RelObjs pending to be engraved
-    std::list<PendingAuxObjs*> m_pendingAuxObjs;
+    std::list<PendingAuxObj*> m_pendingAuxObjs;
 
     //RelObjs that continue in next system
     std::list<PendingRelObj> m_notFinishedRelObj;

--- a/include/lomse_score_layouter.h
+++ b/include/lomse_score_layouter.h
@@ -127,8 +127,14 @@ struct PendingLyrics
 
 };
 
+// some helper typedefs
+typedef std::pair<ImoRelObj*, PendingAuxObjs*> PendingRelObj;
+typedef std::pair<std::string, PendingAuxObjs*> PendingLyricsObj;
+
 
 //---------------------------------------------------------------------------------------
+// Algorithm to layout an score
+//
 class ScoreLayouter : public Layouter
 {
 protected:
@@ -274,7 +280,14 @@ protected:
     LUnits space_used_by_prolog(int iSystem);
     LUnits distance_to_top_of_system(int iSystem, bool fFirstInPage);
 
+    //AuxObjs and RelObjs pending to be engraved
     std::list<PendingAuxObjs*> m_pendingAuxObjs;
+
+    //RelObjs that continue in next system
+    std::list<PendingRelObj> m_notFinishedRelObj;
+
+    //Lyrics that continue in next system
+    std::list<PendingLyricsObj> m_notFinishedLyrics;
 
 
     //---------------------------------------------------------------
@@ -372,7 +385,9 @@ public:
                                  int iSystem, int iCol, int iLine, LUnits prologWidth,
                                  ImoInstrument* pInstr, int idxStaff,
                                  VerticalProfile* pVProfile);
-    GmoShape* create_first_or_intermediate_shape(ImoRelObj* pRO);
+    GmoShape* create_first_or_intermediate_shape(ImoRelObj* pRO, int iInstr, int iStaff,
+                                                 LUnits prologWidth,
+                                                 VerticalProfile* pVProfile);
     GmoShape* create_last_shape(ImoRelObj* pRO);
 
     //AuxRelObj shapes

--- a/include/lomse_slur_engraver.h
+++ b/include/lomse_slur_engraver.h
@@ -88,7 +88,10 @@ public:
 
     //RelObjEngraver mandatory overrides
     void set_prolog_width(LUnits width) override;
-    GmoShape* create_first_or_intermediate_shape(Color color=Color(0,0,0)) override;
+    GmoShape* create_first_or_intermediate_shape(LUnits xStaffLeft, LUnits xStaffRight,
+                                                 LUnits yStaffTop, LUnits prologWidth,
+                                                 VerticalProfile* pVProfile,
+                                                 Color color=Color(0,0,0)) override;
     GmoShape* create_last_shape(Color color=Color(0,0,0)) override;
 
 protected:

--- a/include/lomse_system_layouter.h
+++ b/include/lomse_system_layouter.h
@@ -68,7 +68,7 @@ class SpacingAlgorithm;
 class SystemLayouter;
 class TypeMeasureInfo;
 class VerticalProfile;
-struct PendingAuxObjs;
+struct PendingAuxObj;
 
 //---------------------------------------------------------------------------------------
 // SystemLayouter: algorithm to layout a system
@@ -168,9 +168,9 @@ protected:
     bool measure_number_must_be_displayed(int policy, TypeMeasureInfo* pInfo,
                                           bool fFirstNumberInSystem);
 
-    void engrave_attached_object(ImoObj* pAR, PendingAuxObjs* pPAO, int iSystem);
-    void engrave_not_finished_relobj(ImoRelObj* pRO, PendingAuxObjs* pPAO, int iSystem);
-    void engrave_not_finished_lyrics(const std::string& tag, PendingAuxObjs* pPAO, int iSystem);
+    void engrave_attached_object(ImoObj* pAR, PendingAuxObj* pPAO, int iSystem);
+    void engrave_not_finished_relobj(ImoRelObj* pRO, PendingAuxObj* pPAO, int iSystem);
+    void engrave_not_finished_lyrics(const std::string& tag, PendingAuxObj* pPAO, int iSystem);
 
     void add_last_rel_shape_to_model(GmoShape* pShape, ImoRelObj* pRO, int layer,
                                      int iCol, int iInstr, int iStaff, int idxStaff);

--- a/include/lomse_system_layouter.h
+++ b/include/lomse_system_layouter.h
@@ -98,14 +98,6 @@ protected:
     bool m_fFirstColumnInSystem;
     int m_barlinesInfo;     //info about barlines at end of this system
 
-    //RelObjs that continue in next system
-    typedef std::pair<ImoRelObj*, PendingAuxObjs*> PendingRelObj;
-    std::list<PendingRelObj> m_notFinishedRelObj;
-
-    //Lyrics that continue in next system
-    typedef std::pair<std::string, PendingAuxObjs*> PendingLyrics;
-    std::list<PendingLyrics> m_notFinishedLyrics;
-
     //prolog shapes waiting to be added to slice staff box
     std::list< std::tuple<GmoShape*, int, int> > m_prologShapes;
 

--- a/include/lomse_tie_engraver.h
+++ b/include/lomse_tie_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -79,7 +79,10 @@ public:
 
     //RelObjEngraver mandatory overrides
     void set_prolog_width(LUnits width) override { m_uStaffLeft += width; }
-    GmoShape* create_first_or_intermediate_shape(Color color=Color(0,0,0)) override;
+    GmoShape* create_first_or_intermediate_shape(LUnits xStaffLeft, LUnits xStaffRight,
+                                                 LUnits yStaffTop, LUnits prologWidth,
+                                                 VerticalProfile* pVProfile,
+                                                 Color color=Color(0,0,0)) override;
     GmoShape* create_last_shape(Color color=Color(0,0,0)) override;
 
 

--- a/include/lomse_tuplet_engraver.h
+++ b/include/lomse_tuplet_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -89,7 +89,10 @@ public:
 
     //RelObjEngraver mandatory overrides
     void set_prolog_width(LUnits UNUSED(width)) override {}
-    GmoShape* create_first_or_intermediate_shape(Color color=Color(0,0,0)) override;
+    GmoShape* create_first_or_intermediate_shape(LUnits xStaffLeft, LUnits xStaffRight,
+                                                 LUnits yStaffTop, LUnits prologWidth,
+                                                 VerticalProfile* pVProfile,
+                                                 Color color=Color(0,0,0)) override;
     GmoShape* create_last_shape(Color color=Color(0,0,0)) override;
 
 protected:

--- a/include/lomse_volta_engraver.h
+++ b/include/lomse_volta_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2017. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -63,6 +63,8 @@ protected:
     GmoShapeBarline* m_pStartBarlineShape;
     GmoShapeBarline* m_pStopBarlineShape;
 
+    LUnits m_uPrologWidth = 0.0f;
+
 public:
     VoltaBracketEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter);
     ~VoltaBracketEngraver() {}
@@ -80,7 +82,10 @@ public:
 
     //RelObjEngraver mandatory overrides
     void set_prolog_width(LUnits width) override { m_uStaffLeft += width; }
-    GmoShape* create_first_or_intermediate_shape(Color color=Color(0,0,0)) override;
+    GmoShape* create_first_or_intermediate_shape(LUnits xStaffLeft, LUnits xStaffRight,
+                                                 LUnits yStaffTop, LUnits prologWidth,
+                                                 VerticalProfile* pVProfile,
+                                                 Color color=Color(0,0,0)) override;
     GmoShape* create_last_shape(Color color=Color(0,0,0)) override;
 
 protected:

--- a/include/lomse_wedge_engraver.h
+++ b/include/lomse_wedge_engraver.h
@@ -84,7 +84,10 @@ public:
 
     //RelObjEngraver mandatory overrides
     void set_prolog_width(LUnits width) override;
-    GmoShape* create_first_or_intermediate_shape(Color color=Color(0,0,0)) override;
+    GmoShape* create_first_or_intermediate_shape(LUnits xStaffLeft, LUnits xStaffRight,
+                                                 LUnits yStaffTop, LUnits prologWidth,
+                                                 VerticalProfile* pVProfile,
+                                                 Color color=Color(0,0,0)) override;
     GmoShape* create_last_shape(Color color=Color(0,0,0)) override;
 
 protected:

--- a/src/graphic_model/engravers/lomse_beam_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_beam_engraver.cpp
@@ -134,7 +134,10 @@ void BeamEngraver::add_note_rest(ImoStaffObj* pSO, GmoShape* pStaffObjShape)
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* BeamEngraver::create_first_or_intermediate_shape(Color color)
+GmoShape* BeamEngraver::create_first_or_intermediate_shape(LUnits UNUSED(xStaffLeft),
+                                LUnits UNUSED(xStaffRight), LUnits UNUSED(yStaffTop),
+                                LUnits UNUSED(prologWidth),
+                                VerticalProfile* UNUSED(pVProfile), Color color)
 {
     //TODO: It has been assumed that a beam cannot be split. This has to be revised
     m_color = color;

--- a/src/graphic_model/engravers/lomse_octave_shift_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_octave_shift_engraver.cpp
@@ -102,12 +102,18 @@ void OctaveShiftEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* 
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* OctaveShiftEngraver::create_first_or_intermediate_shape(LUnits UNUSED(xStaffLeft),
-                                    LUnits UNUSED(xStaffRight), LUnits UNUSED(yStaffTop),
-                                    LUnits UNUSED(prologWidth),
-                                    VerticalProfile* UNUSED(pVProfile), Color color)
+GmoShape* OctaveShiftEngraver::create_first_or_intermediate_shape(LUnits xStaffLeft,
+                                    LUnits xStaffRight, LUnits yStaffTop,
+                                    LUnits prologWidth, VerticalProfile* pVProfile,
+                                    Color color)
 {
     m_color = color;
+    m_uStaffLeft = xStaffLeft;
+    m_uStaffRight = xStaffRight;
+    m_uStaffTop = yStaffTop;
+    m_pVProfile = pVProfile;
+    m_uPrologWidth = prologWidth;
+
     if (m_numShapes == 0)
     {
         decide_placement();
@@ -134,9 +140,13 @@ GmoShape* OctaveShiftEngraver::create_intermediate_shape()
 {
     //intermediate shape spanning the whole system
 
+    compute_intermediate_shape_position();
+    //add_user_displacements(0, &m_points[0]);
+    create_main_container_shape();
+    add_line_info();
+
     ++m_numShapes;
-    //TODO
-    return nullptr;
+    return m_pMainShape;
 }
 
 //---------------------------------------------------------------------------------------
@@ -280,6 +290,20 @@ void OctaveShiftEngraver::compute_second_shape_position()
 }
 
 //---------------------------------------------------------------------------------------
+void OctaveShiftEngraver::compute_intermediate_shape_position()
+{
+    //compute xLeft and xRight positions
+    m_points[0].x = m_uStaffLeft + m_uPrologWidth - m_pShapeNumeral->get_width()
+                    - tenths_to_logical(LOMSE_OCTAVE_SHIFT_SPACE_TO_LINE);
+;
+    m_points[1].x = m_pInstrEngrv->get_staves_right();     //xRight at end of staff
+
+    //determine yTop
+    m_points[0].y = determine_top_line_of_shape();
+    m_points[1].y = m_points[0].y;
+}
+
+//---------------------------------------------------------------------------------------
 LUnits OctaveShiftEngraver::determine_top_line_of_shape()
 {
     LUnits yRef = m_uStaffTop;
@@ -326,7 +350,7 @@ void OctaveShiftEngraver::decide_placement()
 //---------------------------------------------------------------------------------------
 void OctaveShiftEngraver::set_prolog_width(LUnits width)
 {
-    m_uPrologWidth += width;
+    m_uPrologWidth = width;
 }
 
 

--- a/src/graphic_model/engravers/lomse_octave_shift_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_octave_shift_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -102,7 +102,10 @@ void OctaveShiftEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* 
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* OctaveShiftEngraver::create_first_or_intermediate_shape(Color color)
+GmoShape* OctaveShiftEngraver::create_first_or_intermediate_shape(LUnits UNUSED(xStaffLeft),
+                                    LUnits UNUSED(xStaffRight), LUnits UNUSED(yStaffTop),
+                                    LUnits UNUSED(prologWidth),
+                                    VerticalProfile* UNUSED(pVProfile), Color color)
 {
     m_color = color;
     if (m_numShapes == 0)

--- a/src/graphic_model/engravers/lomse_slur_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_slur_engraver.cpp
@@ -122,7 +122,10 @@ void SlurEngraver::decide_placement()
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* SlurEngraver::create_first_or_intermediate_shape(Color color)
+GmoShape* SlurEngraver::create_first_or_intermediate_shape(LUnits UNUSED(xStaffLeft),
+                                    LUnits UNUSED(xStaffRight), LUnits UNUSED(yStaffTop),
+                                    LUnits UNUSED(prologWidth),
+                                    VerticalProfile* UNUSED(pVProfile), Color color)
 {
     m_color = color;
     if (m_numShapes == 0)

--- a/src/graphic_model/engravers/lomse_tie_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_tie_engraver.cpp
@@ -110,7 +110,10 @@ void TieEngraver::decide_placement()
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* TieEngraver::create_first_or_intermediate_shape(Color color)
+GmoShape* TieEngraver::create_first_or_intermediate_shape(LUnits UNUSED(xStaffLeft),
+                                    LUnits UNUSED(xStaffRight), LUnits UNUSED(yStaffTop),
+                                    LUnits UNUSED(prologWidth),
+                                    VerticalProfile* UNUSED(pVProfile), Color color)
 {
     m_color = color;
     if (m_numShapes == 0)

--- a/src/graphic_model/engravers/lomse_tuplet_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_tuplet_engraver.cpp
@@ -118,7 +118,10 @@ void TupletEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* pSO,
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* TupletEngraver::create_first_or_intermediate_shape(Color color)
+GmoShape* TupletEngraver::create_first_or_intermediate_shape(LUnits UNUSED(xStaffLeft),
+                                    LUnits UNUSED(xStaffRight), LUnits UNUSED(yStaffTop),
+                                    LUnits UNUSED(prologWidth),
+                                    VerticalProfile* UNUSED(pVProfile), Color color)
 {
     //TODO: It has been assumed that a tuplet cannot be split. This has to be revised
     m_color = color;

--- a/src/graphic_model/engravers/lomse_volta_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_volta_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -105,9 +105,18 @@ void VoltaBracketEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj*
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* VoltaBracketEngraver::create_first_or_intermediate_shape(Color color)
+GmoShape* VoltaBracketEngraver::create_first_or_intermediate_shape(LUnits xStaffLeft,
+                                    LUnits xStaffRight, LUnits yStaffTop,
+                                    LUnits prologWidth, VerticalProfile* pVProfile,
+                                    Color color)
 {
     m_color = color;
+    m_uStaffLeft = xStaffLeft;
+    m_uStaffRight = xStaffRight;
+    m_uStaffTop = yStaffTop;
+    m_pVProfile = pVProfile;
+    m_uPrologWidth = prologWidth;
+
     if (m_numShapes == 0)
         return create_first_shape();
     else
@@ -231,6 +240,12 @@ void VoltaBracketEngraver::set_shape_details(GmoShapeVoltaBracket* pShape,
         xEnd = m_pStopBarlineShape->get_x_left_line();
         if (m_pStopBarlineShape->get_width() < 40.0f)
             xEnd -= 30.0f;
+    }
+
+    if (shapeType == k_intermediate_shape
+        || (m_fFirstShapeAtSystemStart && (shapeType == k_first_shape )) )
+    {
+        xStart += m_uPrologWidth;
     }
 
     //determine yPos

--- a/src/graphic_model/engravers/lomse_wedge_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_wedge_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -106,7 +106,10 @@ void WedgeEngraver::decide_placement()
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* WedgeEngraver::create_first_or_intermediate_shape(Color color)
+GmoShape* WedgeEngraver::create_first_or_intermediate_shape(LUnits UNUSED(xStaffLeft),
+                                    LUnits UNUSED(xStaffRight), LUnits yStaffTop,
+                                    LUnits prologWidth, VerticalProfile* pVProfile,
+                                    Color color)
 {
     m_color = color;
     if (m_numShapes == 0)
@@ -115,7 +118,15 @@ GmoShape* WedgeEngraver::create_first_or_intermediate_shape(Color color)
         return create_first_shape();
     }
     else
-        return create_intermediate_shape();
+    {
+        m_uStaffTop = yStaffTop;
+        m_pVProfile = pVProfile;
+        LUnits save = m_uPrologWidth;
+        m_uPrologWidth = prologWidth;
+        GmoShape* pShape = create_intermediate_shape();
+        m_uPrologWidth = save;
+        return pShape;
+    }
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/engravers/lomse_wedge_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_wedge_engraver.cpp
@@ -112,21 +112,17 @@ GmoShape* WedgeEngraver::create_first_or_intermediate_shape(LUnits UNUSED(xStaff
                                     Color color)
 {
     m_color = color;
+    m_uStaffTop = yStaffTop;
+    m_pVProfile = pVProfile;
+    m_uPrologWidth = prologWidth;
+
     if (m_numShapes == 0)
     {
         decide_placement();
         return create_first_shape();
     }
     else
-    {
-        m_uStaffTop = yStaffTop;
-        m_pVProfile = pVProfile;
-        LUnits save = m_uPrologWidth;
-        m_uPrologWidth = prologWidth;
-        GmoShape* pShape = create_intermediate_shape();
-        m_uPrologWidth = save;
-        return pShape;
-    }
+        return create_intermediate_shape();
 }
 
 //---------------------------------------------------------------------------------------
@@ -344,7 +340,7 @@ LUnits WedgeEngraver::determine_center_line_of_shape(LUnits startSpread, LUnits 
 //---------------------------------------------------------------------------------------
 void WedgeEngraver::set_prolog_width(LUnits width)
 {
-    m_uPrologWidth += width;
+    m_uPrologWidth = width;
 }
 
 

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -724,7 +724,7 @@ void ScoreLayouter::delete_pendig_aux_objects()
     //in other places
 
     //AuxObjs and RelObjs pending to be engraved
-    std::list<PendingAuxObjs*>::iterator itPAO;
+    std::list<PendingAuxObj*>::iterator itPAO;
     for (itPAO = m_pendingAuxObjs.begin(); itPAO != m_pendingAuxObjs.end(); ++itPAO)
         delete *itPAO;
     m_pendingAuxObjs.clear();
@@ -736,6 +736,9 @@ void ScoreLayouter::delete_pendig_aux_objects()
     m_notFinishedRelObj.clear();
 
     //Lyrics that continue in next system
+    std::list<PendingLyricsObj>::iterator itPLO;
+    for (itPLO = m_notFinishedLyrics.begin(); itPLO != m_notFinishedLyrics.end(); ++itPLO)
+        delete (*itPLO).second;
     m_notFinishedLyrics.clear();
 }
 

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -723,10 +723,20 @@ void ScoreLayouter::delete_pendig_aux_objects()
     //it is necessary to delete objects that, in normal processing, will be deleted
     //in other places
 
+    //AuxObjs and RelObjs pending to be engraved
     std::list<PendingAuxObjs*>::iterator itPAO;
     for (itPAO = m_pendingAuxObjs.begin(); itPAO != m_pendingAuxObjs.end(); ++itPAO)
         delete *itPAO;
     m_pendingAuxObjs.clear();
+
+    //RelObjs that continue in next system
+    std::list<PendingRelObj>::iterator itPRO;
+    for (itPRO = m_notFinishedRelObj.begin(); itPRO != m_notFinishedRelObj.end(); ++itPRO)
+        delete (*itPRO).second;
+    m_notFinishedRelObj.clear();
+
+    //Lyrics that continue in next system
+    m_notFinishedLyrics.clear();
 }
 
 //---------------------------------------------------------------------------------------
@@ -1405,11 +1415,24 @@ GmoShape* ShapesCreator::create_last_shape(ImoRelObj* pRO)
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* ShapesCreator::create_first_or_intermediate_shape(ImoRelObj* pRO)
+GmoShape* ShapesCreator::create_first_or_intermediate_shape(ImoRelObj* pRO, int iInstr,
+                                                            int iStaff, LUnits prologWidth,
+                                                            VerticalProfile* pVProfile)
 {
     RelObjEngraver* pEngrv
         = static_cast<RelObjEngraver*>(m_engravers.get_engraver(pRO));
-    return pEngrv->create_first_or_intermediate_shape(pRO->get_color());
+
+    if (pEngrv)
+    {
+        InstrumentEngraver* pInstrEngrv = m_pPartsEngraver->get_engraver_for(iInstr);
+        LUnits xRight = pInstrEngrv->get_staves_right();
+        LUnits xLeft = pInstrEngrv->get_staves_left();
+        LUnits yTop = pInstrEngrv->get_top_line_of_staff(iStaff);
+        return pEngrv->create_first_or_intermediate_shape(xLeft, xRight, yTop,
+                                                          prologWidth, pVProfile,
+                                                          pRO->get_color());
+    }
+    return nullptr;
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/layouters/lomse_spacing_algorithm.cpp
+++ b/src/graphic_model/layouters/lomse_spacing_algorithm.cpp
@@ -495,7 +495,7 @@ void ColumnsBuilder::store_info_about_attached_objects(ImoStaffObj* pSO,
     if (!pAuxObjs && !pRelObjs)
         return;
 
-    PendingAuxObjs* data = LOMSE_NEW PendingAuxObjs(pSO, pMainShape, iInstr, iStaff,
+    PendingAuxObj* data = LOMSE_NEW PendingAuxObj(pSO, pMainShape, iInstr, iStaff,
                            iCol, iLine, pInstr, idxStaff);
     m_pScoreLyt->m_pendingAuxObjs.push_back(data);
 }

--- a/src/graphic_model/layouters/lomse_system_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_system_layouter.cpp
@@ -69,7 +69,7 @@ namespace lomse
 // Some variables to control engraving ordering for AuxObjs/RelObjs
 //=======================================================================================
 
-typedef std::pair<ImoObj*, PendingAuxObjs*> PendingPair;
+typedef std::pair<ImoObj*, PendingAuxObj*> PendingPair;
 
 #define k_num_auxobjs (k_imo_auxobj_last - k_imo_auxobj - 1) + (k_imo_relobj_last - k_imo_relobj -1)
 static int m_order[k_num_auxobjs];
@@ -728,7 +728,7 @@ void SystemLayouter::engrave_system_details(int iSystem)
     std::bitset<k_imo_last> used;
     used.reset();
 
-    std::list<PendingAuxObjs*>::iterator it;
+    std::list<PendingAuxObj*>::iterator it;
     for (it = m_pScoreLyt->m_pendingAuxObjs.begin(); it != m_pScoreLyt->m_pendingAuxObjs.end(); ++it)
     {
         int iCol = (*it)->m_iCol;
@@ -737,7 +737,7 @@ void SystemLayouter::engrave_system_details(int iSystem)
             break;
         if (objSystem == iSystem)
         {
-            PendingAuxObjs* pParent = *it;
+            PendingAuxObj* pParent = *it;
 
             //add its AuxObjs/RelObjs to the system list
             ImoStaffObj* pSO = (*it)->m_pSO;
@@ -801,7 +801,6 @@ void SystemLayouter::engrave_system_details(int iSystem)
     for (itAR = m_pScoreLyt->m_notFinishedLyrics.begin();
          itAR != m_pScoreLyt->m_notFinishedLyrics.end(); ++itAR)
     {
-        //exclude objects
         engrave_not_finished_lyrics((*itAR).first, (*itAR).second, iSystem);
     }
 
@@ -814,7 +813,7 @@ void SystemLayouter::engrave_system_details(int iSystem)
             break;
         if (objSystem == iSystem)
         {
-            PendingAuxObjs* pPAO = *it;
+            PendingAuxObj* pPAO = *it;
 		    it = m_pScoreLyt->m_pendingAuxObjs.erase(it);
             delete pPAO;
         }
@@ -824,7 +823,7 @@ void SystemLayouter::engrave_system_details(int iSystem)
 }
 
 //---------------------------------------------------------------------------------------
-void SystemLayouter::engrave_attached_object(ImoObj* pAR, PendingAuxObjs* pPAO,
+void SystemLayouter::engrave_attached_object(ImoObj* pAR, PendingAuxObj* pPAO,
                                              int iSystem)
 {
     ImoStaffObj* pSO = pPAO->m_pSO;
@@ -869,7 +868,7 @@ void SystemLayouter::engrave_attached_object(ImoObj* pAR, PendingAuxObjs* pPAO,
                                                      iInstr, iStaff, iSystem, iCol,
                                                      iLine, pInstr, idxStaff,
                                                      m_pVProfile);
-            PendingAuxObjs* pData = LOMSE_NEW PendingAuxObjs(*pPAO);
+            PendingAuxObj* pData = LOMSE_NEW PendingAuxObj(*pPAO);
             m_pScoreLyt->m_notFinishedRelObj.push_back(make_pair(pRO, pData) );
         }
         else if (pSO == pRO->get_end_object())
@@ -932,7 +931,8 @@ void SystemLayouter::engrave_attached_object(ImoObj* pAR, PendingAuxObjs* pPAO,
                     m_pShapesCreator->start_engraving_auxrelobj(pLyric, pSO, tag.str(),
                                                 pNoteShape, iInstr, iStaff, iSystem,
                                                 iCol, iLine, pInstr, idxStaff, m_pVProfile);
-                    m_pScoreLyt->m_notFinishedLyrics.push_back(make_pair(tag.str(), pPAO));
+                    PendingAuxObj* pData = LOMSE_NEW PendingAuxObj(*pPAO);
+                    m_pScoreLyt->m_notFinishedLyrics.push_back(make_pair(tag.str(), pData));
                 }
                 else if (pLyric->is_end_of_relation())
                 {
@@ -954,6 +954,7 @@ void SystemLayouter::engrave_attached_object(ImoObj* pAR, PendingAuxObjs* pPAO,
                     {
                         if ((*itAR).first == tag.str())
                         {
+                            delete (*itAR).second;
                             m_pScoreLyt->m_notFinishedLyrics.erase(itAR);
                             break;
                         }
@@ -978,7 +979,8 @@ void SystemLayouter::engrave_attached_object(ImoObj* pAR, PendingAuxObjs* pPAO,
                     }
                     if (it == m_pScoreLyt->m_notFinishedLyrics.end())
                     {
-                        m_pScoreLyt->m_notFinishedLyrics.push_back(make_pair(tag.str(), pPAO));
+                        PendingAuxObj* pData = LOMSE_NEW PendingAuxObj(*pPAO);
+                        m_pScoreLyt->m_notFinishedLyrics.push_back(make_pair(tag.str(), pData));
                     }
                 }
             }
@@ -1000,7 +1002,7 @@ void SystemLayouter::engrave_attached_object(ImoObj* pAR, PendingAuxObjs* pPAO,
 }
 
 //---------------------------------------------------------------------------------------
-void SystemLayouter::engrave_not_finished_relobj(ImoRelObj* pRO, PendingAuxObjs* pPAO,
+void SystemLayouter::engrave_not_finished_relobj(ImoRelObj* pRO, PendingAuxObj* pPAO,
                                                  int UNUSED(iSystem))
 {
     int iInstr = pPAO->m_iInstr;
@@ -1017,7 +1019,7 @@ void SystemLayouter::engrave_not_finished_relobj(ImoRelObj* pRO, PendingAuxObjs*
 }
 
 //---------------------------------------------------------------------------------------
-void SystemLayouter::engrave_not_finished_lyrics(const string& tag, PendingAuxObjs* pPAO,
+void SystemLayouter::engrave_not_finished_lyrics(const string& tag, PendingAuxObj* pPAO,
                                                  int UNUSED(iSystem))
 {
     add_lyrics_shapes_to_model(tag, GmoShape::k_layer_aux_objs, false, pPAO->m_iStaff,


### PR DESCRIPTION
This PR fixes #273. Also fixes the same problem in all current spanner RelObjs (wedges, volta brackets and octave shifts).


### Changes

Method `create_intermediate_shape()` is protected in engravers. The public method that triggers its invocation is `create_first_or_intermediate_shape()`. For spanner RelObjs, the engraver invokes `create_intermediate_shape()` to create a shape for the whole system when the start point is in a previous sytem and the end point is in a later system.

The problem causing that method `create_first_or_intermediate_shape()` was not invoked for intermediate shapes was that pending objects lists `m_notFinishedRelObj` and `m_notFinishedLyrics` were declared as member variables in `SystemLayouter` and thus, they were erased after finishing engraving each system. Now its scope is ScoreLayouter scope.

Once this was solved, and `create_intermediate_shape()` is invoked, the engraver has no information about current system: position, margins, etc. So it was necessary to modify `create_first_or_intermediate_shape()` signature to pass system information to the engraver.

Then, some small changes in the engravers to fix the position of the intermediate shapes. For octave shifts its `create_intermediate_shape()` method was empty and was coded.

Finally, struct `PendingAuxObjs` defined in score layouter was renamed in singular, as `PendingAuxObj`.
