### PR TITLE
Attach dynamics markings to notes or rests on reading MusicXML files

### DIFF
--- a/include/lomse_mxl_analyser.h
+++ b/include/lomse_mxl_analyser.h
@@ -250,6 +250,7 @@ protected:
     MxlVoltasBuilder*   m_pVoltasBuilder;
     MxlWedgesBuilder*   m_pWedgesBuilder;
     MxlOctaveShiftBuilder*  m_pOctaveShiftBuilder;
+    vector<ImoDynamicsMark*> m_pendingDynamicsMarks;
     map<string, int>    m_lyricIndex;
     vector<ImoLyric*>   m_lyrics;
     map<string, int>    m_soundIdToIdx;     //conversion sound-instrument id to index
@@ -407,6 +408,10 @@ public:
 
     //interface for building beams
     inline bool fix_beams() { return m_libraryScope.get_musicxml_options()->fix_beams(); }
+
+    //interface for building dynamics marks
+    void add_pending_dynamics_mark(ImoDynamicsMark* pObj) { m_pendingDynamicsMarks.push_back(pObj); }
+    void attach_pending_dynamics_marks(ImoNoteRest* pNR);
 
     //interface for building lyric lines
     void add_lyrics_data(ImoNote* pNote, ImoLyric* pData);

--- a/include/private/lomse_internal_model_p.h
+++ b/include/private/lomse_internal_model_p.h
@@ -2356,6 +2356,7 @@ public:
     ImoAuxObj* get_attachment(int i);
     void add_attachment(Document* pDoc, ImoAuxObj* pAO);
     void remove_attachment(ImoAuxObj* pAO);
+    void remove_but_not_delete_attachment(ImoAuxObj* pAO);
     ImoAuxObj* find_attachment(int type);
 
     //overrides for Observable children

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -2154,6 +2154,13 @@ void ImoContentObj::remove_attachment(ImoAuxObj* pAO)
 }
 
 //---------------------------------------------------------------------------------------
+void ImoContentObj::remove_but_not_delete_attachment(ImoAuxObj* pAO)
+{
+    ImoAttachments* pAuxObjs = get_attachments();
+    pAuxObjs->remove(pAO);
+}
+
+//---------------------------------------------------------------------------------------
 ImoAuxObj* ImoContentObj::find_attachment(int type)
 {
     ImoAttachments* pAuxObjs = get_attachments();

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -2806,6 +2806,10 @@ public:
         error_if_more_elements();
 
         pSO->add_attachment(pDoc, pImo);
+
+        if (!pSO->is_note_rest())
+            m_pAnalyser->add_pending_dynamics_mark(pImo);
+
         return pImo;
     }
 
@@ -4233,6 +4237,7 @@ public:
 
         pNR->set_visible(fVisible);
         add_to_model(pNR);
+        attach_pending_dynamics_marks(pNR);
         add_to_spanners(pNR);
 
         //deal with grace notes
@@ -4568,6 +4573,12 @@ protected:
             m_pBeamInfo->set_note_rest(pNR);
             m_pAnalyser->add_relation_info(m_pBeamInfo);
         }
+    }
+
+    //----------------------------------------------------------------------------------
+    void attach_pending_dynamics_marks(ImoNoteRest* pNR)
+    {
+        m_pAnalyser->attach_pending_dynamics_marks(pNR);
     }
 
     //----------------------------------------------------------------------------------
@@ -7741,6 +7752,23 @@ void MxlAnalyser::clear_pending_relations()
 
     m_lyrics.clear();
     m_lyricIndex.clear();
+    m_pendingDynamicsMarks.clear();
+}
+
+//---------------------------------------------------------------------------------------
+void MxlAnalyser::attach_pending_dynamics_marks(ImoNoteRest* pNR)
+{
+    for (ImoDynamicsMark* pDynamics : m_pendingDynamicsMarks)
+    {
+        ImoContentObj* pOldParent = pDynamics->get_contentobj_parent();
+
+        if (pOldParent)
+            pOldParent->remove_but_not_delete_attachment(pDynamics);
+
+        pNR->add_attachment(m_pDoc, pDynamics);
+    }
+
+    m_pendingDynamicsMarks.clear();
 }
 
 //---------------------------------------------------------------------------------------


### PR DESCRIPTION
Currently dynamics markings engraver assumes that dynamics is attached to a note or rest. MusicXML importer however attaches it to `ImoDirection` when reading it as a descendant of `<direction>` tag. This difference results in dynamics being not aligned with notes or rests which they belongs to, for example (with [`test-scores/50035-directions-take-no-space.xml`](https://github.com/lenmus/lomse/blob/fe7e7bc993c5b83a5fee5b8bf682d5ead21b6d9f/test-scores/50035-directions-take-no-space.xml))
![before](https://user-images.githubusercontent.com/6000747/102313929-9602db00-3f82-11eb-9cf3-f3e8d4549902.png)

With some real-world scores it may look even worse: some dynamics marks become crossing barlines and causing some wedges being pushed further down:
![Screenshot_20201216_092728](https://user-images.githubusercontent.com/6000747/102314272-3953f000-3f83-11eb-80f1-dfb17ee55d8b.png)

This commit makes MusicXML analyser attach dynamics markings to notes and rests instead of `ImoDirection`. I am not sure whether it has any implications on the model side, but the engraver seems to work much better in this case making dynamics marks aligned with the relevant notes:
![after](https://user-images.githubusercontent.com/6000747/102314458-8768f380-3f83-11eb-83ae-5ca139bc5a10.png)

![Screenshot_20201216_092919](https://user-images.githubusercontent.com/6000747/102314464-8c2da780-3f83-11eb-989c-b7f106167ed0.png)

The approach used here is similar to that already used for octave shifts: if dynamics marking needs to be attached to a note or rest which is not yet available, it is added to a list of pending items which get attached to the next note or rest when it gets read. This approach should be possible to use for other objects that might need it as well — at least I was considering something similar for pedal marks (unless they would be better to be attached to `ImoDirection`?).