### PR TITLE
Fix crash related to MusicXML importer

### DIFF
--- a/src/exporters/lomse_ldp_exporter.cpp
+++ b/src/exporters/lomse_ldp_exporter.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -872,7 +872,7 @@ public:
         else if (m_pObj->get_width() > 0.0f)
             start_element("spacer", m_pObj->get_id());
         else
-            return string("(dir unknown)");
+            return string("(dir empty)");
 
         add_space_width();
         add_spanners();

--- a/src/internal_model/lomse_staffobjs_table.cpp
+++ b/src/internal_model/lomse_staffobjs_table.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -228,10 +228,10 @@ bool ColStaffObjs::is_lower_entry(ColStaffObjsEntry* b, ColStaffObjsEntry* a)
        )
         return false;   //preserve definition order: insert barline B after grace A
 
-    //R4. barlines must go before all other objects  at same timepos having
+    //R4. Any object must go before all other objects at same timepos having
     //    high measure number
-    if (pB->is_barline() && (b->measure() < a->measure()) )
-        return true;    //B (barline) cannot go after A, Try with A-1
+    if (b->measure() < a->measure())
+        return true;    //B (high measure number) cannot go after A, Try with A-1
 
     //R6. Graces in the same timepos must go before note/rest in that timepos
     if (pB->is_grace_note() && (pA->is_rest() || pA->is_regular_note() || pA->is_cue_note()) )

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -3129,7 +3129,7 @@ public:
             int voice = get_child_value_integer( m_pAnalyser->get_current_voice() );
 
             // staff?
-            int staff = 1;
+            int staff = 0;
             if (get_optional("staff"))
                 staff = get_child_value_integer(1) - 1;
 
@@ -4066,6 +4066,19 @@ protected:
 //@ - Grace notes do not have a duration element.
 //@ - Cue notes have a duration element, as do forward elements, but no tie elements.
 //@
+//@ <!ATTLIST note
+//@     %print-style;
+//@     %printout;
+//@     print-leger %yes-no; #IMPLIED
+//@     dynamics CDATA #IMPLIED
+//@     end-dynamics CDATA #IMPLIED
+//@     attack CDATA #IMPLIED
+//@     release CDATA #IMPLIED
+//@     %time-only;
+//@     pizzicato %yes-no; #IMPLIED
+//@     %optional-unique-id;
+//@ >
+//@
 
 class NoteRestMxlAnalyser : public MxlElementAnalyser
 {
@@ -4094,13 +4107,19 @@ public:
         //attrb: print-object
         bool fVisible = get_optional_yes_no_attribute("print-object", "yes");
 
+        //attrb: print-spacing
+        bool fTakesSpace = get_optional_yes_no_attribute("print-spacing", "yes");
+
+        if (!fTakesSpace)
+            return nullptr;     //ignore
+
             //elements
 
         // [<cue>]
         bool fIsCue = get_optional("cue");
-        //for now, ignore cue notes
-        if (fIsCue)
-            return nullptr;
+//        //for now, ignore cue notes
+//        if (fIsCue)
+//            return nullptr;
 
         // [<grace>]
         bool fIsGrace = get_optional("grace");

--- a/src/tests/lomse_test_ldp_exporter.cpp
+++ b/src/tests/lomse_test_ldp_exporter.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -419,7 +419,7 @@ SUITE(LdpExporterTest)
         exporter.set_remove_newlines(true);
         string source = exporter.get_source(pImo);
         //cout << test_name() << endl << "\"" << source << "\"" << endl;
-        CHECK( source == "(dir unknown)" );
+        CHECK( source == "(dir empty)" );
     }
 
 

--- a/src/tests/lomse_test_staffobjs_table.cpp
+++ b/src/tests/lomse_test_staffobjs_table.cpp
@@ -365,8 +365,8 @@ SUITE(ColStaffObjsBuilderTest)
         CHECK_ENTRY0(it, 1,	    0,	  0,	0,	  1,	"(r q v1 p1)" );
         CHECK_ENTRY0(it, 0,	    0,	  0,	64,	  0,	"(barline simple)" );
         CHECK_ENTRY0(it, 1,	    0,	  0,	64,	  1,	"(barline simple)" );
-        CHECK_ENTRY0(it, 0,	    0,	  1,	64,	  0,	"(dir unknown)" );
-        CHECK_ENTRY0(it, 1,	    0,	  1,	64,	  1,	"(dir unknown)" );
+        CHECK_ENTRY0(it, 0,	    0,	  1,	64,	  0,	"(dir empty)" );
+        CHECK_ENTRY0(it, 1,	    0,	  1,	64,	  1,	"(dir empty)" );
         CHECK_ENTRY0(it, 0,	    0,	  1,	64,	  0,	"(n a4 q v1 p1)" );
         CHECK_ENTRY0(it, 1,	    0,	  1,	64,	  1,	"(n e4 q v1 p1)" );
         CHECK_ENTRY0(it, 0,	    0,	  1,	128,  0,	"(barline simple)" );
@@ -590,6 +590,56 @@ SUITE(ColStaffObjsBuilderTest)
         CHECK_ENTRY0(it, 0,    0,      0,   128,   0, "(barline simple)" );
         CHECK_ENTRY0(it, 0,    0,      1,   128,   0, "(n c3 q v1 p1)" );
     }
+
+    TEST_FIXTURE(ColStaffObjsBuilderTestFixture, lower_entry_13)
+    {
+        //@13. R4. Direction in previous measure, 2nd instr, cannot go after barline
+        //@        at the same timepos in 1st instr.
+
+        Document doc(m_libraryScope);
+        doc.from_file(m_scores_path + "unit-tests/colstaffobjs/08-direction-after-ts-in-2nd-instr.xml",
+                      Document::k_format_mxl);
+        ImoScore* pScore = dynamic_cast<ImoScore*>( doc.get_content_item(0) );
+        CHECK( pScore != nullptr );
+        ColStaffObjs* pTable = pScore->get_staffobjs_table();
+
+//        cout << test_name() << endl;
+//        cout << pTable->dump();
+
+        CHECK( pTable->num_lines() == 2 );
+        CHECK( pTable->num_entries() == 28 );
+        CHECK( is_equal_time(pTable->min_note_duration(), TimeUnits(k_duration_half)));
+
+        ColStaffObjsIterator it = pTable->begin();
+        //              instr, staff, meas. time, line, scr
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(clef G p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(key C)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(time 3 4)" );
+        CHECK_ENTRY0(it, 1,    0,      0,   0,     1, "(clef G p1)" );
+        CHECK_ENTRY0(it, 1,    0,      0,   0,     1, "(key C)" );
+        CHECK_ENTRY0(it, 1,    0,      0,   0,     1, "(time 3 4)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,     0, "(dir empty)" );
+        CHECK_ENTRY0(it, 1,    0,      0,   0,     1, "(dir empty)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   0,	   0, "(n b5 h. v1 p1 (stem down)(dyn \"p\" below))" );
+        CHECK_ENTRY0(it, 1,    0,      0,   0,     1, "(n b5 h. v1 p1 (stem down)(dyn \"p\" below))" );
+        CHECK_ENTRY0(it, 1,    0,      0,   192,   1, "(dir 0 (TODO:  No LdpGenerator for Imo. Imo name=wedge, Imo type=102, id=68) p1)" );
+        CHECK_ENTRY0(it, 0,    0,      0,   192,   0, "(barline simple)" );
+        CHECK_ENTRY0(it, 1,    0,      0,   192,   1, "(barline simple)" );
+        CHECK_ENTRY0(it, 0,    0,      1,   192,   0, "(time 2 4)" );
+        CHECK_ENTRY0(it, 1,    0,      1,   192,   1, "(time 2 4)" );
+        CHECK_ENTRY0(it, 0,    0,      1,   192,   0, "(n b5 h v1 p1 (stem down))" );
+        CHECK_ENTRY0(it, 1,    0,      1,   192,   1, "(n b5 h v1 p1 (stem down))" );
+        CHECK_ENTRY0(it, 1,    0,      1,   320,   1, "(dir 0 (TODO:  No LdpGenerator for Imo. Imo name=wedge, Imo type=102, id=68) p1)" );
+        CHECK_ENTRY0(it, 0,    0,      1,   320,   0, "(barline simple)" );
+        CHECK_ENTRY0(it, 1,    0,      1,   320,   1, "(barline simple)" );
+        CHECK_ENTRY0(it, 0,    0,      2,   320,   0, "(time 4 4)" );
+        CHECK_ENTRY0(it, 1,    0,      2,   320,   1, "(time 4 4)" );
+        CHECK_ENTRY0(it, 0,    0,      2,   320,   0, "(n b5 w v1 p1)" );
+        CHECK_ENTRY0(it, 1,    0,      2,   320,   1, "(n a5 w v1 p1)" );
+        CHECK_ENTRY0(it, 1,    0,      2,   576,   1, "(dir 0 (TODO:  No LdpGenerator for Imo. Imo name=wedge, Imo type=102, id=76) p1)" );
+        CHECK_ENTRY0(it, 1,    0,      2,   576,   1, "(dir 0 (TODO:  No LdpGenerator for Imo. Imo name=wedge, Imo type=102, id=76) p1)" );
+        CHECK_ENTRY0(it, 0,    0,      2,   576,   0, "(barline simple)" );
+        CHECK_ENTRY0(it, 1,    0,      2,   576,   1, "(barline simple)" );    }
 
     TEST_FIXTURE(ColStaffObjsBuilderTestFixture, playback_time_200)
     {

--- a/test-scores/unit-tests/colstaffobjs/08-direction-after-ts-in-2nd-instr.xml
+++ b/test-scores/unit-tests/colstaffobjs/08-direction-after-ts-in-2nd-instr.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name/>
+    </score-part>
+    <score-part id="P2">
+      <part-name/>
+    </score-part>
+  </part-list>
+  <!--=========================================================-->
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>8</divisions>
+        <key>
+          <fifths>0</fifths>
+          <mode>major</mode>
+        </key>
+        <time>
+          <beats>3</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+        <staff-details>
+          <staff-size>108</staff-size>
+        </staff-details>
+      </attributes>
+      <direction placement="below">
+        <direction-type>
+          <dynamics halign="center">
+            <p/>
+          </dynamics>
+        </direction-type>
+        <sound dynamics="67"/>
+      </direction>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>24</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <dot/>
+        <stem>down</stem>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="2">
+      <attributes>
+        <time>
+          <beats>2</beats>
+          <beat-type>4</beat-type>
+        </time>
+      </attributes>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>16</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>down</stem>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="3">
+      <attributes>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <staff-details>
+          <staff-size>100</staff-size>
+        </staff-details>
+      </attributes>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>32</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+  </part>
+  <!--=========================================================-->
+  <part id="P2">
+    <measure number="1">
+      <attributes>
+        <divisions>8</divisions>
+        <key>
+          <fifths>0</fifths>
+          <mode>major</mode>
+        </key>
+        <time>
+          <beats>3</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+        <staff-details>
+          <staff-size>108</staff-size>
+        </staff-details>
+      </attributes>
+      <direction placement="below">
+        <direction-type>
+          <dynamics halign="center">
+            <p/>
+          </dynamics>
+        </direction-type>
+        <sound dynamics="67"/>
+      </direction>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>24</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <dot/>
+        <stem>down</stem>
+      </note>
+      <direction placement="below">
+        <direction-type>
+          <wedge type="crescendo"/>
+        </direction-type>
+        <offset>-21</offset>
+      </direction>
+    </measure>
+    <!--=======================================================-->
+    <measure number="2">
+      <attributes>
+        <time>
+          <beats>2</beats>
+          <beat-type>4</beat-type>
+        </time>
+      </attributes>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>16</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>down</stem>
+      </note>
+      <direction>
+        <direction-type>
+          <wedge spread="16" type="stop"/>
+        </direction-type>
+        <offset>-1</offset>
+      </direction>
+    </measure>
+    <!--=======================================================-->
+    <measure number="3">
+      <attributes>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <staff-details>
+          <staff-size>100</staff-size>
+        </staff-details>
+      </attributes>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>32</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <accidental>sharp</accidental>
+      </note>
+      <direction placement="below">
+        <direction-type>
+          <wedge spread="15" type="diminuendo"/>
+        </direction-type>
+        <offset>-30</offset>
+      </direction>
+      <direction>
+        <direction-type>
+          <wedge type="stop"/>
+        </direction-type>
+        <offset>-1</offset>
+      </direction>
+    </measure>
+  </part>
+  <!--=========================================================-->
+</score-partwise>


### PR DESCRIPTION
This PR fixes a couple of issues detected when importing a MusicXML file:
- Notes not taking visible space `<note print-spacing="no">` are no longer imported.
- Fix a rule for ordering StaffObjs.
- Cue notes are now imported, although for now they are displayed as normal notes.