### PR TITLE
Add full support for cue notes

### DIFF
--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -1133,6 +1133,7 @@ GmoShape* ShapesCreator::create_staffobj_shape(ImoStaffObj* pSO, int iInstr, int
         }
         case k_imo_note_regular:
         case k_imo_note_grace:
+        case k_imo_note_cue:
         {
             ImoNote* pImo = static_cast<ImoNote*>(pSO);
             NoteEngraver engrv(m_libraryScope, m_pScoreMeter, &m_engravers,

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -4171,9 +4171,6 @@ public:
 
         // [<cue>]
         bool fIsCue = get_optional("cue");
-//        //for now, ignore cue notes
-//        if (fIsCue)
-//            return nullptr;
 
         // [<grace>]
         bool fIsGrace = get_optional("grace");
@@ -4207,7 +4204,8 @@ public:
         }
         else
         {
-            int type = (fIsGrace ? k_imo_note_grace : k_imo_note_regular);
+            int type = (fIsGrace ? k_imo_note_grace
+                                 : (fIsCue ? k_imo_note_cue : k_imo_note_regular));
             pNote = static_cast<ImoNote*>(ImFactory::inject(type, pDoc));
             pNR = pNote;
             if (get_optional("unpitched"))

--- a/src/sound/lomse_midi_table.cpp
+++ b/src/sound/lomse_midi_table.cpp
@@ -162,7 +162,8 @@ void SoundEventsTable::create_events()
         pSO = cursor.get_staffobj();
         if (pSO->is_note_rest())
         {
-            add_noterest_events(cursor, measure);
+            if (!pSO->is_cue_note())
+                add_noterest_events(cursor, measure);
         }
         else if (pSO->is_barline())
         {


### PR DESCRIPTION
Closes #252. With this PR cue notes are properly imported in MusicXML, and are correctly managed: are rendered in smaller size and are ignored in playback.