### PR TITLE
Draw repeat barline dots on all staves

### DIFF
--- a/include/lomse_barline_engraver.h
+++ b/include/lomse_barline_engraver.h
@@ -39,6 +39,7 @@ namespace lomse
 
 //forward declarations
 class ImoBarline;
+class InstrumentEngraver;
 class GmoBoxSliceInstr;
 class GmoShape;
 class ScoreMeter;
@@ -47,7 +48,8 @@ class ScoreMeter;
 class BarlineEngraver : public Engraver
 {
 public:
-    BarlineEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter, int iInstr=0);
+    BarlineEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
+                    int iInstr=0, InstrumentEngraver* pInstrEngrv = nullptr);
     BarlineEngraver(LibraryScope& libraryScope);
     ~BarlineEngraver() {}
 
@@ -61,6 +63,7 @@ public:
 
 protected:
     GmoShape* m_pBarlineShape;
+    InstrumentEngraver* m_pInstrEngrv;
 
 };
 

--- a/include/lomse_box_slice.h
+++ b/include/lomse_box_slice.h
@@ -62,8 +62,9 @@ public:
     //helpers for layout
     /**  Move boxes and shapes to theirs final 'y' positions. */
     void reposition_slices_and_shapes(const std::vector<LUnits>& yOrgShifts,
-                                      std::vector<LUnits>& heights,
-                                      vector<LUnits>& barlinesHeight,
+                                      const std::vector<LUnits>& heights,
+                                      const std::vector<LUnits>& barlinesHeight,
+                                      const std::vector<std::vector<LUnits>>& relStaffTopPositions,
                                       SystemLayouter* pSysLayouter);
     GmoBoxSliceStaff* get_slice_staff_for(int iInstr, int iStaff);
 

--- a/include/lomse_box_slice_instr.h
+++ b/include/lomse_box_slice_instr.h
@@ -61,8 +61,9 @@ public:
     //helpers for layout
     /**  Move boxes and shapes to theirs final 'y' positions. */
     void reposition_slices_and_shapes(const std::vector<LUnits>& yOrgShifts,
-                                      std::vector<LUnits>& heights,
+                                      const std::vector<LUnits>& heights,
                                       LUnits barlinesHeight,
+                                      const std::vector<LUnits>& relStaffTopPositions,
                                       SystemLayouter* pSysLayouter);
     GmoBoxSliceStaff* get_slice_staff_for(int iStaff);
 
@@ -88,6 +89,7 @@ public:
     //helpers for layout
     /**  Move shapes to theirs final 'y' positions and increment barlines height. */
     void reposition_shapes(const vector<LUnits>& yShifts, LUnits barlinesHeight,
+                           const std::vector<LUnits>& relStaffTopPositions,
                            SystemLayouter* pSysLayouter, int staff);
 
 protected:

--- a/include/lomse_box_system.h
+++ b/include/lomse_box_system.h
@@ -68,8 +68,9 @@ public:
     //helpers for layout
     /**  Move boxes and shapes to theirs final 'y' positions. */
     void reposition_slices_and_shapes(const std::vector<LUnits>& yOrgShifts,
-                                      std::vector<LUnits>& heights,
-                                      vector<LUnits>& barlinesHeight,
+                                      const std::vector<LUnits>& heights,
+                                      const std::vector<LUnits>& barlinesHeight,
+                                      const std::vector<std::vector<LUnits>>& relStaffTopPositions,
                                       SystemLayouter* pSysLayouter);
 
     //slices

--- a/include/lomse_instrument_engraver.h
+++ b/include/lomse_instrument_engraver.h
@@ -192,7 +192,7 @@ public:
     LUnits get_staff_bottom_position() { return m_staffBottom.back()  + m_yShifts.back(); }
     LUnits get_top_line_of_staff(int iStaff);
     LUnits get_bottom_line_of_staff(int iStaff);
-    LUnits get_unshifted_bottom_line_of_staff(int iStaff);
+    void reset_staff_position_shifts();
 
     //shapes
     void add_staff_lines(GmoBoxSystem* pBox);

--- a/include/lomse_shape_barline.h
+++ b/include/lomse_shape_barline.h
@@ -33,6 +33,8 @@
 #include "lomse_basic.h"
 #include "lomse_shape_base.h"
 
+#include <vector>
+
 namespace lomse
 {
 
@@ -57,6 +59,7 @@ protected:
     LUnits  m_xRightLine;           //x right of last right line
     LUnits  m_xLeftLine;            //x left of first left line
 
+    std::vector<LUnits> m_relStaffTopPositions;
 
     friend class BarlineEngraver;
     GmoShapeBarline(ImoObj* pCreatorImo, ShapeId idx, int nBarlineType,
@@ -76,6 +79,9 @@ public:
     inline LUnits get_x_right_line() { return m_xRightLine + m_uxLeft; }
     inline LUnits get_x_left_line() { return m_xLeftLine + m_uxLeft; }
 
+    void set_relative_staff_top_positions(const std::vector<LUnits>& positions) { m_relStaffTopPositions = positions; }
+    void set_relative_staff_top_positions(std::vector<LUnits>&& positions) { m_relStaffTopPositions = std::move(positions); }
+
 protected:
     void compute_width();
     void determine_lines_relative_positions();
@@ -84,6 +90,7 @@ protected:
     void draw_thick_line(Drawer* pDrawer, LUnits uxLeft, LUnits uyTop, LUnits uWidth,
                          LUnits uHeight, Color color);
     void draw_two_dots(Drawer* pDrawer, LUnits uxPos, LUnits uyPos, Color color);
+    void draw_repeat_dots_for_all_staves(Drawer* pDrawer, LUnits uxPos, LUnits uyPos, Color color);
 
 };
 

--- a/src/graphic_model/engravers/lomse_instrument_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_instrument_engraver.cpp
@@ -360,6 +360,7 @@ void PartsEngraver::set_position_and_width_for_staves(LUnits indent, UPoint org,
     {
         (*it)->set_staves_horizontal_position(left, width, indent);
         (*it)->set_slice_instr_origin(org);
+        (*it)->reset_staff_position_shifts();
     }
 }
 
@@ -827,7 +828,7 @@ void InstrumentEngraver::reposition_staff(int iStaff, LUnits yShift)
 //---------------------------------------------------------------------------------------
 LUnits InstrumentEngraver::get_top_line_of_staff(int iStaff)
 {
-    return m_org.y + m_staffTop[iStaff] + m_lineThickness[iStaff] / 2.0f;
+    return m_org.y + m_staffTop[iStaff] + m_yShifts[iStaff] + m_lineThickness[iStaff] / 2.0f;
 }
 
 //---------------------------------------------------------------------------------------
@@ -838,9 +839,12 @@ LUnits InstrumentEngraver::get_bottom_line_of_staff(int iStaff)
 }
 
 //---------------------------------------------------------------------------------------
-LUnits InstrumentEngraver::get_unshifted_bottom_line_of_staff(int iStaff)
+void InstrumentEngraver::reset_staff_position_shifts()
 {
-    return m_org.y + m_staffBottom[iStaff] + m_lineThickness[iStaff] / 2.0f;
+    for (LUnits& yShift : m_yShifts)
+    {
+        yShift = 0;
+    }
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -1109,7 +1109,7 @@ GmoShape* ShapesCreator::create_staffobj_shape(ImoStaffObj* pSO, int iInstr, int
                 m_pPartsEngraver->get_engraver_for(iInstr);
             LUnits yTop = pInstrEngrv->get_barline_top();
             LUnits yBottom = pInstrEngrv->get_barline_bottom();
-            BarlineEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr);
+            BarlineEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr, pInstrEngrv);
             Color color = pImo->get_color();
             return engrv.create_shape(pImo, pos.x, yTop, yBottom, color);
         }

--- a/src/graphic_model/layouters/lomse_system_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_system_layouter.cpp
@@ -239,8 +239,7 @@ void SystemLayouter::create_vertical_profile()
         for (int iStaff=0; iStaff < pInstrEngraver->get_num_staves(); iStaff++)
         {
             LUnits yTop = pInstrEngraver->get_top_line_of_staff(iStaff);
-            //LUnits yBottom = pInstrEngraver->get_bottom_line_of_staff(iStaff);
-            LUnits yBottom = pInstrEngraver->get_unshifted_bottom_line_of_staff(iStaff);
+            LUnits yBottom = pInstrEngraver->get_bottom_line_of_staff(iStaff);
             int idxStaff = m_pScoreMeter->staff_index(iInstr, iStaff);
             m_pVProfile->initialize(idxStaff, yTop, yBottom);
         }

--- a/src/graphic_model/layouters/lomse_system_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_system_layouter.cpp
@@ -596,16 +596,27 @@ void SystemLayouter::reposition_slice_boxes_and_shapes(const vector<LUnits>& yOr
 {
     int numInstrs = m_pScore->get_num_instruments();
     vector<LUnits> barlinesHeight(numInstrs);
+    vector<vector<LUnits>> relStaffTopPositions(numInstrs);
 
     for (int iInstr = 0; iInstr < numInstrs; iInstr++)
     {
         InstrumentEngraver* pInstrEngrv = m_pPartsEngraver->get_engraver_for(iInstr);
-        barlinesHeight[iInstr] = pInstrEngrv->get_barline_bottom()
-                                - pInstrEngrv->get_barline_top();
+
+        const LUnits yTop = pInstrEngrv->get_barline_top();
+        barlinesHeight[iInstr] = pInstrEngrv->get_barline_bottom() - yTop;
+
+        const int numStaves = pInstrEngrv->get_num_staves();
+        relStaffTopPositions[iInstr].reserve(numStaves);
+
+        for (int iStaff = 0; iStaff < numStaves; ++iStaff)
+        {
+            const LUnits relStaffTop = pInstrEngrv->get_top_line_of_staff(iStaff) - yTop;
+            relStaffTopPositions[iInstr].push_back(relStaffTop);
+        }
     }
 
     GmoBoxSystem* pSystem = get_box_system();
-    pSystem->reposition_slices_and_shapes(yOrgShifts, heights, barlinesHeight, this);
+    pSystem->reposition_slices_and_shapes(yOrgShifts, heights, barlinesHeight, relStaffTopPositions, this);
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/lomse_box_slice.cpp
+++ b/src/graphic_model/lomse_box_slice.cpp
@@ -65,8 +65,9 @@ GmoBoxSliceInstr* GmoBoxSlice::add_box_for_instrument(ImoInstrument* pInstr,
 
 //---------------------------------------------------------------------------------------
 void GmoBoxSlice::reposition_slices_and_shapes(const vector<LUnits>& yOrgShifts,
-                                               vector<LUnits>& heights,
-                                               vector<LUnits>& barlinesHeight,
+                                               const vector<LUnits>& heights,
+                                               const vector<LUnits>& barlinesHeight,
+                                               const vector<vector<LUnits>>& relStaffTopPositions,
                                                SystemLayouter* pSysLayouter)
 
 {
@@ -76,7 +77,8 @@ void GmoBoxSlice::reposition_slices_and_shapes(const vector<LUnits>& yOrgShifts,
     {
         GmoBoxSliceInstr* pSlice = static_cast<GmoBoxSliceInstr*>(*it);
         pSlice->reposition_slices_and_shapes(yOrgShifts, heights,
-                                             barlinesHeight[iInstr], pSysLayouter);
+                                             barlinesHeight[iInstr], relStaffTopPositions[iInstr],
+                                             pSysLayouter);
     }
 
     //shift origin and increase height

--- a/src/graphic_model/lomse_box_slice_instr.cpp
+++ b/src/graphic_model/lomse_box_slice_instr.cpp
@@ -77,8 +77,9 @@ void GmoBoxSliceInstr::add_shape(GmoShape* pShape, int layer, int iStaff)
 
 //---------------------------------------------------------------------------------------
 void GmoBoxSliceInstr::reposition_slices_and_shapes(const vector<LUnits>& yOrgShifts,
-                                                    vector<LUnits>& heights,
+                                                    const vector<LUnits>& heights,
                                                     LUnits barlinesHeight,
+                                                    const std::vector<LUnits>& relStaffTopPositions,
                                                     SystemLayouter* pSysLayouter)
 
 {
@@ -88,7 +89,7 @@ void GmoBoxSliceInstr::reposition_slices_and_shapes(const vector<LUnits>& yOrgSh
     for (it=m_childBoxes.begin(); it != m_childBoxes.end(); ++it, ++staff)
     {
         GmoBoxSliceStaff* pSlice = static_cast<GmoBoxSliceStaff*>(*it);
-        pSlice->reposition_shapes(yOrgShifts, barlinesHeight, pSysLayouter, staff);
+        pSlice->reposition_shapes(yOrgShifts, barlinesHeight, relStaffTopPositions, pSysLayouter, staff);
 
         m_size.height += heights[idxStaff];
     }
@@ -121,6 +122,7 @@ GmoBoxSliceStaff::~GmoBoxSliceStaff()
 //---------------------------------------------------------------------------------------
 void GmoBoxSliceStaff::reposition_shapes(const vector<LUnits>& yShifts,
                                          LUnits barlinesHeight,
+                                         const std::vector<LUnits>& relStaffTopPositions,
                                          SystemLayouter* pSysLayouter, int UNUSED(staff))
 
 {
@@ -133,7 +135,11 @@ void GmoBoxSliceStaff::reposition_shapes(const vector<LUnits>& yShifts,
         for (it=m_shapes.begin(); it != m_shapes.end(); ++it)
         {
             if ((*it)->is_shape_barline())
-                (*it)->set_height(barlinesHeight);
+            {
+                GmoShapeBarline* pBarlineShape = static_cast<GmoShapeBarline*>(*it);
+                pBarlineShape->set_height(barlinesHeight);
+                pBarlineShape->set_relative_staff_top_positions(relStaffTopPositions);
+            }
         }
     }
     else
@@ -189,8 +195,10 @@ void GmoBoxSliceStaff::reposition_shapes(const vector<LUnits>& yShifts,
             }
             else if ((*it)->is_shape_barline())
             {
-                (*it)->reposition_shape(yShift);
-                (*it)->set_height(barlinesHeight);
+                GmoShapeBarline* pBarlineShape = static_cast<GmoShapeBarline*>(*it);
+                pBarlineShape->reposition_shape(yShift);
+                pBarlineShape->set_height(barlinesHeight);
+                pBarlineShape->set_relative_staff_top_positions(relStaffTopPositions);
             }
             else
             {

--- a/src/graphic_model/lomse_box_system.cpp
+++ b/src/graphic_model/lomse_box_system.cpp
@@ -100,8 +100,9 @@ GmoShapeStaff* GmoBoxSystem::get_staff_shape(int iInstr, int iStaff)
 
 //---------------------------------------------------------------------------------------
 void GmoBoxSystem::reposition_slices_and_shapes(const vector<LUnits>& yOrgShifts,
-                                                vector<LUnits>& heights,
-                                                vector<LUnits>& barlinesHeight,
+                                                const vector<LUnits>& heights,
+                                                const vector<LUnits>& barlinesHeight,
+                                                const vector<vector<LUnits>>& relStaffTopPositions,
                                                 SystemLayouter* pSysLayouter)
 
 {
@@ -110,6 +111,7 @@ void GmoBoxSystem::reposition_slices_and_shapes(const vector<LUnits>& yOrgShifts
     {
         GmoBoxSlice* pSlice = static_cast<GmoBoxSlice*>(*it);
         pSlice->reposition_slices_and_shapes(yOrgShifts, heights, barlinesHeight,
+                                             relStaffTopPositions,
                                              pSysLayouter);
     }
 

--- a/src/graphic_model/lomse_shape_barline.cpp
+++ b/src/graphic_model/lomse_shape_barline.cpp
@@ -208,7 +208,7 @@ void GmoShapeBarline::on_draw(Drawer* pDrawer, RenderOptions& opt)
         case k_barline_end_repetition:
             //uxPos += m_uRadius;
             uxPos += m_uRadius * 2.7f;   //BUG-BYPASS: Need to shift right the drawing
-            draw_two_dots(pDrawer, uxPos, uyTop, color);
+            draw_repeat_dots_for_all_staves(pDrawer, uxPos, uyTop, color);
             uxPos += m_uRadius + m_uSpacing;
             draw_thin_line(pDrawer, uxPos, uyTop, uyBottom, color);
             uxPos += m_uThinLineWidth + m_uSpacing;
@@ -220,29 +220,29 @@ void GmoShapeBarline::on_draw(Drawer* pDrawer, RenderOptions& opt)
             uxPos += m_uThickLineWidth + m_uSpacing;
             draw_thin_line(pDrawer, uxPos, uyTop, uyBottom, color);
             uxPos += m_uThinLineWidth + m_uSpacing + m_uRadius;
-            draw_two_dots(pDrawer, uxPos, uyTop, color);
+            draw_repeat_dots_for_all_staves(pDrawer, uxPos, uyTop, color);
             break;
 
         case k_barline_double_repetition:
             uxPos += m_uRadius;
-            draw_two_dots(pDrawer, uxPos, uyTop, color);
+            draw_repeat_dots_for_all_staves(pDrawer, uxPos, uyTop, color);
             uxPos += m_uSpacing + m_uRadius;
             draw_thin_line(pDrawer, uxPos, uyTop, uyBottom, color);
             uxPos += m_uThinLineWidth + m_uSpacing;
             draw_thin_line(pDrawer, uxPos, uyTop, uyBottom, color);
             uxPos += m_uThinLineWidth + m_uSpacing + m_uRadius;
-            draw_two_dots(pDrawer, uxPos, uyTop, color);
+            draw_repeat_dots_for_all_staves(pDrawer, uxPos, uyTop, color);
             break;
 
         case k_barline_double_repetition_alt:
             uxPos += m_uRadius;
-            draw_two_dots(pDrawer, uxPos, uyTop, color);
+            draw_repeat_dots_for_all_staves(pDrawer, uxPos, uyTop, color);
             uxPos += m_uSpacing + m_uRadius;
             draw_thick_line(pDrawer, uxPos, uyTop, m_uThickLineWidth, uyBottom-uyTop, color);
             uxPos += m_uThickLineWidth + m_uSpacing;
             draw_thick_line(pDrawer, uxPos, uyTop, m_uThickLineWidth, uyBottom-uyTop, color);
             uxPos += m_uThickLineWidth + m_uSpacing + m_uRadius;
-            draw_two_dots(pDrawer, uxPos, uyTop, color);
+            draw_repeat_dots_for_all_staves(pDrawer, uxPos, uyTop, color);
             break;
 
         case k_barline_start:
@@ -304,6 +304,22 @@ void GmoShapeBarline::draw_two_dots(Drawer* pDrawer, LUnits uxPos, LUnits uyPos,
     pDrawer->circle(uxPos, uyPos + uShift1, m_uRadius);
     pDrawer->circle(uxPos, uyPos + uShift2, m_uRadius);
     pDrawer->end_path();
+}
+
+//---------------------------------------------------------------------------------------
+void GmoShapeBarline::draw_repeat_dots_for_all_staves(Drawer* pDrawer, LUnits uxPos, LUnits uyPos, Color color)
+{
+    if (m_relStaffTopPositions.empty())
+    {
+        draw_two_dots(pDrawer, uxPos, uyPos, color);
+        return;
+    }
+
+    for (LUnits relStaffTop : m_relStaffTopPositions)
+    {
+        const LUnits absStaffTop = uyPos + relStaffTop;
+        draw_two_dots(pDrawer, uxPos, absStaffTop, color);
+    }
 }
 
 ////---------------------------------------------------------------------------------------


### PR DESCRIPTION
Currently Lomse draws dots of repeat barlines only on the first staff of the instrument, for example:
![before](https://user-images.githubusercontent.com/6000747/125104411-07a0a300-e0e6-11eb-8036-bc9bfc5383f2.png)

However repeat dots are commonly placed on each staff in multi-staff scores. This PR makes repeat dots appear on all staves, so the example shown above now looks like the following:
![after](https://user-images.githubusercontent.com/6000747/125105023-ab8a4e80-e0e6-11eb-9760-383d3e1d0b17.png)

As repeat dots drawing is handled by a barline shape, this shape needs to know coordinates of all staves in its range, so most of the changes in this PR are about forwarding this information to barline shapes. The first commit here reverts b3c2f2b4c2d32040fad74b8f3efaa91a2175ad62 and instead ensures that vertical staff position shifts are reset when a new system's layout begins. This is needed to ensure that `InstrumentEngraver::get_top_line_of_staff()` (which definition is changed to take these shifts into account, consistently with the other relevant methods of `InstrumentEngraver`) always gives correct positions for staff coordinates in the current system.