### PR TITLE
MusicXML: fix wedge endpoints order if wedge end is found before wedge start

### DIFF
--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -7399,7 +7399,7 @@ protected:
 
         if (m_pAnalyser->wedge_id_exists(num) && value != "continue")
         {
-            m_pInfo1->set_start(false);
+            m_pInfo1->set_start(value != "stop");
             int wedgeId =  m_pAnalyser->get_wedge_id_and_close(num);
             m_pInfo1->set_wedge_number(wedgeId);
             if (value == "crescendo")
@@ -7407,7 +7407,7 @@ protected:
         }
         else if (value == "crescendo" || value == "diminuendo" || value == "stop")
         {
-            m_pInfo1->set_start(true);
+            m_pInfo1->set_start(value != "stop");
             int wedgeId =  m_pAnalyser->new_wedge_id(num);
             m_pInfo1->set_wedge_number(wedgeId);
             m_pInfo1->set_crescendo(value == "crescendo");
@@ -7822,7 +7822,7 @@ void MxlAnalyser::add_relation_info(ImoObj* pDto)
     else if (pDto->is_volta_bracket_dto())
         m_pVoltasBuilder->add_item_info(static_cast<ImoVoltaBracketDto*>(pDto));
     else if (pDto->is_wedge_dto())
-        m_pWedgesBuilder->add_item_info(static_cast<ImoWedgeDto*>(pDto));
+        m_pWedgesBuilder->add_item_info_reversed_valid(static_cast<ImoWedgeDto*>(pDto));
     else if (pDto->is_octave_shift_dto())
         m_pOctaveShiftBuilder->add_item_info(static_cast<ImoOctaveShiftDto*>(pDto));
 }
@@ -8478,6 +8478,11 @@ void MxlWedgesBuilder::add_relation_to_staffobjs(ImoWedgeDto* pEndDto)
 {
     ImoWedgeDto* pStartDto = m_matches.front();
     m_matches.push_back(pEndDto);
+
+    //start and end coud be reversed if end was defined before start
+    if (m_matches.back()->is_start_of_relation())
+        std::swap(m_matches.front(), m_matches.back());
+
     Document* pDoc = m_pAnalyser->get_document_being_analysed();
 
     ImoWedge* pWedge = static_cast<ImoWedge*>(

--- a/src/tests/lomse_test_mxl_analyser.cpp
+++ b/src/tests/lomse_test_mxl_analyser.cpp
@@ -6496,6 +6496,7 @@ SUITE(MxlAnalyserTest)
                         CHECK( pWedge->is_crescendo() == false );
                         CHECK( pWedge->get_wedge_number() == 1 );
                         CHECK( !is_different(pWedge->get_color(), Color(0,0,0)) );
+                        CHECK( pWedge->get_end_object() == pDir ); //the first ImoDirection is the end of this edge
                     }
                 }
             }


### PR DESCRIPTION
Similar to slurs (which are handled in #286), wedge end can be found before wedge start in a MusicXML file. The code responsible for reading wedges has a provision for this case so such wedges are already imported. However order of endpoints of such wedges is wrong which leads to a crash on an attempt to render such wedge. A minimal example of this case can be given by this file: 
[wedge.musicxml.zip](https://github.com/lenmus/lomse/files/6796796/wedge.musicxml.zip)

This pull request changes handling of wedges' endpoints in the same way as it has been done for slurs in #286, so order of wedge endpoints is corrected so that wedge stop always goes last. This allows to properly import and display such wedges.

This pull request though doesn't deal with the reason of the crash itself, so an incorrect MusicXML file still can lead to a crash if trying to engrave such score. So in the future some fix for this crash could still be useful (for example, by not assuming a correct order or endpoints on engraving stage or by validating endpoints order after reading a MusicXML file).