### PR TITLE
Fix -Wdeprecated-copy compiler warnings from GCC

### DIFF
--- a/include/lomse_score_iterator.h
+++ b/include/lomse_score_iterator.h
@@ -54,8 +54,6 @@ protected:
 
 public:
     StaffObjsIterator(ColStaffObjs* pColStaffObjs);
-    StaffObjsIterator(const StaffObjsIterator& it);
-    ~StaffObjsIterator();
 
 
     inline bool is_first() { return m_it == m_pColStaffObjs->begin(); }

--- a/include/lomse_staffobjs_table.h
+++ b/include/lomse_staffobjs_table.h
@@ -181,15 +181,6 @@ public:
                 }
             }
 
-            virtual ~iterator() {}
-
-            iterator& operator =(const iterator& it) {
-                m_pCurrent = it.m_pCurrent;
-                m_pNext = it.m_pNext;
-                m_pPrev = it.m_pPrev;
-                return *this;
-            }
-
 	        ColStaffObjsEntry* operator *() const { return m_pCurrent; }
 
             iterator& operator ++() {

--- a/include/lomse_xml_parser.h
+++ b/include/lomse_xml_parser.h
@@ -60,7 +60,6 @@ protected:
 
 public:
     XmlNode() {}
-    XmlNode(const XmlNode& node) : m_node(node.m_node) {}
     XmlNode(const XmlNode* node) : m_node(node->m_node) {}
 
     string name() { return string(m_node.name()); }

--- a/include/private/lomse_internal_model_p.h
+++ b/include/private/lomse_internal_model_p.h
@@ -3228,20 +3228,6 @@ protected:
     {
     }
 
-    ImoLineStyle(ImoLineStyle& info)
-        : ImoSimpleObj(k_imo_line_style)
-        , m_lineStyle( info.get_line_style() )
-        , m_startEdge( info.get_start_edge() )
-        , m_endEdge( info.get_end_edge() )
-        , m_startStyle( info.get_start_cap() )
-        , m_endStyle( info.get_end_cap() )
-        , m_color( info.get_color() )
-        , m_width( info.get_width() )
-        , m_startPoint( info.get_start_point() )
-        , m_endPoint( info.get_end_point() )
-    {
-    }
-
 public:
     virtual ~ImoLineStyle() {}
 
@@ -3621,7 +3607,6 @@ protected:
     friend class ImoDocument;
     friend class ImoScore;
     ImoPageInfo();
-    ImoPageInfo(ImoPageInfo& dto);
 
 public:
     virtual ~ImoPageInfo() {}
@@ -5854,7 +5839,6 @@ protected:
     friend class ImFactory;
     friend class ImoScore;
     ImoSystemInfo();
-    ImoSystemInfo(ImoSystemInfo& dto);
 
 public:
     virtual ~ImoSystemInfo() {}

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -5146,19 +5146,6 @@ ImoPageInfo::ImoPageInfo()
     //defaults: DIN A4 (210.0 x 297.0 mm), portrait
 }
 
-//---------------------------------------------------------------------------------------
-ImoPageInfo::ImoPageInfo(ImoPageInfo& dto)
-    : ImoSimpleObj(k_imo_page_info)
-    , m_uLeftMargin( dto.get_left_margin() )
-    , m_uRightMargin( dto.get_right_margin() )
-    , m_uTopMargin( dto.get_top_margin() )
-    , m_uBottomMargin( dto.get_bottom_margin() )
-    , m_uBindingMargin( dto.get_binding_margin() )
-    , m_uPageSize( dto.get_page_size() )
-    , m_fPortrait( dto.is_portrait() )
-{
-}
-
 
 //=======================================================================================
 // ImoScoreText implementation
@@ -5292,17 +5279,6 @@ ImoSystemInfo::ImoSystemInfo()
     , m_rightMargin(0.0f)
     , m_systemDistance(0.0f)
     , m_topSystemDistance(0.0f)
-{
-}
-
-//---------------------------------------------------------------------------------------
-ImoSystemInfo::ImoSystemInfo(ImoSystemInfo& dto)
-    : ImoSimpleObj(k_imo_system_info)
-    , m_fFirst( dto.is_first() )
-    , m_leftMargin( dto.get_left_margin() )
-    , m_rightMargin( dto.get_right_margin() )
-    , m_systemDistance( dto.get_system_distance() )
-    , m_topSystemDistance( dto.get_top_system_distance() )
 {
 }
 

--- a/src/score/lomse_score_iterator.cpp
+++ b/src/score/lomse_score_iterator.cpp
@@ -46,18 +46,6 @@ StaffObjsIterator::StaffObjsIterator(ColStaffObjs* pColStaffObjs)
 }
 
 //---------------------------------------------------------------------------------------
-StaffObjsIterator::StaffObjsIterator(const StaffObjsIterator& it)
-{
-    m_pColStaffObjs = it.m_pColStaffObjs;
-    m_it = it.m_it;;
-}
-
-//---------------------------------------------------------------------------------------
-StaffObjsIterator::~StaffObjsIterator()
-{
-}
-
-//---------------------------------------------------------------------------------------
 void StaffObjsIterator::first()
 {
     m_it = m_pColStaffObjs->begin();


### PR DESCRIPTION
This PR fixes [`-Wdeprecated-copy`](https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html) warnings which appear when compiling Lomse with GCC 10. The reason of the warnings is that some classes contain declarations only for one of copy constructor or copy assignment operator, but the other declaration was missing (but actually used by the library's code). Therefore a compiler is forced to generate the missing constructor/operator itself but this is deprecated in such situation since C++11 and actually should not normally happen since this violates [the rule of three](https://en.wikipedia.org/wiki/Rule_of_three_(C%2B%2B_programming)). Therefore in order to avoid the warning (and potential issues related to this situation) copy constructor and copy assignment operator should either both be user-defined (or deleted) or not defined at all so both their definitions will be defined by a compiler if needed.

In Lomse code the warnings result from manually defining copy constructor or assignment in two ways:
1) Exactly that way as it would be defined by a compiler (that is, just copying/assigning all members of this class and invoking base classes' copying/assignment if needed)
2) Defining them *almost* that way: copy constructors for `ImoLineStyle`, `ImoSystemInfo` and `ImoPageInfo` differ from the default definition in parameters of the base class constructor, but this doesn't seem to be necessary from these classes' semantics, and these copy constructors are actually never used (which can be verified by deleting these copy constructors with `= delete`).

Since the copy constructors or assignment operators in question are either identical to the default ones or unused, I went for removing them in both cases, so they can be defined by a compiler in the default way. This fixes the related warnings and should hopefully make semantics of these operations more clear.

The only case which is not covered by this PR is about [`PathAttributes`](https://github.com/lenmus/lomse/blob/0ff4802acba463bbbd259727c4eefe61c773f7e7/include/lomse_path_attributes.h#L167) class which needs to have user-defined copy constructor and assignment operator (since it has to copy its `fill_gradient` by creating a new instance of that gradient) but is used only in `agg::pod_bvector` container which does not honor destructor of this class. However I wonder whether `pod_bvector` can be replaced there by `vector` or `deque` from STL, so this class could manage lifetime of that gradient without relying on other objects to delete it?