### PR TITLE
Avoid crashes with malformed files (spanners reversed)

### DIFF
--- a/docs/api/doxyfile
+++ b/docs/api/doxyfile
@@ -19,7 +19,7 @@
 
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "Lomse library. API documentation"
-PROJECT_NUMBER         = 0.28.0
+PROJECT_NUMBER         = 0.28.1
 PROJECT_BRIEF          =
 PROJECT_LOGO           = ./images/logo_100x195.png
 OUTPUT_DIRECTORY       = ../../zz_build-api

--- a/include/lomse_model_builder.h
+++ b/include/lomse_model_builder.h
@@ -133,8 +133,8 @@ protected:
 };
 
 //---------------------------------------------------------------------------------------
-// GroupBarlinesFixer. Implements the algorithm to traverse the score instruments and assign
-// a unique partID to any instrument not having partID
+// GroupBarlinesFixer. Implements the algorithm for ensuring that barlines shared between
+// all instruments in a group are are identified and marked as such.
 class GroupBarlinesFixer
 {
 protected:

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -1405,9 +1405,14 @@ void ShapesCreator::finish_engraving_relobj(ImoRelObj* pRO,
 
     RelObjEngraver* pEngrv
         = static_cast<RelObjEngraver*>(m_engravers.get_engraver(pRO));
-    pEngrv->set_end_staffobj(pRO, pSO, pStaffObjShape, iInstr, iStaff, iSystem, iCol,
-                             xLeft, xRight, yTop, idxStaff, pVProfile);
-    pEngrv->set_prolog_width( prologWidth );
+
+    //pEngrv could not exist when malformed files, when start and end are reversed
+    if (pEngrv)
+    {
+        pEngrv->set_end_staffobj(pRO, pSO, pStaffObjShape, iInstr, iStaff, iSystem, iCol,
+                                 xLeft, xRight, yTop, idxStaff, pVProfile);
+        pEngrv->set_prolog_width( prologWidth );
+    }
 }
 
 //---------------------------------------------------------------------------------------
@@ -1415,7 +1420,12 @@ GmoShape* ShapesCreator::create_last_shape(ImoRelObj* pRO)
 {
     RelObjEngraver* pEngrv
         = static_cast<RelObjEngraver*>(m_engravers.get_engraver(pRO));
-    return pEngrv->create_last_shape(pRO->get_color());
+
+    //pEngrv could not exist when malformed files, when start and end are reversed
+    if (pEngrv)
+        return pEngrv->create_last_shape(pRO->get_color());
+    else
+        return nullptr;
 }
 
 //---------------------------------------------------------------------------------------


### PR DESCRIPTION
When the internal model has a malformed `ImoRelObj` (start and end not in music time order) Lomse will crash when trying to render it. These situations could occur, for instance, when importing a malformed MusicXML file with one or more spanners reversed. See comments in PR#296.

I've analysed the posibility of `ModelBuilder` trying to fix any malformed `ImoRelObj` but it is complex when more than two `ImoStaffObj` are involved (e.g., spanners with 'continue' intermediate points) as in these cases it is not possible to know exactly which is the correct order.

Therefore, instead of trying to fix the malformed `ImoRelObj` this PR just add checks to avoid crashes during rendition.

It also includes two unrelated non-important commits:
• The version number is increased in API documentation (doxyfile)
• A bad comment, describing class `GroupBarlinesFixer` responsibilities, has been fixed.