### PR TITLE
Add initial support for arpeggio

### DIFF
--- a/include/lomse_bitmap_drawer.h
+++ b/include/lomse_bitmap_drawer.h
@@ -197,6 +197,7 @@ public:
     int draw_text(double x, double y, const std::string& str) override;
     int draw_text(double x, double y, const wstring& str) override;
     void draw_glyph(double x, double y, unsigned int ch) override;
+    void draw_glyph_rotated(double x, double y, unsigned int ch, double rotation) override;
 
 
     //copy/blend a bitmap

--- a/include/lomse_calligrapher.h
+++ b/include/lomse_calligrapher.h
@@ -70,10 +70,12 @@ public:
     int draw_text(double x, double y, const wstring& str, Color color,
                   double scale=1.0);
     void draw_glyph(double x, double y, unsigned int ch, Color color, double scale);
+    void draw_glyph_rotated(double x, double y, unsigned int ch, Color color, double scale, double rotation);
 
 protected:
     void draw_glyph(double x, double y, unsigned int ch, Color color);
     void set_scale(double scale);
+    void set_scale_and_rotation(double scale, double rotation);
 
 };
 
@@ -93,6 +95,7 @@ public:
 
     LUnits measure_width(const std::string& str);
     LUnits measure_width(const wstring& str);
+    LUnits get_advance_x(unsigned int ch);
     LUnits get_ascender();
     LUnits get_descender();
     LUnits get_font_height();

--- a/include/lomse_chord_engraver.h
+++ b/include/lomse_chord_engraver.h
@@ -98,6 +98,8 @@ protected:
     ChordNoteData* m_pLinkNoteData;     //for cross-staff chords, the last note in the
                                         //same staff than the flag note
 
+    bool m_fSomeAccidentalsShifted;
+
 public:
     ChordEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter, int numNotes,
                   double fontSize, int symbolSize);
@@ -136,6 +138,7 @@ protected:
     void find_reference_notes();
     void layout_noteheads();
     void layout_accidentals();
+    void layout_arpeggio();
     void determine_stem_x_left();
     void add_stem_and_flag();
     void add_stem_flag_segment(StemFlagEngraver* engrv);
@@ -156,6 +159,8 @@ protected:
 
     LUnits check_if_accidentals_overlap(GmoShapeAccidentals* pPrevAcc,
                                         GmoShapeAccidentals* pCurAcc);
+
+    void ensure_note_bounds_updated();
 
     //helpers
     inline bool has_stem() { return m_fHasStem; }

--- a/include/lomse_drawer.h
+++ b/include/lomse_drawer.h
@@ -621,6 +621,7 @@ public:
         @param ch  The character to render.
     */
     virtual void draw_glyph(double x, double y, unsigned int ch) = 0;
+    virtual void draw_glyph_rotated(double x, double y, unsigned int ch, double rotation) = 0;
     //@}    //Text redering methods
 
 

--- a/include/lomse_engraving_options.h
+++ b/include/lomse_engraving_options.h
@@ -77,6 +77,8 @@ namespace lomse
 #define LOMSE_LEGER_LINE_OUTGOING        5.0f
 #define LOMSE_GRACE_NOTES_SCALE          0.60f  //Scaling factor for grace notes size
 #define LOMSE_CUE_NOTES_SCALE            0.75f  //Scaling factor for cue notes size
+#define LOMSE_ARPEGGIO_SPACE_TO_CHORD    6.0f   //Spacing between an arpeggio and a chord
+#define LOMSE_ARPEGGIO_MAX_OUTGOING      3.0f   //Amount of space arpeggio is allowed to go beyond a chord's top or bottom note
 
 //System layouter
     //spacing function parameters

--- a/include/lomse_glyphs.h
+++ b/include/lomse_glyphs.h
@@ -319,6 +319,10 @@ enum EGlyphIndex
 
     //Multi-segment lines (U+EAA0 - U+EB0F)
     k_glyph_trill_wiggle_segment,           // Trill wiggle segment
+    k_glyph_arpeggiato_wiggle_segment_up,   // Arpeggiato wiggle segment, upwards
+    k_glyph_arpeggiato_wiggle_segment_down, // Arpeggiato wiggle segment, downwards
+    k_glyph_arpeggiato_arrow_up,            // Arpeggiato arrowhead up
+    k_glyph_arpeggiato_arrow_down,          // Arpeggiato arrowhead down
 
     //Tremolos (U+E220 - U+E23F)
     k_glyph_tremolo_1,     // Combining tremolo 1

--- a/include/lomse_gm_basic.h
+++ b/include/lomse_gm_basic.h
@@ -171,6 +171,7 @@ public:
                 k_box_control, k_box_table, k_box_table_rows,
            k_shape,
                 k_shape_accidentals, k_shape_accidental_sign,
+                k_shape_arpeggio,
                 k_shape_articulation,
                 k_shape_barline, k_shape_beam, k_shape_brace,
                 k_shape_bracket, k_shape_button,
@@ -221,6 +222,7 @@ public:
     inline bool is_box_system() { return m_objtype == k_box_system; }
     inline bool is_box_table_rows() { return m_objtype == k_box_table_rows; }
 
+    bool is_shape_arpeggio() const { return m_objtype == k_shape_arpeggio; }
     inline bool is_shape_articulation() { return m_objtype == k_shape_articulation; }
     inline bool is_shape_accidentals() { return m_objtype == k_shape_accidentals; }
     inline bool is_shape_accidental_sign() { return m_objtype == k_shape_accidental_sign; }
@@ -276,10 +278,10 @@ public:
     inline void set_height(LUnits height) { m_size.height = height; }
 
     //position
-    inline LUnits get_left() { return m_origin.x; }
-    inline LUnits get_top() { return m_origin.y; }
-    inline LUnits get_right() { return m_origin.x + m_size.width; }
-    inline LUnits get_bottom() { return m_origin.y + m_size.height; }
+    LUnits get_left() const { return m_origin.x; }
+    LUnits get_top() const { return m_origin.y; }
+    LUnits get_right() const { return m_origin.x + m_size.width; }
+    LUnits get_bottom() const { return m_origin.y + m_size.height; }
     void set_origin(UPoint& pos);
     void set_origin(const UPoint& pos);
     void set_origin(LUnits xLeft, LUnits yTop);

--- a/include/lomse_im_note.h
+++ b/include/lomse_im_note.h
@@ -350,6 +350,9 @@ public:
     //grace notes related to this note
     ImoGraceRelObj* get_grace_relobj();
 
+    //arpeggio
+    ImoArpeggio* get_arpeggio();
+
 
     //pitch. Only valid when m_actual_acc is computed
     FPitch get_fpitch();            //FPitch. Ignores fractional part of actual accidentals

--- a/include/lomse_mxl_analyser.h
+++ b/include/lomse_mxl_analyser.h
@@ -278,6 +278,7 @@ protected:
     ImoScore*       m_pCurScore;        //the score under construction
     ImoInstrument*  m_pCurInstrument;   //the instrument being analysed
     ImoNote*        m_pLastNote;        //last note added to the score
+    ImoArpeggioDto* m_pArpeggioDto;     //data for the last arpeggio encountered
     ImoBarline*     m_pLastBarline;     //last barline added to current instrument
     ImoDocument*    m_pImoDoc;          //the document containing the score
     PartList        m_partList;         //the list of instruments
@@ -370,6 +371,10 @@ public:
     void save_last_note(ImoNote* pNote);
     inline ImoNote* get_last_note() { return m_pLastNote; }
     ImoNote* get_last_note_for(int iStaff);
+
+    void save_arpeggio_data(ImoArpeggioDto* pArpeggioDto);
+    ImoArpeggioDto* get_arpeggio_data() { return m_pArpeggioDto; }
+    void reset_arpeggio_data();
 
     //last barline added to current instrument
     inline void save_last_barline(ImoBarline* pBarline) { m_pLastBarline = pBarline; }

--- a/include/lomse_shape_base.h
+++ b/include/lomse_shape_base.h
@@ -153,6 +153,9 @@ public:
     inline void unlock() { m_fLocked = false; }
     void lock();
 
+    //may be needed in case child shapes changed their positions independently of the entire composite shape
+    void force_recompute_bounds() { recompute_bounds(); }
+
     //virtual methods from base class
     virtual void shift_origin(const USize& shift) override;
     virtual void reposition_shape(LUnits yShift) override;

--- a/include/lomse_shape_note.h
+++ b/include/lomse_shape_note.h
@@ -171,6 +171,8 @@ protected:
     GmoShapeNote* m_pLinkNote;  //note containing the link segment for the stem
     GmoShapeNote* m_pStartNote; //note containing the extensible segment for the stem
 
+    GmoShapeArpeggio* m_pArpeggio; //arpeggio, if a chord has any
+
 public:
     GmoShapeChordBaseNote(ImoObj* pCreatorImo, LUnits x, LUnits y, Color color,
                           LibraryScope& libraryScope)
@@ -178,6 +180,7 @@ public:
         , m_pFlagNote(nullptr)
         , m_pLinkNote(nullptr)
         , m_pStartNote(nullptr)
+        , m_pArpeggio(nullptr)
     {
         m_objtype = GmoObj::k_shape_chord_base_note;
     }
@@ -188,11 +191,14 @@ public:
     GmoShapeNote* get_top_note();
     GmoShapeNote* get_bottom_note();
 
+    GmoShapeArpeggio* get_arpeggio() { return m_pArpeggio; }
+
 protected:
     friend class ChordEngraver;
     void set_flag_note(GmoShapeNote* pNote);
     void set_link_note(GmoShapeNote* pNote);
     void set_start_note(GmoShapeNote* pNote);
+    void set_arpeggio(GmoShapeArpeggio* pArp) { m_pArpeggio = pArp; }
 
 };
 

--- a/include/lomse_shapes.h
+++ b/include/lomse_shapes.h
@@ -476,6 +476,40 @@ protected:
     }
 };
 
+//---------------------------------------------------------------------------------------
+class GmoShapeArpeggio : public GmoSimpleShape
+{
+protected:
+    LibraryScope& m_libraryScope;
+    double m_fontHeight;
+
+    LUnits m_unusedSpaceTop;
+    LUnits m_unusedSpaceBottom;
+
+    unsigned int m_segmentGlyph;
+    unsigned int m_segmentCount;
+    unsigned int m_arrowGlyph;
+    LUnits m_xInitialAdvance;
+    LUnits m_yInitialAdvance;
+    LUnits m_segmentAdvance;
+    bool m_fUp;
+
+    friend class ChordEngraver;
+    GmoShapeArpeggio(ImoObj* pCreatorImo, ShapeId idx,
+                     LUnits xRight, LUnits yTop, LUnits yBottom,
+                     bool fUp, bool fHasArrow,
+                     Color color, LibraryScope& libraryScope,
+                     double fontHeight);
+
+public:
+    //implementation of virtual methods in base class
+    void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
+
+    void increase_length_up(LUnits increment);
+
+protected:
+    void compute_shape_geometry(LUnits xPosRight, LUnits yTop, LUnits yBottom);
+};
 
 }   //namespace lomse
 

--- a/include/private/lomse_internal_model_p.h
+++ b/include/private/lomse_internal_model_p.h
@@ -525,6 +525,20 @@ enum EArticulations
 //-----------------------------------------------------------------------------
 /** @ingroup enumerations
 
+    This enum describes valid values for argpeggio types.
+
+    @#include <lomse_internal_model.h>
+*/
+enum EArpeggio
+{
+    k_arpeggio_standard,    ///< Standard arpeggio
+    k_arpeggio_arrow_up,    ///< Arpeggio with an up arrow
+    k_arpeggio_arrow_down,  ///< Arpeggio with a down arrow
+};
+
+//-----------------------------------------------------------------------------
+/** @ingroup enumerations
+
     This enum describes valid values for ornaments.
 
     @#include <lomse_internal_model.h>
@@ -643,6 +657,7 @@ enum EImoObjType
 
     //ImoDto (A)
     k_imo_dto,
+    k_imo_arpeggio_dto,
     k_imo_beam_dto,
     k_imo_border_dto,
     k_imo_color_dto,
@@ -767,6 +782,7 @@ enum EImoObjType
 
     // ImoRelObj (A)
     k_imo_relobj,           ///< &nbsp;&nbsp;&nbsp;&nbsp; <b>Relation objects. Any of the following:</b>
+    k_imo_arpeggio,         ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Arpeggio
     k_imo_beam,             ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Beam
     k_imo_chord,            ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Chord
     k_imo_grace_relobj,     ///< &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Grace notes relationship
@@ -4225,6 +4241,55 @@ public:
 protected:
     void add_private_style(ImoStyle* pStyle);
 
+};
+
+//---------------------------------------------------------------------------------------
+class ImoArpeggio : public ImoRelObj
+{
+protected:
+    EArpeggio m_type;
+
+    friend class ImFactory;
+    ImoArpeggio()
+        : ImoRelObj(k_imo_arpeggio)
+        , m_type(k_arpeggio_standard)
+    {
+    }
+
+public:
+    //getters
+    EArpeggio get_type() const { return m_type; }
+
+    //setters
+    void set_type(EArpeggio value) { m_type = value; }
+
+    //required override for ImoRelObj
+    void reorganize_after_object_deletion() override;
+};
+
+//---------------------------------------------------------------------------------------
+class ImoArpeggioDto : public ImoSimpleObj
+{
+protected:
+    EArpeggio m_type;
+    Color m_color;
+
+public:
+    ImoArpeggioDto() : ImoSimpleObj(k_imo_arpeggio_dto) {}
+
+    //getters
+    EArpeggio get_type() const { return m_type; }
+    const Color& get_color() const { return m_color; }
+
+    //setters
+    void set_type(EArpeggio type) { m_type = type; }
+    void set_color(const Color& color) { m_color = color; }
+
+    void apply_properties_to(ImoArpeggio* pArpeggio) const
+    {
+        pArpeggio->set_type(m_type);
+        pArpeggio->set_color(m_color);
+    }
 };
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/lomse_box_slice_instr.cpp
+++ b/src/graphic_model/lomse_box_slice_instr.cpp
@@ -169,7 +169,7 @@ void GmoBoxSliceStaff::reposition_shapes(const vector<LUnits>& yShifts,
             else if ((*it)->is_shape_note())
             {
                 GmoShapeNote* pShapeNote = static_cast<GmoShapeNote*>(*it);
-                LUnits increment = (yShift + yShifts[m_idxStaff-1]);
+                LUnits increment = (yShift - yShifts[m_idxStaff-1]);
                 pShapeNote->reposition_shape(yShift);
 
                 if (pShapeNote->is_cross_staff_chord())
@@ -177,6 +177,11 @@ void GmoBoxSliceStaff::reposition_shapes(const vector<LUnits>& yShifts,
                     if (pShapeNote->is_chord_start_note())
                     {
                         pShapeNote->increment_stem_length(increment);
+
+                        GmoShapeArpeggio* pArpeggio = pShapeNote->get_base_note_shape()->get_arpeggio();
+
+                        if (pArpeggio)
+                            pArpeggio->increase_length_up(increment);
                     }
                     else if (pShapeNote->is_chord_flag_note() && !pShapeNote->is_up())
                     {

--- a/src/graphic_model/lomse_glyphs.cpp
+++ b/src/graphic_model/lomse_glyphs.cpp
@@ -295,6 +295,10 @@ const GlyphData m_glyphs_smufl[] =
 
 //Multi-segment lines (U+EAA0 - U+EB0F)
     GlyphData(0xEAA4),  // Trill wiggle segment
+    GlyphData(0xEAA9),  // Arpeggiato wiggle segment, upwards
+    GlyphData(0xEAAA),  // Arpeggiato wiggle segment, downwards
+    GlyphData(0xEAAD),  // Arpeggiato arrowhead up
+    GlyphData(0xEAAE),  // Arpeggiato arrowhead down
 
 //Tremolos (U+E220 - U+E23F)
     GlyphData(0xE220),  // Combining tremolo 1

--- a/src/graphic_model/lomse_gm_basic.cpp
+++ b/src/graphic_model/lomse_gm_basic.cpp
@@ -181,6 +181,7 @@ const string& GmoObj::get_name(int objtype)
         m_typeToName[k_shape]                   = "shape (A)      ";
         m_typeToName[k_shape_accidentals]       = "accidentals    ";
         m_typeToName[k_shape_accidental_sign]   = "accidental-sign";
+        m_typeToName[k_shape_arpeggio]          = "arpeggio       ";
         m_typeToName[k_shape_articulation]      = "articulation   ";
         m_typeToName[k_shape_barline]           = "barline        ";
         m_typeToName[k_shape_beam]              = "beam           ";

--- a/src/internal_model/lomse_im_factory.cpp
+++ b/src/internal_model/lomse_im_factory.cpp
@@ -55,6 +55,8 @@ ImoObj* ImFactory::inject(int type, Document* pDoc, ImoId id)
     switch(type)
     {
         case k_imo_anonymous_block:     pObj = LOMSE_NEW ImoAnonymousBlock();     break;
+        case k_imo_arpeggio:            pObj = LOMSE_NEW ImoArpeggio();           break;
+        case k_imo_arpeggio_dto:        pObj = LOMSE_NEW ImoArpeggioDto();        break;
         case k_imo_articulation_symbol: pObj = LOMSE_NEW ImoArticulationSymbol(); break;
         case k_imo_articulation_line:   pObj = LOMSE_NEW ImoArticulationLine();   break;
         case k_imo_attachments:         pObj = LOMSE_NEW ImoAttachments();        break;

--- a/src/internal_model/lomse_im_note.cpp
+++ b/src/internal_model/lomse_im_note.cpp
@@ -285,6 +285,12 @@ ImoGraceRelObj* ImoNote::get_grace_relobj()
 }
 
 //---------------------------------------------------------------------------------------
+ImoArpeggio* ImoNote::get_arpeggio()
+{
+    return static_cast<ImoArpeggio*>( find_relation(k_imo_arpeggio) );
+}
+
+//---------------------------------------------------------------------------------------
 FPitch ImoNote::get_fpitch()
 {
     //FPitch. Ignores fractional part of actual accidentals

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -480,6 +480,7 @@ const string& ImoObj::get_name(int type)
         m_TypeToName[k_imo_inline_wrapper] = "wrapper";
 
         // ImoDto, ImoSimpleObj (A)
+        m_TypeToName[k_imo_arpeggio_dto] = "arpeggio";
         m_TypeToName[k_imo_beam_dto] = "beam";
         m_TypeToName[k_imo_bezier_info] = "bezier";
         m_TypeToName[k_imo_border_dto] = "border";
@@ -556,6 +557,7 @@ const string& ImoObj::get_name(int type)
         m_TypeToName[k_imo_lyric] = "lyric";
 
         // ImoRelObj (A)
+        m_TypeToName[k_imo_arpeggio] = "arpeggio";
         m_TypeToName[k_imo_beam] = "beam";
         m_TypeToName[k_imo_chord] = "chord";
         m_TypeToName[k_imo_grace_relobj] = "grace-relobj";
@@ -2535,6 +2537,15 @@ void ImoDocument::delete_block_level_obj(ImoBlockLevelObj* pAt)
     delete pAt;
 
     set_dirty(true);
+}
+
+
+//=======================================================================================
+// ImoArpeggio implementation
+//=======================================================================================
+void ImoArpeggio::reorganize_after_object_deletion()
+{
+    //Nothing to do
 }
 
 

--- a/src/render/lomse_bitmap_drawer.cpp
+++ b/src/render/lomse_bitmap_drawer.cpp
@@ -856,6 +856,16 @@ void BitmapDrawer::draw_glyph(double x, double y, unsigned int ch)
 }
 
 //---------------------------------------------------------------------------------------
+void BitmapDrawer::draw_glyph_rotated(double x, double y, unsigned int ch, double rotation)
+{
+    render_existing_paths();
+
+    TransAffine& mtx = m_pRenderer->get_transform();
+    mtx.transform(&x, &y);
+    m_pCalligrapher->draw_glyph_rotated(x, y, ch, m_textColor, m_pRenderer->get_scale(), rotation);
+}
+
+//---------------------------------------------------------------------------------------
 int BitmapDrawer::draw_text(double x, double y, const std::string& str)
 {
     //returns the number of chars drawn

--- a/src/render/lomse_calligrapher.cpp
+++ b/src/render/lomse_calligrapher.cpp
@@ -122,6 +122,14 @@ void Calligrapher::draw_glyph(double x, double y, unsigned int ch, Color color,
 }
 
 //---------------------------------------------------------------------------------------
+void Calligrapher::draw_glyph_rotated(double x, double y, unsigned int ch, Color color,
+                                      double scale, double rotation)
+{
+    set_scale_and_rotation(scale, rotation);
+    draw_glyph(x, y, ch, color);
+}
+
+//---------------------------------------------------------------------------------------
 void Calligrapher::draw_glyph(double x, double y, unsigned int ch, Color color)
 {
     //ch is the glyph (utf-32)
@@ -150,6 +158,18 @@ void Calligrapher::set_scale(double scale)
 
     agg::trans_affine mtx;
     mtx *= agg::trans_affine_scaling(scale);
+    m_pFonts->set_transform(mtx);
+}
+
+//---------------------------------------------------------------------------------------
+void Calligrapher::set_scale_and_rotation(double scale, double rotation)
+{
+   if (!m_pFonts->is_font_valid())
+        return;
+
+    agg::trans_affine mtx;
+    mtx *= agg::trans_affine_scaling(scale);
+    mtx *= agg::trans_affine_rotation(rotation);
     m_pFonts->set_transform(mtx);
 }
 
@@ -221,6 +241,22 @@ void TextMeter::measure_glyphs(wstring* glyphs, std::vector<LUnits>& glyphWidths
         else
             glyphWidths.push_back( 0.0f );
     }
+}
+
+//---------------------------------------------------------------------------------------
+LUnits TextMeter::get_advance_x(unsigned int ch)
+{
+    if (!m_pFonts->is_font_valid())
+        return 0.0f;
+
+    set_transform();
+
+    const lomse::glyph_cache* glyph = m_pFonts->get_glyph_cache(ch);
+
+    if (glyph)
+        return static_cast<LUnits>(glyph->advance_x);
+    else
+        return 0.0f;
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/tests/lomse_test_staffobjs_table.cpp
+++ b/src/tests/lomse_test_staffobjs_table.cpp
@@ -622,22 +622,22 @@ SUITE(ColStaffObjsBuilderTest)
         CHECK_ENTRY0(it, 1,    0,      0,   0,     1, "(dir empty)" );
         CHECK_ENTRY0(it, 0,    0,      0,   0,	   0, "(n b5 h. v1 p1 (stem down)(dyn \"p\" below))" );
         CHECK_ENTRY0(it, 1,    0,      0,   0,     1, "(n b5 h. v1 p1 (stem down)(dyn \"p\" below))" );
-        CHECK_ENTRY0(it, 1,    0,      0,   192,   1, "(dir 0 (TODO:  No LdpGenerator for Imo. Imo name=wedge, Imo type=102, id=68) p1)" );
+        CHECK_ENTRY0(it, 1,    0,      0,   192,   1, "(dir 0 (TODO:  No LdpGenerator for Imo. Imo name=wedge, Imo type=104, id=68) p1)" );
         CHECK_ENTRY0(it, 0,    0,      0,   192,   0, "(barline simple)" );
         CHECK_ENTRY0(it, 1,    0,      0,   192,   1, "(barline simple)" );
         CHECK_ENTRY0(it, 0,    0,      1,   192,   0, "(time 2 4)" );
         CHECK_ENTRY0(it, 1,    0,      1,   192,   1, "(time 2 4)" );
         CHECK_ENTRY0(it, 0,    0,      1,   192,   0, "(n b5 h v1 p1 (stem down))" );
         CHECK_ENTRY0(it, 1,    0,      1,   192,   1, "(n b5 h v1 p1 (stem down))" );
-        CHECK_ENTRY0(it, 1,    0,      1,   320,   1, "(dir 0 (TODO:  No LdpGenerator for Imo. Imo name=wedge, Imo type=102, id=68) p1)" );
+        CHECK_ENTRY0(it, 1,    0,      1,   320,   1, "(dir 0 (TODO:  No LdpGenerator for Imo. Imo name=wedge, Imo type=104, id=68) p1)" );
         CHECK_ENTRY0(it, 0,    0,      1,   320,   0, "(barline simple)" );
         CHECK_ENTRY0(it, 1,    0,      1,   320,   1, "(barline simple)" );
         CHECK_ENTRY0(it, 0,    0,      2,   320,   0, "(time 4 4)" );
         CHECK_ENTRY0(it, 1,    0,      2,   320,   1, "(time 4 4)" );
         CHECK_ENTRY0(it, 0,    0,      2,   320,   0, "(n b5 w v1 p1)" );
         CHECK_ENTRY0(it, 1,    0,      2,   320,   1, "(n a5 w v1 p1)" );
-        CHECK_ENTRY0(it, 1,    0,      2,   576,   1, "(dir 0 (TODO:  No LdpGenerator for Imo. Imo name=wedge, Imo type=102, id=76) p1)" );
-        CHECK_ENTRY0(it, 1,    0,      2,   576,   1, "(dir 0 (TODO:  No LdpGenerator for Imo. Imo name=wedge, Imo type=102, id=76) p1)" );
+        CHECK_ENTRY0(it, 1,    0,      2,   576,   1, "(dir 0 (TODO:  No LdpGenerator for Imo. Imo name=wedge, Imo type=104, id=76) p1)" );
+        CHECK_ENTRY0(it, 1,    0,      2,   576,   1, "(dir 0 (TODO:  No LdpGenerator for Imo. Imo name=wedge, Imo type=104, id=76) p1)" );
         CHECK_ENTRY0(it, 0,    0,      2,   576,   0, "(barline simple)" );
         CHECK_ENTRY0(it, 1,    0,      2,   576,   1, "(barline simple)" );    }
 


### PR DESCRIPTION
This pull request contains a basic implementation of arpeggio in Lomse. This implementation is somewhat limited (which I have briefly described below) but it is still able to import an arpeggio attached to one chord and display it when rendering a score. Therefore it can be useful to handle arpeggio in the most common cases and is hopefully able to serve as a basis for further improvements.

## Examples

Here are some examples of arpeggio rendering with the current version of this PR:
 - [`32d-Arpeggio.xml`](https://github.com/cuthbertLab/musicxmlTestSuite/blob/main/xmlFiles/32d-Arpeggio.xml) from the [unofficial MusicXML test suite](https://github.com/cuthbertLab/musicxmlTestSuite) (non-arpeggiate is not implemented in this pull request):
![arpeggio_testsuite](https://user-images.githubusercontent.com/6000747/127771873-4dbbb7da-e32b-4c0a-b74d-0550bfc9459f.png)
 - Arpeggio of different lengths:
![arpeggio_test_length](https://user-images.githubusercontent.com/6000747/127771935-8ee07873-d6cd-4248-baea-1c89d0cc817f.png)
 - Arpeggio on cross-staff chords (based on [this example](https://www.w3.org/2021/06/musicxml40/musicxml-reference/examples/tutorial-apres-un-reve), extra dynamic marks were added to test the case when staff distance gets increased in the course of engraving):
![arpeggio_cross_staff_chord](https://user-images.githubusercontent.com/6000747/127771943-8e7c29f0-f34e-4c25-87ad-185ed05e201a.png)
 - Some real-world examples:

| Example 1  | Example 2 | Example 3 |
| ------------- | ------------- | ----------- |
| ![arp1](https://user-images.githubusercontent.com/6000747/127771969-7365c0aa-f32f-4913-8698-7661972bc520.png) | ![arp2](https://user-images.githubusercontent.com/6000747/127771972-89ab24d4-d2e8-4c0e-bd46-4b09f58676a9.png) | ![arp3](https://user-images.githubusercontent.com/6000747/127771975-d6a3eb01-64ce-4d98-98bd-c764e805dd4d.png)


## Limitations of the current implementation

In this PR arpeggios are implemented in the internal model similarly to chords, as `RelObj`s connecting several notes. This seems to be natural in the context of the Lomse score model and potentially allows representation of a "true" cross-staff arpeggio involving separate chords on different staves. However reading such arpeggios is not implemented in the MusicXML importer (primarily because it wasn't clear for me how they are supposed to be represented in a MusicXML file), and the importer assumes that arpeggio always spans only for one chord. Similarly, the engraver only checks for arpeggio in one note and renders it only for one chord. This works fine in the most common case of a one-chord arpeggio but in order to support cross-staff arpeggio this will need to be corrected.

Also this PR does not include support of arpeggio in the LDP format (not sure if I need to do something special to add it or it is handled automatically?) and does not include support for MIDI rendering of arpeggio so all chords would sound non-arpeggiated on playback.