### PR TITLE
Fix playback loop due to bug in MusicXML importer

### DIFF
--- a/include/lomse_path_attributes.h
+++ b/include/lomse_path_attributes.h
@@ -164,14 +164,18 @@ struct PathAttributes
     //destructor
     ~PathAttributes()
     {
-        //AWARE: This destructor IS NEVER INVOKED
-        //AttrStorage objects are pod_bvector<PathAttributes>
-        //and pod_bvector doesn't invoke destructors, just dealloc memory. Therefore,
-        //memory allocated for GradientAttributes is released in
-        //BitmapDrawer::delete_paths().
-        //fill_gradient is deleted there, so DON'T DO IT HERE
+        //AWARE: This destructor IS NEVER INVOKED because
+        // AttrStorage objects are pod_bvector<PathAttributes>
+        // and pod_bvector doesn't invoke destructors, just dealloc memory. Thus,
+        // it is useless to try to delete GradientAttributes in this destructor.
+        // Currently, memory allocated for GradientAttributes will be  released in
+        // BitmapDrawer::delete_paths(), but **only** if this PathAttributes
+        // object is used to render something.
 
-        //delete fill_gradient;
+        //TODO: Fix this to avoid memory leaks if PathAttributes is not used
+
+        //delete fill_gradient();   //useless. Never invoked
+
     }
 };
 


### PR DESCRIPTION
Playback loop was detected in MozartTrio smaple and fixed in this PR. It was caused by just a missing `k_barline_double_repetition_alt` in method `BarlineMxlAnalizer::combine_barlines()` but I take the opportunity to add a couple of unimportant changes:

- refactor a method, for better understanding
- add comments to explain conversion between MusicXML and Lomse barlines
- add a TODO comment to remember the need to improve that piece of code