### PR TITLE
Fix middle spanner segments being displayed on a wrong page in some cases

### DIFF
--- a/src/graphic_model/layouters/lomse_system_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_system_layouter.cpp
@@ -1016,7 +1016,9 @@ void SystemLayouter::engrave_not_finished_relobj(ImoRelObj* pRO, PendingAuxObj* 
                                                  int UNUSED(iSystem))
 {
     int iInstr = pPAO->m_iInstr;
-    int iCol = pPAO->m_iCol;
+    //pRO may span for several systems, ensure that the new
+    //shape is bound to a column from this system
+    int iCol = max(pPAO->m_iCol, m_iFirstCol);
     int iStaff = pPAO->m_iStaff;
     int idxStaff = pPAO->m_idxStaff;
 


### PR DESCRIPTION
This pull request fixes a case when a middle spanner segment is shown on a wrong page. The issue can be illustrated, for example, with this score: [slur.musicxml.txt](https://github.com/lenmus/lomse/files/6949826/slur.musicxml.txt)

To reproduce the issue two conditions are necessary:
1. A slur spans for several systems (because page width is small or a slur is particularly long)
2. A system somewhere in the middle of the slur range is moved to another page.

If these conditions are met a slur segment which belongs to the first system on the second page is instead displayed on the first page: 

| Page 1  | Page 2 |
| ------------- | ------------- |
| ![before1](https://user-images.githubusercontent.com/6000747/128613993-98c37038-b959-42a3-b92f-dbb56238947b.png) | ![before2](https://user-images.githubusercontent.com/6000747/128613999-cf31a106-1161-474d-b007-ba998ae9022c.png) |

The reason why this happens is that the shape for this slur segment is bound to a wrong system box because an incorrect column number for this shape is used. Therefore when its system gets moved to the next page a coordinate shift applied to this system does not get propagated to this slur segment's shape. This PR fixes it by ensuring that the column number the `RelObj` shape is bound to belongs to the column range of the current system. As a result, all slur segments in the example shown above get rendered on correct pages.

| Page 1  | Page 2 |
| ------------- | ------------- |
| ![after1](https://user-images.githubusercontent.com/6000747/128614006-5bc14d9a-bade-40fc-857b-f59675cd9123.png) | ![after2](https://user-images.githubusercontent.com/6000747/128614009-679138a6-33cf-4887-a956-2cc8d0d7314f.png) |