### PR TITLE
MusicXML: fix adding spurious staves on reading mid-score <attributes> with <staves> tag

### DIFF
--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -1994,10 +1994,11 @@ public:
         // staves?
         if (get_optional("staves"))
         {
-            int staves = get_child_value_integer(1);
+            const int targetStaves = get_child_value_integer(1);
             ImoInstrument* pInstr = dynamic_cast<ImoInstrument*>(m_pAnchor->get_parent_imo());
+            int instrStaves = pInstr->get_num_staves();
             // coverity[tainted_data]
-            for(; staves > 1; --staves)
+            for (; instrStaves < targetStaves; ++instrStaves)
                 pInstr->add_staff();
         }
 

--- a/src/tests/lomse_test_mxl_analyser.cpp
+++ b/src/tests/lomse_test_mxl_analyser.cpp
@@ -1353,6 +1353,81 @@ SUITE(MxlAnalyserTest)
         delete pRoot;
     }
 
+    TEST_FIXTURE(MxlAnalyserTestFixture, MxlAnalyser_attributes_04)
+    {
+        //@04 setting number of staves
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        parser.parse_text(
+            "<score-partwise version='3.0'><part-list>"
+            "<score-part id='P1'><part-name>Music</part-name></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "<attributes>"
+                "<staves>3</staves>"
+            "</attributes>"
+            "</measure>"
+            "</part></score-partwise>"
+        );
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+
+        CHECK( errormsg.str() == expected.str() );
+
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
+        CHECK( pDoc );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore );
+        CHECK( pScore->get_num_instruments() == 1 );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        CHECK( pInstr->get_num_staves() == 3 );
+
+        delete pRoot;
+    }
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, MxlAnalyser_attributes_05)
+    {
+        //@05 repeatedly setting <staves> value in the mid-score <attributes> should not lead to adding extra staves
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        parser.parse_text(
+            "<score-partwise version='3.0'><part-list>"
+            "<score-part id='P1'><part-name>Music</part-name></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "<attributes>"
+                "<staves>2</staves>"
+            "</attributes>"
+            "</measure>"
+            "<measure number='2'>"
+            "<attributes>"
+                "<staves>2</staves>"
+            "</attributes>"
+            "</measure>"
+            "</part></score-partwise>"
+        );
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+
+        CHECK( errormsg.str() == expected.str() );
+
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
+        CHECK( pDoc );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore );
+        CHECK( pScore->get_num_instruments() == 1 );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        CHECK( pInstr->get_num_staves() == 2 );
+
+        delete pRoot;
+    }
+
 
     //@ barline --------------------------------------------------------------------------
 


### PR DESCRIPTION
When Lomse reads a mid-score `<attributes>` tags which contains some value for `<staves>` larger than 1, it may attempt to add extra staves to the existing instrument, which may lead to adding spurious staves or even to a crash. This may occur with the scores exported from MuseScore if they contain section breaks, for example:
 - [lomse_attr_staves_crash.musicxml.txt](https://github.com/lenmus/lomse/files/6950064/lomse_attr_staves_crash.musicxml.txt) — crashes Lomse on engraving stage
(the original score in the MuseScore format: [lomse_attr_staves_crash.mscx.txt](https://github.com/lenmus/lomse/files/6950071/lomse_attr_staves_crash.mscx.txt))
 - [lomse_attr_staves_no_crash.musicxml.txt](https://github.com/lenmus/lomse/files/6950065/lomse_attr_staves_no_crash.musicxml.txt) — doesn't crash Lomse but displays a spurious third staff which shouldn't be there.


The cause of the issue is that the MusicXML importer assumes that the instrument has only one staff prior to reading `<attributes>` tag and adds staves on top of that regardless of whether they are needed. This PR corrects this behavior so no unnecessary staves are added. I am not sure whether something more sensible needs to be done if number of staves actually changes but if it doesn't this solution prevents the issues related to that.