### PR TITLE
Support arpeggiated chords in playback

### DIFF
--- a/include/lomse_staffobjs_table.h
+++ b/include/lomse_staffobjs_table.h
@@ -303,7 +303,9 @@ protected:
     TimeUnits   m_minNoteDuration;
     TimeUnits   m_gracesAnacrusisTime;
     StaffVoiceLineTable  m_lines;
-    std::vector<ColStaffObjsEntry*> m_graces;       //entries for grace notes
+    std::vector<ColStaffObjsEntry*> m_graces;   //entries for grace notes
+    std::vector<ImoNote*> m_arpeggios;          //chord base notes for arpeggiated chords
+
 
     ColStaffObjsBuilderEngine(ImoScore* pScore)
         : m_pColStaffObjs(nullptr)
@@ -332,12 +334,17 @@ protected:
     void set_num_lines();
     void add_entries_for_key_or_time_signature(ImoObj* pImo, int nInstr);
     void set_min_note_duration();
-    void compute_playback_time();
+    void compute_grace_notes_playback_time();
     void process_grace_relobj(ImoGraceNote* pGrace, ImoGraceRelObj* pGRO,
                               ColStaffObjsEntry* pEntry);
     ImoNote* locate_grace_principal_note(ColStaffObjsEntry* pEntry);
     ImoNote* locate_grace_previous_note(ColStaffObjsEntry* pEntry);
     void fix_negative_playback_times();
+    void compute_arpeggiated_chords_playback_time();
+
+    static void save_arpeggiated_note(ImoNote* pNote, bool fBottomUp,
+                                      list<ImoNote*>& chordNotes);
+
 
 };
 

--- a/src/tests/lomse_test_staffobjs_table.cpp
+++ b/src/tests/lomse_test_staffobjs_table.cpp
@@ -1323,6 +1323,72 @@ SUITE(ColStaffObjsBuilderTest)
         check_note(__LINE__, *it, k_imo_note_regular, 1, 16.0, 128.0);   //ppal. dur 100%
     }
 
+    TEST_FIXTURE(ColStaffObjsBuilderTestFixture, playback_time_301)
+    {
+        //@301. single arpeggiated chord. bottom-up
+
+        Document doc(m_libraryScope);
+        doc.from_file(m_scores_path + "unit-tests/arpeggios/301-arpeggiated-chord-up.xml",
+                      Document::k_format_mxl);
+        ImoScore* pScore = dynamic_cast<ImoScore*>( doc.get_content_item(0) );
+        CHECK( pScore != nullptr );
+        ColStaffObjs* pColStaffObjs = pScore->get_staffobjs_table();
+//        cout << test_name() << endl;
+//        cout << pColStaffObjs->dump();
+
+        CHECK( pColStaffObjs->num_lines() == 1 );
+        CHECK( pColStaffObjs->num_entries() == 8 );
+        CHECK( is_equal_time(pColStaffObjs->anacrusis_missing_time(), 192.0) );
+        CHECK( is_equal_time(pColStaffObjs->anacrusis_extra_time(), 0.0) );
+        CHECK( pColStaffObjs->is_anacrusis_start() == true );
+
+        ColStaffObjsIterator it = pColStaffObjs->begin();
+                    //(clef G p1)
+        ++it;       //(key C)
+        ++it;       //(time 4 4)
+        ++it;       //(chord (n#39 c4 q v1 p1 (stem up))
+        check_note(__LINE__, *it, k_imo_note_regular, 0, 0.0, 64.0);
+        ++it;       //(n#42 e4 q v1 p1 (stem up))
+        check_note(__LINE__, *it, k_imo_note_regular, 0, 5.33, 58.67);
+        ++it;       //(n#46 g4 q v1 p1 (stem up))
+        check_note(__LINE__, *it, k_imo_note_regular, 0, 10.67, 53.33);
+        ++it;       //(n#49 b4 q v1 p1 (stem up)))
+        check_note(__LINE__, *it, k_imo_note_regular, 0, 16.00, 48.00);
+    }
+
+    TEST_FIXTURE(ColStaffObjsBuilderTestFixture, playback_time_302)
+    {
+        //@301. single arpeggiated chord. bottom-up
+
+        Document doc(m_libraryScope);
+        doc.from_file(m_scores_path + "unit-tests/arpeggios/302-arpeggiated-chord-down.xml",
+                      Document::k_format_mxl);
+        ImoScore* pScore = dynamic_cast<ImoScore*>( doc.get_content_item(0) );
+        CHECK( pScore != nullptr );
+        ColStaffObjs* pColStaffObjs = pScore->get_staffobjs_table();
+//        cout << test_name() << endl;
+//        cout << pColStaffObjs->dump();
+
+        CHECK( pColStaffObjs->num_lines() == 1 );
+        CHECK( pColStaffObjs->num_entries() == 8 );
+        CHECK( is_equal_time(pColStaffObjs->anacrusis_missing_time(), 192.0) );
+        CHECK( is_equal_time(pColStaffObjs->anacrusis_extra_time(), 0.0) );
+        CHECK( pColStaffObjs->is_anacrusis_start() == true );
+
+        ColStaffObjsIterator it = pColStaffObjs->begin();
+                    //(clef G p1)
+        ++it;       //(key C)
+        ++it;       //(time 4 4)
+        ++it;       //(chord (n#39 c4 q v1 p1 (stem up))
+        check_note(__LINE__, *it, k_imo_note_regular, 0, 16.00, 48.00);
+        ++it;       //(n#42 e4 q v1 p1 (stem up))
+        check_note(__LINE__, *it, k_imo_note_regular, 0, 10.67, 53.33);
+        ++it;       //(n#46 g4 q v1 p1 (stem up))
+        check_note(__LINE__, *it, k_imo_note_regular, 0, 5.33, 58.67);
+        ++it;       //(n#49 b4 q v1 p1 (stem up)))
+        check_note(__LINE__, *it, k_imo_note_regular, 0, 0.00, 64.00);
+    }
+
 
     // ColStaffObjsBuilderEngine2x ------------------------------------------------------
 

--- a/test-scores/unit-tests/arpeggios/301-arpeggiated-chord-up.xml
+++ b/test-scores/unit-tests/arpeggios/301-arpeggiated-chord-up.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise>
+  <part-list>
+    <score-part id="P1">
+      <part-name></part-name>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <arpeggiate/>
+          </notations>
+        </note>
+      <note>
+        <chord/>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <arpeggiate/>
+          </notations>
+        </note>
+      <note>
+        <chord/>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <arpeggiate/>
+          </notations>
+        </note>
+      <note>
+        <chord/>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <arpeggiate/>
+          </notations>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/test-scores/unit-tests/arpeggios/302-arpeggiated-chord-down.xml
+++ b/test-scores/unit-tests/arpeggios/302-arpeggiated-chord-down.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise>
+  <part-list>
+    <score-part id="P1">
+      <part-name></part-name>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <arpeggiate direction="down"/>
+          </notations>
+        </note>
+      <note>
+        <chord/>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <arpeggiate/>
+          </notations>
+        </note>
+      <note>
+        <chord/>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <arpeggiate/>
+          </notations>
+        </note>
+      <note>
+        <chord/>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        <notations>
+          <arpeggiate/>
+          </notations>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>


### PR DESCRIPTION
This PR fixes #304.

I had doubts about how to compute the delay between arpeggio notes, as this is something that, to me, depends on tempo, chord note type and perhaps other factors. For now, I have set the total delay (on set time difference between first and last arpeggiated notes) to be the shortest time of (0.7 * chord duration) and one sixteenth note. In the tests with a few scores the arpeggios sound acceptable. But ideas for improving this computation are always welcome.