### PR TITLE
Fix bug: MusicXML duration ignored in tuplets

### DIFF
--- a/include/lomse_im_note.h
+++ b/include/lomse_im_note.h
@@ -111,7 +111,8 @@ public:
     inline void set_dots(int dots) { m_nDots = dots; }
     inline void set_voice(int voice) { m_nVoice = voice; }
     void set_note_type_and_dots(int noteType, int dots);
-    void set_time_modification(int numerator, int denominator);
+    void set_time_modifiers_and_duration(int numerator, int denominator);
+    void set_time_modifiers(int numerator, int denominator);
     void set_type_dots_duration(int noteType, int dots, TimeUnits duration);
     inline void set_playback_duration(TimeUnits value) { m_playDuration = value; }
     inline void set_event_duration(TimeUnits value) { m_eventDuration = value; }

--- a/include/lomse_mxl_analyser.h
+++ b/include/lomse_mxl_analyser.h
@@ -339,7 +339,7 @@ public:
     ImoInstrument* get_instrument(const string& id) { return m_partList.get_instrument(id); }
     float current_divisions() { return m_divisions; }
     void set_current_divisions(float value) { m_divisions = value; }
-    TimeUnits duration_to_timepos(int duration);
+    TimeUnits duration_to_time_units(int duration);
 
     //timepos
     TimeUnits get_current_time() { return m_time; }

--- a/src/internal_model/lomse_im_note.cpp
+++ b/src/internal_model/lomse_im_note.cpp
@@ -91,7 +91,7 @@ ImoTuplet* ImoNoteRest::get_first_tuplet()
 }
 
 //---------------------------------------------------------------------------------------
-void ImoNoteRest::set_time_modification(int numerator, int denominator)
+void ImoNoteRest::set_time_modifiers_and_duration(int numerator, int denominator)
 {
     m_timeModifierTop = numerator;
     m_timeModifierBottom = denominator;
@@ -100,6 +100,13 @@ void ImoNoteRest::set_time_modification(int numerator, int denominator)
     m_duration = to_duration(m_nNoteType, m_nDots) * modifier;
     m_playDuration = m_duration;
     m_eventDuration = m_duration;
+}
+
+//---------------------------------------------------------------------------------------
+void ImoNoteRest::set_time_modifiers(int numerator, int denominator)
+{
+    m_timeModifierTop = numerator;
+    m_timeModifierBottom = denominator;
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/parser/ldp/lomse_ldp_analyser.cpp
+++ b/src/parser/ldp/lomse_ldp_analyser.cpp
@@ -3822,7 +3822,7 @@ public:
         //time modification
         if (m_pTimeModifDto != nullptr)
         {
-            pNR->set_time_modification( m_pTimeModifDto->get_top_number(),
+            pNR->set_time_modifiers_and_duration( m_pTimeModifDto->get_top_number(),
                                         m_pTimeModifDto->get_bottom_number() );
             delete m_pTimeModifDto;
         }
@@ -7387,7 +7387,7 @@ void TupletsBuilder::add_relation_to_staffobjs(ImoTupletDto* pEndDto)
 
         //if not only graphical (LDP < 2.0) add time modification the note/rest
         if (!pStartDto->is_only_graphical())
-            pNR->set_time_modification( m_pTuplet->get_normal_number(),
+            pNR->set_time_modifiers_and_duration( m_pTuplet->get_normal_number(),
                                         m_pTuplet->get_actual_number() );
     }
 }

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -3241,7 +3241,7 @@ public:
         if (!get_mandatory("duration"))
             return nullptr;
         int duration = get_child_value_integer(0);
-        TimeUnits shift = m_pAnalyser->duration_to_timepos(duration);
+        TimeUnits shift = m_pAnalyser->duration_to_time_units(duration);
 
         //<voice>
         if (fFwd && get_optional("voice"))
@@ -4467,7 +4467,7 @@ protected:
                            int duration)
     {
         int noteType = k_unknown_notetype;
-        TimeUnits units = m_pAnalyser->duration_to_timepos(duration);
+        TimeUnits units = m_pAnalyser->duration_to_time_units(duration);
         if (!type.empty())
             noteType = to_note_type(type);
         else if (pNR->is_rest())
@@ -6986,7 +6986,7 @@ public:
         fError |= error_if_more_elements();
 
         if (!fError)
-            m_pNR->set_time_modification(m_normal, m_actual);
+            m_pNR->set_time_modifiers(m_normal, m_actual);
 
         return nullptr;
     }
@@ -8179,7 +8179,7 @@ int MxlAnalyser::get_octave_shift_id_and_close(int num)
 }
 
 //---------------------------------------------------------------------------------------
-TimeUnits MxlAnalyser::duration_to_timepos(int duration)
+TimeUnits MxlAnalyser::duration_to_time_units(int duration)
 {
     //AWARE: 'divisions' indicates how many divisions per quarter note
     //       and 'duration' is expressed in 'divisions'


### PR DESCRIPTION

Test file: [overlap-problem.xml.txt](https://github.com/lenmus/lomse/files/6963180/overlap-problem.xml.txt)

![image](https://user-images.githubusercontent.com/5238679/128901295-af6bbd09-ced9-4a87-b411-86f19d5caf2d.png)

The cause of the error is the following:

The test file was generated by MuseScore. It defines `<divisions>480</divisions>` and assigns a duration of 69 to each note in the 7-tuplet (excesive, rounded up). Thus, total duration of the 7-tuplet is 483 instead of 480. To compensate the extra duration introduced, MuseScore adds a `<backup>` element with a duration of 3, so that next rest get properly positioned at 480 ticks, but causing an overlap between last 7-tuplet note and the rest. The `<backup>` and the overlap error could have been easily avoided by choosing another `<divisions>` value such as 3*4*5*7 = 420. This suggests a bug in the MuseScore MusicXML exporter.

When there is a tuplet, Lomse MusicXML importer ignored assigned duration and recomputed notes duration from total tuplet duration. Thus Lomse correctly computes the end of the tuplet at 480, but then, the backup shifts back current time position by an small amount, causing that the next rest after the 7-tuplet get placed, in time, slightly before than all other rests in the other staves. And this error is propagated to all following StaffObjs in fourth instrument, barlines included, and so, they are rendered slightly before. If the `<backup>` is removed the file was correctly rendered.

This PR fixes the MusicXML importer so that now MusicXML duration is always used and Lomse does not recompute it. 

But once this bug is fixed, the file is displayed with a big gap after the first rest:

![image](https://user-images.githubusercontent.com/5238679/128901351-28a01f60-6fcb-4efa-b5cf-77ea084b6b68.png)

The cause is that last note of 7-tuplet is still sounding at timepos 480 (start of rest after that note), and thus, current spacing algorithm behaves as if there were two voices sounding in beat two of fourth instrument: the quarter rest and the last 7-tuplet note (approx. a 32th note) and thus, this small overlapped note forces excessive space after the rest.

Taking into account that:
- The MusicXML file indeed specifies an incorrect time position for the end of the last 7-tuplet note, easily avoidable, suggesting a bug in the MuseScore MusicXML exporter.
- I have no other MusicXML samples with this bug, suggesting it is a rare case.
- Fixing the spacing algorithm to deal with this is complex and could require a lot of work.

I have decided not to open an issue for now. I will wait until more evidence than this case really needs to be addressed in Lomse.

