### PR TITLE
Fix a crash on reading a MusicXML score with a start repeat barline in the first measure

### DIFF
--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -2199,7 +2199,7 @@ protected:
 
     void create_barline(const string& location)
     {
-        if (location == "left")
+        if (location == "left" && m_pAnalyser->get_last_barline())
         {
             //this barline must be combined with previous barline
             m_pBarline = m_pAnalyser->get_last_barline();


### PR DESCRIPTION
If a left barline is explicitly defined in a MusicXML score in the first measure Lomse still tries to combine it with the non-existing previous barline and crashes (which can be reproduced with [this example score](https://github.com/lenmus/lomse/files/6964977/test-repeat-start.musicxml.txt)). This PR simply adds a null-pointer check to prevent a crash and adds a simple test on basic handling of left and right barlines combining.

Ideally though a start repeat barline should be rendered after key and time signatures, whether they appear together in the beginning of a score or not. This may require MusicXML importer to do some extra work to sort the relevant objects in the score's object columns table but this involves more changes and isn't necessary for preventing the crash itself so I didn't implement it for this pull request.