### PR TITLE
MusicXML: fix a crash on reading <tied> element with unknown type

### DIFF
--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -6816,13 +6816,16 @@ public:
 
         set_tie_type_and_id(type, num, pNote);
 
-        m_pInfo1->set_note(pNote);
-        m_pAnalyser->add_relation_info(m_pInfo1);
-
-        if (m_pInfo2)
+        if (m_pInfo1)
         {
-            m_pInfo2->set_note(pNote);
-            m_pAnalyser->add_relation_info(m_pInfo2);
+            m_pInfo1->set_note(pNote);
+            m_pAnalyser->add_relation_info(m_pInfo1);
+
+            if (m_pInfo2)
+            {
+                m_pInfo2->set_note(pNote);
+                m_pAnalyser->add_relation_info(m_pInfo2);
+            }
         }
 
         return nullptr;     //m_pInfo1 has been deleted in add_relation_info()


### PR DESCRIPTION
Test score: [let-ring.musicxml.txt](https://github.com/lenmus/lomse/files/6978280/let-ring.musicxml.txt)

This PR fixes a crash on reading `<tied>` element which has an unknown `type` attribute value. Lomse prints a warning about the unknown attribute and warns that the tie would be ignored but actually a crash happens due to a missing null pointer check. Other similar element analyzers (at least those for slurs, wedges and octave shifts) already have similar checks in place and thus should not be affected by the issues of this type.

In the test file the unknown attribute value is `let-ring` which has been added in the 3.1 version of MusicXML, according to [the changelog](https://www.w3.org/2021/06/musicxml40/version-history/31). However it could possibly be some invalid value so this check will still be necessary if the `let-ring` type support is implemented at some point in future.

I am not sure whether it makes sense to setup a test for this specific case as the change is trivial, but possibly a larger test for an ability of the MusicXML analyzer to properly skip unknown tags and attribute values could be set up later.