### PR TITLE
Add a minimal implementation of StaffObjShapeCursor, improve wedge horizontal positioning

### DIFF
--- a/include/lomse_engraver.h
+++ b/include/lomse_engraver.h
@@ -67,7 +67,7 @@ public:
     virtual ~Engraver() {}
 
 protected:
-    LUnits tenths_to_logical(Tenths value);
+    LUnits tenths_to_logical(Tenths value) const;
     virtual double determine_font_size();
     virtual void add_user_shift(ImoContentObj* pImo, UPoint* pos);
 };

--- a/include/lomse_gm_basic.h
+++ b/include/lomse_gm_basic.h
@@ -491,10 +491,33 @@ protected:
     void draw_shapes(Drawer* pDrawer, RenderOptions& opt);
     void add_shapes_to_tables_in(GmoBoxDocPage* pPage);
 
+    friend class StaffObjShapeCursor;
     friend class GraphicModel;
     void add_boxes_to_map_imo_to_box(GraphicModel* pGM);
     void add_boxes_to_controls_map(GraphicModel* pGM);
 
+};
+
+//---------------------------------------------------------------------------------------
+class StaffObjShapeCursor {
+public:
+    explicit StaffObjShapeCursor(GmoBox* pBox);
+    explicit StaffObjShapeCursor(GmoShape* pShape);
+
+    GmoShape* get_shape() const { return (*m_it); }
+    TimeUnits get_time() const;
+
+    bool next();
+    bool next(TimeUnits maxTime);
+    bool nextAfter(TimeUnits time);
+
+    bool prev();
+    bool prev(TimeUnits minTime);
+    bool prevBefore(TimeUnits time);
+
+protected:
+    GmoBox* m_pCurrentBox;
+    std::list<GmoShape*>::const_iterator m_it;
 };
 
 //---------------------------------------------------------------------------------------

--- a/include/lomse_wedge_engraver.h
+++ b/include/lomse_wedge_engraver.h
@@ -98,9 +98,10 @@ protected:
     GmoShape* create_final_shape();
 
     void compute_first_shape_position();
-    void compute_last_shape_position();
-    void compute_intermediate_shape_position();
+    void compute_intermediate_or_last_shape_position();
 
+    LUnits determine_shape_position_left(bool first) const;
+    LUnits determine_shape_position_right() const;
     LUnits determine_center_line_of_shape(LUnits startSpread, LUnits endSpread);
     //void add_user_displacements(int iWedge, UPoint* points);
 

--- a/src/graphic_model/engravers/lomse_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_engraver.cpp
@@ -39,7 +39,7 @@ namespace lomse
 //---------------------------------------------------------------------------------------
 // Engraver implementation
 //---------------------------------------------------------------------------------------
-LUnits Engraver::tenths_to_logical(Tenths value)
+LUnits Engraver::tenths_to_logical(Tenths value) const
 {
     return m_pMeter->tenths_to_logical(value, m_iInstr, m_iStaff);
 }

--- a/src/graphic_model/lomse_gm_basic.cpp
+++ b/src/graphic_model/lomse_gm_basic.cpp
@@ -735,6 +735,96 @@ void GmoBox::add_boxes_to_map_imo_to_box(GraphicModel* pGM)
 
 
 //=======================================================================================
+// StaffObjShapeCursor
+//=======================================================================================
+StaffObjShapeCursor::StaffObjShapeCursor(GmoBox* pBox)
+    : m_pCurrentBox(pBox), m_it(pBox->m_shapes.begin())
+{
+}
+
+//---------------------------------------------------------------------------------------
+StaffObjShapeCursor::StaffObjShapeCursor(GmoShape* pShape)
+    : m_pCurrentBox(pShape->get_owner_box())
+{
+    std::list<GmoShape*>& shapes = m_pCurrentBox->m_shapes;
+    m_it = std::find(shapes.begin(), shapes.end(), pShape);
+}
+
+//---------------------------------------------------------------------------------------
+TimeUnits StaffObjShapeCursor::get_time() const
+{
+    return static_cast<ImoStaffObj*>(get_shape()->get_creator_imo())->get_time();
+}
+
+//---------------------------------------------------------------------------------------
+bool StaffObjShapeCursor::next()
+{
+    ++m_it;
+    return m_it != m_pCurrentBox->m_shapes.end() && (*m_it)->get_creator_imo()->is_staffobj();
+}
+
+//---------------------------------------------------------------------------------------
+bool StaffObjShapeCursor::next(TimeUnits maxTime)
+{
+    if (!next())
+        return false;
+
+    //next() ensures that we have a staffobj shape
+    ImoStaffObj* pSO = static_cast<ImoStaffObj*>(get_shape()->get_creator_imo());
+    return pSO->get_time() <= maxTime;
+}
+
+//---------------------------------------------------------------------------------------
+bool StaffObjShapeCursor::nextAfter(TimeUnits time)
+{
+    while (next())
+    {
+        //next() ensures that we have a staffobj shape
+        ImoStaffObj* pSO = static_cast<ImoStaffObj*>(get_shape()->get_creator_imo());
+        if (pSO->get_time() > time)
+            return true;
+    }
+
+    return false;
+}
+
+//---------------------------------------------------------------------------------------
+bool StaffObjShapeCursor::prev()
+{
+    if (m_it == m_pCurrentBox->m_shapes.begin())
+        return false;
+
+    --m_it;
+    return (*m_it)->get_creator_imo()->is_staffobj();
+}
+
+//---------------------------------------------------------------------------------------
+bool StaffObjShapeCursor::prev(TimeUnits minTime)
+{
+    if (!prev())
+        return false;
+
+    //prev() ensures that we have a staffobj shape
+    ImoStaffObj* pSO = static_cast<ImoStaffObj*>(get_shape()->get_creator_imo());
+    return pSO->get_time() >= minTime;
+}
+
+//---------------------------------------------------------------------------------------
+bool StaffObjShapeCursor::prevBefore(TimeUnits time)
+{
+    while (prev())
+    {
+        //prev() ensures that we have a staffobj shape
+        ImoStaffObj* pSO = static_cast<ImoStaffObj*>(get_shape()->get_creator_imo());
+        if (pSO->get_time() < time)
+            return true;
+    }
+
+    return false;
+}
+
+
+//=======================================================================================
 // GmoLayer: helper class. A collection of GmoShape objects
 //=======================================================================================
 


### PR DESCRIPTION
This pull request provides a proof-of-concept implementation of a horizontal alignment of an object attached to an `ImoDirection` to staff object shapes by finding them in the graphical model, like discussed in #309.

It turns out that note and rest shapes currently belong to a `GmoBoxSliceStaff` box which maintain a list of their child shapes in engraving order. As staff objects seem to be engraved ordered by time, shapes in the `GmoBoxSliceStaff`'s list are also sorted by the time of the corresponding internal model objects. They are not however sorted by their `x` coordinates, and in order to obtain the leftmost note at a certain position one has to check all the notes in the current time position. Also the same list contains shapes for auxiliary and relation objects which are already engraved, so only a part of this list is useful for engravers.

To handle all this I have implemented a helper `StaffObjShapeCursor` class which implements basic iterating over `GmoBox` child shapes with filtering of staff object shapes and support for basic time point limitations. Currently it iterates only over `GmoBoxSliceStaff` which makes it limited only to a current measure and staff but it can potentially be expanded to handle the entire instrument or all instruments and to support iterating over several measures. Even with these limitations it can be useful but from what I see expanding iteration abilities of this cursor will likely be needed in future. For example, the current cursor does not allow to handle wedges attached to a direction starting before a barline, like in the situation described in #277. However I am not sure about the semantics of such MusicXML encoding, perhaps in that case it was intended to leave the wedge start before that barline.

To demonstrate the usage of the newly implemented cursor I have implemented some changes to the wedge horizontal positioning.

First, I have added an alignment of a wedge start to its starting note when it is possible to determine one with the current implementation of the cursor. If it is not possible I have added a small offset to the old position, just to avoid a possible collision with a barline in cases like #277.

Concerning the end point of a wedge, the situation seems to be a bit more difficult. From what I see in "Behind Bars" Gould recommends aligning a wedge end to the start of the next notehead (which is close to what Lomse does currently), Lilypond according to [its documentation](https://lilypond.org/doc/v2.23/Documentation/notation/expressive-marks-attached-to-notes#dynamics) aligns it to the end note's right edge, and in printed music I have observed really different options of that. Therefore in this PR I went for a more conservative approach and just added an offset before the barline if a wedge happens to end just before it. The option to align a wedge end to the end note's right edge is also trivial to implement with the new cursor, although it does not currently handle notes in a different staff of the same instrument, like mentioned above.

| This PR  | Alignment to the end note's right edge |
| ------------- | ------------- |
| ![this_pr](https://user-images.githubusercontent.com/6000747/130337833-cac8d6a8-cf73-4b83-bc2d-b02923afe66b.png) | ![align_to_note](https://user-images.githubusercontent.com/6000747/130337836-376b1e20-1f0f-4905-bc4b-ad985eeac0e5.png) |

Therefore to reach its full potential `StaffObjShapeCursor` will probably need to be expanded, and possibly some minor changes to the internal model may be needed to improve performance of the cursor if it happens to be slow (for example, to avoid linear search for the shape position in the list). However this method may already be useful even with its current limitations. Therefore if we decide to go that way this PR can be useful as it is, or I can try to expand the cursor further to see how it will look like if multiple staves and measures are to be handled.