### PR TITLE
Fix a crash when a tuplet starts or ends with an invisible note

### DIFF
--- a/include/lomse_tuplet_engraver.h
+++ b/include/lomse_tuplet_engraver.h
@@ -102,7 +102,7 @@ protected:
     ImoNoteRest* get_start_noterest() { return m_noteRests.front().first; }
     ImoNoteRest* get_end_noterest() { return m_noteRests.back().first; }
 
-    void compute_y_coordinates();
+    void compute_y_coordinates(GmoShapeNote* pStart, GmoShapeNote* pEnd);
     GmoShapeNote* get_first_note();
     GmoShapeNote* get_last_note();
 

--- a/src/graphic_model/engravers/lomse_tuplet_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_tuplet_engraver.cpp
@@ -131,6 +131,12 @@ GmoShape* TupletEngraver::create_first_or_intermediate_shape(LUnits UNUSED(xStaf
 //---------------------------------------------------------------------------------------
 GmoShape* TupletEngraver::create_last_shape(Color color)
 {
+    GmoShapeNote* pStart = get_first_note();
+    GmoShapeNote* pEnd = get_last_note();
+
+    if (!pStart || !pEnd)
+        return nullptr;     //all group are rests or notes longer than quarter note!
+
     m_color = color;
     decide_tuplet_placement();
     decide_if_show_bracket();
@@ -138,7 +144,7 @@ GmoShape* TupletEngraver::create_last_shape(Color color)
 
     if (m_fDrawNumber || m_fDrawBracket)
     {
-        compute_y_coordinates();
+        compute_y_coordinates(pStart, pEnd);
         create_shape();
         set_shape_details();
         m_numShapes = 1;
@@ -221,14 +227,8 @@ void TupletEngraver::add_text_shape()
 }
 
 //---------------------------------------------------------------------------------------
-void TupletEngraver::compute_y_coordinates()
+void TupletEngraver::compute_y_coordinates(GmoShapeNote* pStart, GmoShapeNote* pEnd)
 {
-    GmoShapeNote* pStart = get_first_note();
-    GmoShapeNote* pEnd = get_last_note();
-
-    if (!pStart || !pEnd)
-    	return;     //all group are rests or notes longer than quarter note!
-
     GmoShapeBeam* pBeamShapeStart = static_cast<GmoShapeBeam*>(
                                     pStart->find_related_shape(GmoObj::k_shape_beam) );
     GmoShapeBeam* pBeamShapeEnd = static_cast<GmoShapeBeam*>(

--- a/src/graphic_model/engravers/lomse_tuplet_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_tuplet_engraver.cpp
@@ -349,8 +349,8 @@ GmoShapeNote* TupletEngraver::get_first_note()
     std::list< pair<ImoNoteRest*, GmoShape*> >::iterator it;
     for (it = m_noteRests.begin(); it != m_noteRests.end(); ++it)
     {
-        if ((*it).first->is_note())
-            return dynamic_cast<GmoShapeNote*>((*it).second);
+        if ((*it).second->is_shape_note())
+            return static_cast<GmoShapeNote*>((*it).second);
     }
     return nullptr;    //imposible case unless all group are rests!
 }
@@ -361,8 +361,8 @@ GmoShapeNote* TupletEngraver::get_last_note()
     std::list< pair<ImoNoteRest*, GmoShape*> >::reverse_iterator it;
     for (it = m_noteRests.rbegin(); it != m_noteRests.rend(); ++it)
     {
-        if ((*it).first->is_note())
-            return dynamic_cast<GmoShapeNote*>((*it).second);
+        if ((*it).second->is_shape_note())
+            return static_cast<GmoShapeNote*>((*it).second);
     }
     return nullptr;    //imposible case unless all group are rests!
 }

--- a/src/graphic_model/lomse_shape_tuplet.cpp
+++ b/src/graphic_model/lomse_shape_tuplet.cpp
@@ -218,21 +218,21 @@ void GmoShapeTuplet::compute_horizontal_position()
     //when the tuplet is engraved the system is not justified and, therefore,
     //the notes will be moved.
 
-    if (m_pStartNR->is_shape_rest())
-        m_uxStart = m_pStartNR->get_left();
-    else
+    if (m_pStartNR->is_shape_note())
     {
         GmoShapeNote* pStartNote = static_cast<GmoShapeNote*>(m_pStartNR);
         m_uxStart = pStartNote->get_notehead_left();
     }
-
-    if (m_pEndNR->is_shape_rest())
-        m_uxEnd = m_pEndNR->get_right();
     else
+        m_uxStart = m_pStartNR->get_left();
+
+    if (m_pEndNR->is_shape_note())
     {
         GmoShapeNote* pEndNote = static_cast<GmoShapeNote*>(m_pEndNR);
         m_uxEnd = pEndNote->get_notehead_right();
     }
+    else
+        m_uxEnd = m_pEndNR->get_right();
 }
 
 //---------------------------------------------------------------------------------------


### PR DESCRIPTION
Invisible notes are quite often found in digital score formats to achieve certain playback effects. Lomse correctly imports `print-object` attribute of such notes and creates invisible shapes in place of them but this doesn't play well with engraving some relation objects which happen to include such invisible notes. Therefore I have encountered a number of crashes on engraving scores which include invisible notes.

This pull requests fixes a crash in case an invisible note is a start or end note in a tuplet (a small example score: [lomse_tuplet_invisible_note_crash.musicxml.txt](https://github.com/lenmus/lomse/files/7027305/lomse_tuplet_invisible_note_crash.musicxml.txt)). In this case it is enough just to rearrange a bit a logic of the tuplet engraver to explicitly check all assumptions about shape types which the engraver makes. Therefore the engraver's logic remains unchanged for the case when all notes and rests in the tuplet are visible but it now correctly handles the case when some of the tuplet's notes are invisible.