### PR TITLE
Fix a crash on engraving a beam including invisible notes

### DIFF
--- a/include/lomse_system_layouter.h
+++ b/include/lomse_system_layouter.h
@@ -174,6 +174,7 @@ protected:
 
     void add_last_rel_shape_to_model(GmoShape* pShape, ImoRelObj* pRO, int layer,
                                      int iCol, int iInstr, int iStaff, int idxStaff);
+    void delete_rel_obj_engraver(ImoRelObj* pRO);
     void add_lyrics_shapes_to_model(const std::string& tag, int layer, bool fLast,
                                     int iStaff, int idxStaff);
     void add_aux_shape_to_model(GmoShape* pShape, int layer, int iCol, int iInstr,

--- a/src/graphic_model/engravers/lomse_beam_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_beam_engraver.cpp
@@ -116,6 +116,12 @@ void BeamEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* pSO,
 //---------------------------------------------------------------------------------------
 void BeamEngraver::add_note_rest(ImoStaffObj* pSO, GmoShape* pStaffObjShape)
 {
+    if (pStaffObjShape->is_shape_invisible())
+        return;
+
+    if (pSO->is_note())
+        ++m_numNotes;
+
     ImoNoteRest* pNR = dynamic_cast<ImoNoteRest*>(pSO);
 
     if (pNR->is_note())
@@ -147,6 +153,12 @@ GmoShape* BeamEngraver::create_first_or_intermediate_shape(LUnits UNUSED(xStaffL
 //---------------------------------------------------------------------------------------
 GmoShape* BeamEngraver::create_last_shape(Color color)
 {
+    if (!m_numNotes)
+    {
+        LOMSE_LOG_WARN("No notes in beam");
+        return nullptr;
+    }
+
     m_color = color;
     decide_stems_direction();
     determine_number_of_beam_levels();

--- a/src/graphic_model/layouters/lomse_system_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_system_layouter.cpp
@@ -891,7 +891,6 @@ void SystemLayouter::engrave_attached_object(ImoObj* pAR, PendingAuxObj* pPAO,
                                                       iLine, prologWidth, pInstr,
                                                       idxStaff, m_pVProfile);
             GmoShape* pAuxShape = m_pShapesCreator->create_last_shape(pRO);
-            if (pAuxShape)
             add_last_rel_shape_to_model(pAuxShape, pRO, GmoShape::k_layer_aux_objs,
                                         iCol, iInstr, iStaff, idxStaff);
 
@@ -1121,6 +1120,12 @@ void SystemLayouter::add_last_rel_shape_to_model(GmoShape* pShape, ImoRelObj* pR
                                                  int layer, int iCol, int iInstr,
                                                  int iStaff, int idxStaff)
 {
+    if (!pShape)
+    {
+        delete_rel_obj_engraver(pRO);
+        return;
+    }
+
     //in case of cross-staff beams (beams with flag stem segments in two or more staves),
     //the beam must be placed on bottom staff when below or double-stemmed or in top
     //staff when above.
@@ -1142,17 +1147,21 @@ void SystemLayouter::add_last_rel_shape_to_model(GmoShape* pShape, ImoRelObj* pR
     add_aux_shape_to_model(pShape, layer, iCol, iInstr, iStaff, idxStaff);
 
     if (fDeleteEngraver)
+        delete_rel_obj_engraver(pRO);
+}
+
+//---------------------------------------------------------------------------------------
+void SystemLayouter::delete_rel_obj_engraver(ImoRelObj* pRO)
+{
+    RelObjEngraver* pEngrv
+        = dynamic_cast<RelObjEngraver*>(m_engravers.get_engraver(pRO));
+    if (pEngrv == nullptr)
     {
-        RelObjEngraver* pEngrv
-            = dynamic_cast<RelObjEngraver*>(m_engravers.get_engraver(pRO));
-        if (pEngrv == nullptr)
-        {
-            LOMSE_LOG_ERROR("Engraver is not RelObjEngraver");
-            return;
-        }
-        m_engravers.remove_engraver(pRO);
-        delete pEngrv;
+        LOMSE_LOG_ERROR("Engraver is not RelObjEngraver");
+        return;
     }
+    m_engravers.remove_engraver(pRO);
+    delete pEngrv;
 }
 
 //---------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes another case of a crash with invisible notes (see also #311). If a beam includes invisible notes or fully consists of invisible notes then a crash happens because the engraver assumes that a beam always contains at least one visible note. This PR makes the engraver skip invisible staff objects passed to it and explicitly check that there are visible notes which can be used to engrave the beam. `m_numNotes` counter is reset later by the beam engraving algorithm so it should be fine to reuse it for this purpose.

Also this PR includes changes to properly delete the engraver if the last shape it produces is `nullptr`. Actually it would probably be even better if the `EngraverMap` would be responsible for deleting the engravers stored in it but this is probably something that doesn't belong to the scope of this PR.

An example score for this crash: [lomse_beam_invisible_note_crash.musicxml.txt](https://github.com/lenmus/lomse/files/7027326/lomse_beam_invisible_note_crash.musicxml.txt)
