### PR TITLE
Ensure that non-finished relation objects are engraved in the correct order

### DIFF
--- a/src/graphic_model/layouters/lomse_system_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_system_layouter.cpp
@@ -796,22 +796,26 @@ void SystemLayouter::engrave_system_details(int iSystem)
                     ++it;
             }
         }
-    }
 
-    //engrave RelObjs that continue in next system
-    list<PendingRelObj>::iterator itR;
-    for (itR = m_pScoreLyt->m_notFinishedRelObj.begin();
-         itR != m_pScoreLyt->m_notFinishedRelObj.end(); ++itR)
-    {
-        engrave_not_finished_relobj((*itR).first, (*itR).second, iSystem);
-    }
-
-    //engrave Lyrics that continue in next system
-    list<PendingLyricsObj>::iterator itAR;
-    for (itAR = m_pScoreLyt->m_notFinishedLyrics.begin();
-         itAR != m_pScoreLyt->m_notFinishedLyrics.end(); ++itAR)
-    {
-        engrave_not_finished_lyrics((*itAR).first, (*itAR).second, iSystem);
+        if (k_imo_relobj < type && type < k_imo_relobj_last)
+        {
+            //engrave RelObjs that continue in next system
+            for (PendingRelObj& obj : m_pScoreLyt->m_notFinishedRelObj)
+            {
+                if (obj.first->get_obj_type() == type)
+                {
+                    engrave_not_finished_relobj(obj.first, obj.second, iSystem);
+                }
+            }
+        }
+        else if (type == k_imo_lyric)
+        {
+            //engrave Lyrics that continue in next system
+            for (PendingLyricsObj& obj : m_pScoreLyt->m_notFinishedLyrics)
+            {
+                engrave_not_finished_lyrics(obj.first, obj.second, iSystem);
+            }
+        }
     }
 
     //delete engraved staffobjs


### PR DESCRIPTION
In order to ensure that different objects are engraved in the expected order Lomse makes several passes across the system's list of pending objects and engraves object of one type in each pass. However this doesn't work for objects that are not finished in the current system as those are engraved after engraving all objects that are finished in the current system. This leads to an inconsistent engraving order if unfinished relation objects are involved, for example (note that the order for a wedge and an octave shift is inverted when the octave shift spans for two systems):
![1](https://user-images.githubusercontent.com/6000747/131262287-0ca244eb-a943-47d9-ac5d-8f6f00dfd72f.png)
This pull request moves engraving of non-finished relation objects to the same loop that does engraving of other objects which makes the engraving order more consistent between those objects:
![2](https://user-images.githubusercontent.com/6000747/131262306-0cf61b66-e188-4262-af5a-8afd90d187b8.png)
(test file: [engraving-order-example.musicxml.txt](https://github.com/lenmus/lomse/files/7073072/engraving-order-example.musicxml.txt))

Of course, the situation shown in the example is not really common, but having a consistent engraving order will greatly simplify things in future. This will ensure the correct engraving order if more object types are added (for example, to ensure the engraving order between wedges and pedal lines which are typically both placed below a staff) and will make it easier to introduce vertical alignment of certain element types (for example, consecutive volta brackets, pedals, combinations of dynamic marks and hairpins etc.)