### PR TITLE
Fix a crash on engraving a double-stemmed beam with a chord and multiple notes

### DIFF
--- a/src/graphic_model/engravers/lomse_chord_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_chord_engraver.cpp
@@ -911,8 +911,6 @@ bool BeamedChordHelper::compute_stem_direction_for_chord(ImoNote* pBaseNote,
         fStemDown ? ++m_nDownForced : ++m_nUpForced;
         computedStem = (fStemDown ? k_computed_stem_forced_down
                                   : k_computed_stem_forced_up);
-        pChord->set_stem_direction(computedStem);
-        m_pStemsDir->push_back(computedStem);
     }
     else
     {

--- a/src/graphic_model/engravers/lomse_note_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_note_engraver.cpp
@@ -201,9 +201,6 @@ void NoteEngraver::determine_stem_direction()
     ImoBeam* pBeam = m_pNote->get_beam();
     if (pBeam && pBeam->contains_chords())
     {
-        //As the stem will be engraved by the beam, it doesn't matter with stem
-        //direction is set in this method
-        m_fStemDown = false;
         if (m_pNote == pBeam->get_start_object())
         {
             //When the note is in a beam and the beam contains chords, stem direction
@@ -211,6 +208,14 @@ void NoteEngraver::determine_stem_direction()
             vector<int> clefs = m_pCursor->get_applicable_clefs_for_instrument(m_iInstr);
             BeamedChordHelper helper(pBeam, &clefs);
             m_fStemDown = helper.compute_stems_directions();
+        }
+        else if (m_pNote->get_computed_stem() != k_computed_stem_undecided)
+        {
+            m_fStemDown = m_pNote->is_computed_stem_down();
+        }
+        else
+        {
+            m_fStemDown = false;
         }
     }
     else if (m_pNote->is_grace_note())

--- a/src/internal_model/lomse_im_note.cpp
+++ b/src/internal_model/lomse_im_note.cpp
@@ -220,6 +220,7 @@ ImoNote::ImoNote(int step, int octave, int noteType, EAccidentals accidentals, i
     , m_stemDirection(stem)
     , m_pTieNext(nullptr)
     , m_pTiePrev(nullptr)
+    , m_computedStem(k_computed_stem_undecided)
 {
     m_step = step;
     m_octave = octave;


### PR DESCRIPTION
This PR fixes a crash which occurs with [this score](https://musescore.com/openscore/scores/5421848) for Beethoven's Moonlight Sonata. The part which produces this crash can be reduced down to this example score ([lomse_beaming_crash2.musicxml.txt](https://github.com/lenmus/lomse/files/7073131/lomse_beaming_crash2.musicxml.txt)):
![изображение](https://user-images.githubusercontent.com/6000747/131263335-5f0524d5-bdb1-492a-a9cb-de1d19155212.png)

In this score there is a beam which connects both chords and single notes and which is set up so that stem directions are different. The same beam with no chords does not produce a crash.

Stem directions for beams with chords are computed before engraving the beam by a special `BeamedChordHelper`, and the beam engraver does not compute stem directions by itself in this case. However when setting the `m_fDoubleStemmed` flag directions are taken [from the beam](https://github.com/lenmus/lomse/blob/e08559c1de83fa7411ebde86400725b982db8d18/src/graphic_model/engravers/lomse_beam_engraver.cpp#L413) while later notes with different stem directions are split by querying their orientation [from note shape objects](https://github.com/lenmus/lomse/blob/e08559c1de83fa7411ebde86400725b982db8d18/src/graphic_model/engravers/lomse_beam_engraver.cpp#L813). Note engraver didn't set up orientation for such notes properly so stem orientation data from the notes and from the beam were getting out of sync. Therefore one of the lists got empty which later produced a crash.

This patch makes the note engraver take into account stem directions computed by the `BeamedChordHelper` to ensure that note shape orientation is in sync with the beam's stem directions data. This seems to be the safest approach as note shape orientation is used in multiple places in the beam engraver.

Also this patch fixes the issue with `BeamedChordHelper` adding duplicated items to the beam directions list, this is also needed to ensure that stem directions data are in sync.