### PR TITLE
Fix anchor line for chords

### DIFF
--- a/include/lomse_shape_base.h
+++ b/include/lomse_shape_base.h
@@ -143,15 +143,11 @@ class GmoCompositeShape : public GmoShape
 {
 protected:
 	std::list<GmoShape*> m_components;	//constituent shapes
-    bool m_fLocked;                     //constituent shapes cannot be moved
 
 public:
     ~GmoCompositeShape() override;
 
     virtual int add(GmoShape* pShape);
-    inline bool is_locked() { return m_fLocked; }
-    inline void unlock() { m_fLocked = false; }
-    void lock();
 
     //may be needed in case child shapes changed their positions independently of the entire composite shape
     void force_recompute_bounds() { recompute_bounds(); }

--- a/src/graphic_model/lomse_shape_base.cpp
+++ b/src/graphic_model/lomse_shape_base.cpp
@@ -200,7 +200,6 @@ GmoSimpleShape::~GmoSimpleShape()
 GmoCompositeShape::GmoCompositeShape(ImoObj* pCreatorImo, int objtype, ShapeId idx,
                                      Color color)
     : GmoShape(pCreatorImo, objtype, idx, color)
-    , m_fLocked(true)
 {
 }
 
@@ -277,13 +276,6 @@ void GmoCompositeShape::on_draw(Drawer* pDrawer, RenderOptions& opt)
     std::list<GmoShape*>::iterator it;
     for (it = m_components.begin(); it != m_components.end(); ++it)
         (*it)->on_draw(pDrawer, opt);
-}
-
-//---------------------------------------------------------------------------------------
-void GmoCompositeShape::lock()
-{
-    m_fLocked = true;
-    recompute_bounds();
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/tests/lomse_test_shapes.cpp
+++ b/src/tests/lomse_test_shapes.cpp
@@ -94,29 +94,7 @@ SUITE(GmoShapeTest)
         CHECK( shape.get_origin() == newOrigin );
     }
 
-    TEST_FIXTURE(GmoShapeTestFixture, Composite_IsLocked)
-    {
-        Document doc(m_libraryScope);
-        ImoNote* pNote = static_cast<ImoNote*>(ImFactory::inject(k_imo_note_regular, &doc));
-        pNote->set_step(0);
-        pNote->set_octave(4);
-        pNote->set_notated_accidentals(k_no_accidentals);
-        pNote->set_note_type(k_whole);
-
-        ScoreMeter meter(nullptr, 1, 1, LOMSE_STAFF_LINE_SPACING);
-        EngraversMap storage;
-        NoteEngraver engraver(m_libraryScope, &meter, &storage, 0, 0);
-        GmoShapeNote* pShape =
-            dynamic_cast<GmoShapeNote*>(engraver.create_shape(pNote, k_clef_F4, 0, UPoint(10.0f, 15.0f)) );
-
-        CHECK( pShape != nullptr );
-        CHECK( pShape && pShape->is_locked() == true );
-
-        delete pNote;
-        delete pShape;
-    }
-
-    TEST_FIXTURE(GmoShapeTestFixture, Composite_LockRecomputesBounds)
+    TEST_FIXTURE(GmoShapeTestFixture, Composite_RecomputeBounds)
     {
         Document doc(m_libraryScope);
         ImoNote* pNote = static_cast<ImoNote*>(ImFactory::inject(k_imo_note_regular, &doc));
@@ -132,17 +110,13 @@ SUITE(GmoShapeTest)
         CHECK( pShape != nullptr);
         if (pShape)
         {
-            pShape->unlock();
-            CHECK( pShape->is_locked() == false );
-
             USize size = pShape->get_size();
             UPoint org = pShape->get_origin();
             GmoShapeNotehead* pNH = pShape->get_notehead_shape();
             USize shift(200.0f, 300.0f);
             pNH->shift_origin(shift);
-            pShape->lock();
+            pShape->force_recompute_bounds();
 
-            CHECK( pShape->is_locked() == true );
             CHECK( pShape->get_size() == size );
             CHECK( pShape->get_origin().x == org.x + shift.width );
             CHECK( pShape->get_origin().y == org.y + shift.height );
@@ -152,7 +126,7 @@ SUITE(GmoShapeTest)
         delete pShape;
     }
 
-    TEST_FIXTURE(GmoShapeTestFixture, Composite_LockRecomputesBounds2)
+    TEST_FIXTURE(GmoShapeTestFixture, Composite_RecomputeBounds2)
     {
         Document doc(m_libraryScope);
         ImoNote* pNote = static_cast<ImoNote*>(ImFactory::inject(k_imo_note_regular, &doc));
@@ -168,17 +142,13 @@ SUITE(GmoShapeTest)
         CHECK( pShape != nullptr);
         if (pShape)
         {
-            pShape->unlock();
-            CHECK( pShape->is_locked() == false );
-
             USize size = pShape->get_size();
             GmoShapeNotehead* pNH = pShape->get_notehead_shape();
             GmoShapeAccidentals* pAcc = pShape->get_accidentals_shape();
             USize shift(200.0f, 300.0f);
             pNH->shift_origin(shift);
-            pShape->lock();
+            pShape->force_recompute_bounds();
 
-            CHECK( pShape->is_locked() == true );
             CHECK( pShape->get_size().width == size.width + shift.width );
             CHECK( pShape->get_origin().x == min(pAcc->get_origin().x, pNH->get_origin().x) );
             CHECK( pShape->get_origin().y == min(pAcc->get_origin().y, pNH->get_origin().y) );


### PR DESCRIPTION
Notes in different voices that sound at the same time are vertically aligned in the score. These alignment lines are sometimes named ‘_beatlines_’ in academic literature but, in Lomse, for historical reasons, they are named ‘_anchor_’ lines.

This PR fixes the computation of anchor lines for chords, that caused alignment problems, e.g. test score 00623:

Current:
![image](https://user-images.githubusercontent.com/5238679/132026874-ac51f064-2bbc-4d2d-abe4-4c28f4a68194.png)  
After this PR:
![image](https://user-images.githubusercontent.com/5238679/132026906-a4831099-b6e8-4e28-89ab-21c6cc4370a6.png)
 

In addition, this PR removes methods `lock()` and `unlock()` in `GmoShapeComposite` an the related variable, as they are not used and are not needed.

