### PR TITLE
Implement relative alignment of auxiliary objects, align voltas and hairpin-dynamic sequences

### DIFF
--- a/add-sources.cmake
+++ b/add-sources.cmake
@@ -107,6 +107,7 @@ set(GRAPHIC_MODEL_FILES
     ${LOMSE_SRC_DIR}/graphic_model/engravers/lomse_volta_engraver.cpp
     ${LOMSE_SRC_DIR}/graphic_model/engravers/lomse_wedge_engraver.cpp
 
+    ${LOMSE_SRC_DIR}/graphic_model/layouters/lomse_aux_shapes_aligner.cpp
     ${LOMSE_SRC_DIR}/graphic_model/layouters/lomse_blocks_container_layouter.cpp
     ${LOMSE_SRC_DIR}/graphic_model/layouters/lomse_document_layouter.cpp
     ${LOMSE_SRC_DIR}/graphic_model/layouters/lomse_inlines_container_layouter.cpp

--- a/include/lomse_dynamics_mark_engraver.h
+++ b/include/lomse_dynamics_mark_engraver.h
@@ -42,6 +42,7 @@ class ImoDynamicsMark;
 class GmoShape;
 class ScoreMeter;
 class GmoShapeDynamicsMark;
+class VerticalProfile;
 
 //---------------------------------------------------------------------------------------
 class DynamicsMarkEngraver : public Engraver
@@ -52,10 +53,12 @@ protected:
     bool m_fAbove;
     GmoShape* m_pParentShape;
     GmoShapeDynamicsMark* m_pDynamicsMarkShape;
+    int m_idxStaff;
+    VerticalProfile* m_pVProfile;
 
 public:
     DynamicsMarkEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                    int iInstr, int iStaff);
+                    int iInstr, int iStaff, int idxStaff, VerticalProfile* pVProfile);
     ~DynamicsMarkEngraver() {}
 
     GmoShapeDynamicsMark* create_shape(ImoDynamicsMark* pDynamicsMark, UPoint pos,
@@ -68,6 +71,7 @@ protected:
     void center_on_parent();
     void add_voice();
     int find_glyph();
+    void shift_shape_if_collision();
 
 };
 

--- a/include/lomse_engraver.h
+++ b/include/lomse_engraver.h
@@ -142,6 +142,9 @@ public:
                                             VerticalProfile* UNUSED(pVProfile),
                                             Color UNUSED(color)=Color(0,0,0)) { return nullptr; }
     virtual GmoShape* create_last_shape(Color UNUSED(color)=Color(0,0,0)) { return nullptr; }
+
+protected:
+    void add_to_aux_shapes_aligner(GmoShape* pShape, bool fAboveStaff);
 };
 
 //---------------------------------------------------------------------------------------

--- a/include/lomse_engraving_options.h
+++ b/include/lomse_engraving_options.h
@@ -118,6 +118,9 @@ namespace lomse
 //wedges
 #define LOMSE_WEDGE_LINE_THICKNESS      1.5f    //line thickness for wedges/hairpins
 #define LOMSE_WEDGE_NIENTE_RADIUS       4.0f    //radius for niente circles in wedges
+#define LOMSE_WEDGE_HORIZONTAL_ALIGN_DISTANCE 6.0f //space between a wedge and the nearest wedge or dynamic mark
+#define LOMSE_WEDGE_ALIGN_MAX_EDGE_SHIFT 50.0f  //maximum amount of space a wedge's end can be horizontally shifted if collision with another wedge or dynamic mark is detected
+#define LOMSE_WEDGE_BASELINE_SHIFT_Y    5.0f    //wedge baseline shift relative to its center to properly align with dynamic marks
 
 //octave-shift lines
 #define LOMSE_OCTAVE_SHIFT_LINE_THICKNESS  1.0f //thickness for octave-shift lines

--- a/include/lomse_gm_basic.h
+++ b/include/lomse_gm_basic.h
@@ -360,6 +360,7 @@ public:
     void set_origin_and_notify_observers(LUnits xLeft, LUnits yTop);
     virtual bool hit_test(LUnits x, LUnits y);
     virtual void reposition_shape(LUnits yShift);
+    virtual LUnits get_baseline_y() const { return get_bottom(); }
 
     //related shapes
     inline std::list<GmoShape*>* get_related_shapes() { return m_pRelatedShapes; }

--- a/include/lomse_shape_wedge.h
+++ b/include/lomse_shape_wedge.h
@@ -63,16 +63,18 @@ protected:
     LUnits m_yBottomStart;
     LUnits m_xBottomEnd;
     LUnits m_yBottomEnd;
+    LUnits m_yBaseline;
 
     int     m_niente;
     LUnits  m_radiusNiente;
 
 public:
     GmoShapeWedge(ImoObj* pCreatorImo, ShapeId idx, UPoint points[], LUnits thickness,
-                  Color color, int niente, LUnits radius);
+                  Color color, int niente, LUnits radius, LUnits yBaseline);
     virtual ~GmoShapeWedge();
 
     void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
+    LUnits get_baseline_y() const override;
 
     //construction
     enum {

--- a/include/lomse_shapes.h
+++ b/include/lomse_shapes.h
@@ -62,6 +62,9 @@ public:
 
     void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 
+    LUnits get_relative_baseline_y() const { return m_shiftToDraw.height; }
+    LUnits get_baseline_y() const override { return m_origin.y + get_relative_baseline_y(); }
+
 protected:
     GmoShapeGlyph(ImoObj* pCreatorImo, int type, ShapeId idx, unsigned int nGlyph,
                   UPoint pos, Color color, LibraryScope& libraryScope,

--- a/include/lomse_system_layouter.h
+++ b/include/lomse_system_layouter.h
@@ -38,6 +38,7 @@
 #include "lomse_spacing_algorithm.h"
 
 #include <list>
+#include <memory>
 #include <tuple>
 
 namespace lomse
@@ -51,6 +52,7 @@ class GmoShape;
 class GmoBoxSystem;
 class GmoShapeBeam;
 class GmoShapeNote;
+class AuxShapesAlignersSystem;
 class ImoAuxObj;
 class ImoRelObj;
 class ImoAuxRelObj;
@@ -69,6 +71,7 @@ class SystemLayouter;
 class TypeMeasureInfo;
 class VerticalProfile;
 struct PendingAuxObj;
+enum EAuxShapesAlignmentScope : int;
 
 //---------------------------------------------------------------------------------------
 // SystemLayouter: algorithm to layout a system
@@ -103,6 +106,8 @@ protected:
 
     SpacingAlgorithm* m_pSpAlgorithm;
     int m_constrains;
+
+    std::unique_ptr<AuxShapesAlignersSystem> m_curAuxShapesAligner;
 
 public:
     SystemLayouter(ScoreLayouter* pScoreLyt, LibraryScope& libraryScope,
@@ -153,6 +158,7 @@ protected:
     void redistribute_free_space();
     void engrave_measure_numbers();
     void engrave_system_details(int iSystem);
+    void setup_aux_shapes_aligner(EAuxShapesAlignmentScope scope, Tenths maxAlignDistance = 0.0f);
     void add_instruments_info();
     void move_staves_to_avoid_collisions();
     void reposition_staves_in_engravers(const std::vector<LUnits>& yOrgShifts);

--- a/include/lomse_vertical_profile.h
+++ b/include/lomse_vertical_profile.h
@@ -41,6 +41,8 @@ namespace lomse
 //forward declarations
 class GmoShape;
 class GmoBox;
+class AuxShapesAligner;
+class AuxShapesAlignersSystem;
 
 #define LOMSE_PAPER_LOWER_LIMIT   -100000000000000.0f  //any impossible low value
 #define LOMSE_PAPER_UPPER_LIMIT    100000000000000.0f  //any impossible high value
@@ -94,6 +96,8 @@ protected:
 	std::vector<PointsRow*> m_xMax;         //ptrs. to max x pos vector for each staff
 	std::vector<PointsRow*> m_xMin;         //ptrs. to min x pos vector for each staff
 
+    AuxShapesAlignersSystem* m_pCurrentAuxShapesAligner = nullptr;
+
 public:
     VerticalProfile(LUnits xStart, LUnits xEnd, int numStaves);
     virtual ~VerticalProfile();
@@ -119,6 +123,11 @@ public:
     */
     std::vector<UPoint> get_min_profile_points(LUnits xStart, LUnits xEnd, int idxStaff);
     std::vector<UPoint> get_max_profile_points(LUnits xStart, LUnits xEnd, int idxStaff);
+
+    //auxiliary shapes aligner
+    void set_current_aux_shapes_aligner(AuxShapesAlignersSystem* p) { m_pCurrentAuxShapesAligner = p; }
+    AuxShapesAlignersSystem* get_current_aux_shapes_aligner() { return m_pCurrentAuxShapesAligner; }
+    AuxShapesAligner* get_current_aux_shapes_aligner(int staff, bool fAbove);
 
     //debug
     void dbg_add_vertical_profile_shapes(GmoBox* pBoxSystem);

--- a/include/lomse_wedge_engraver.h
+++ b/include/lomse_wedge_engraver.h
@@ -66,6 +66,7 @@ protected:
     GmoShapeInvisible* m_pEndDirectionShape;
 
     UPoint m_points[4];    //points for wedge
+    LUnits m_yAlignBaseline; //baseline coordinate for aligning with dynamic marks
 
 public:
     WedgeEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
@@ -97,10 +98,13 @@ protected:
     GmoShape* create_intermediate_shape();
     GmoShape* create_final_shape();
 
+    void compute_shape_x_position(bool first);
     void compute_first_shape_position();
     void compute_intermediate_or_last_shape_position();
 
+    LUnits determine_default_shape_position_left(bool first) const;
     LUnits determine_shape_position_left(bool first) const;
+    LUnits determine_default_shape_position_right() const;
     LUnits determine_shape_position_right() const;
     LUnits determine_center_line_of_shape(LUnits startSpread, LUnits endSpread);
     //void add_user_displacements(int iWedge, UPoint* points);

--- a/src/graphic_model/engravers/lomse_volta_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_volta_engraver.cpp
@@ -143,6 +143,7 @@ GmoShape* VoltaBracketEngraver::create_intermediate_shape()
     set_shape_details(pShape, k_intermediate_shape);
     pShape->set_two_brackets();
 
+    add_to_aux_shapes_aligner(pShape, true);
     ++m_numShapes;
     return pShape;
 }
@@ -165,6 +166,7 @@ GmoShape* VoltaBracketEngraver::create_single_shape()
 
     set_shape_details(pShape, k_single_shape);
 
+    add_to_aux_shapes_aligner(pShape, true);
     m_numShapes++;
     return pShape;
 }
@@ -198,6 +200,7 @@ GmoShape* VoltaBracketEngraver::create_first_shape()
     set_shape_details(pShape, k_first_shape);
     pShape->set_two_brackets();
 
+    add_to_aux_shapes_aligner(pShape, true);
     m_numShapes++;
     return pShape;
 }
@@ -213,6 +216,7 @@ GmoShape* VoltaBracketEngraver::create_final_shape()
     set_shape_details(pShape, k_final_shape);
     pShape->set_two_brackets();
 
+    add_to_aux_shapes_aligner(pShape, true);
     m_numShapes++;
     return pShape;
 }

--- a/src/graphic_model/layouters/lomse_aux_shapes_aligner.cpp
+++ b/src/graphic_model/layouters/lomse_aux_shapes_aligner.cpp
@@ -1,0 +1,229 @@
+//---------------------------------------------------------------------------------------
+// This file is part of the Lomse library.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice, this
+//      list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright notice, this
+//      list of conditions and the following disclaimer in the documentation and/or
+//      other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+// SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// For any comment, suggestion or feature request, please contact the manager of
+// the project at cecilios@users.sourceforge.net
+//---------------------------------------------------------------------------------------
+
+#include "lomse_aux_shapes_aligner.h"
+
+#include "lomse_gm_basic.h"
+#include "lomse_vertical_profile.h"
+
+namespace lomse
+{
+
+//=======================================================================================
+// AuxShapesAligner implementation
+//=======================================================================================
+AuxShapesAligner::AuxShapesAligner(LUnits xAbsLeft, LUnits xAbsRight)
+    : m_xAbsLeft(xAbsLeft)
+    , m_xAbsRight(xAbsRight)
+{
+}
+
+//---------------------------------------------------------------------------------------
+void AuxShapesAligner::add_shape(GmoShape* pShape)
+{
+    const LUnits xLeft = pShape->get_left();
+    const LUnits xRight = pShape->get_right();
+
+    //erase intersecting shapes
+    auto it = m_shapes.upper_bound(xLeft);
+    while (it != m_shapes.end())
+    {
+        const GmoShape* pExistingShape = it->second;
+
+        if (pExistingShape->get_right() > xRight)
+        {
+            if (pExistingShape->get_left() < xRight)
+                m_shapes.erase(it);
+            break;
+        }
+
+        m_shapes.erase(it);
+        it = m_shapes.upper_bound(xLeft);
+    }
+
+    //add new shape
+    m_shapes.emplace(xRight, pShape);
+}
+
+//---------------------------------------------------------------------------------------
+void AuxShapesAligner::align_shape_base_lines(LUnits maxAlignDistance, VerticalProfile* pVProfile, int idxStaff, bool fDown)
+{
+    if (m_shapes.empty())
+        return;
+
+    auto itGroupBegin = m_shapes.begin();
+    LUnits yBaseline = itGroupBegin->second->get_baseline_y();
+    LUnits xPrev = itGroupBegin->second->get_right();
+
+    for (auto it = itGroupBegin; it != m_shapes.end(); ++it)
+    {
+        const GmoShape* pShape = it->second;
+        const LUnits yShapeBaseline = pShape->get_baseline_y();
+
+        if (pShape->get_left() - xPrev > maxAlignDistance)
+        {
+            set_base_line_for_range(itGroupBegin, it, yBaseline, pVProfile, idxStaff);
+            itGroupBegin = it;
+            yBaseline = yShapeBaseline;
+        }
+        else if (fDown)
+        {
+            if (yShapeBaseline > yBaseline)
+                yBaseline = yShapeBaseline;
+        }
+        else
+        {
+            if (yShapeBaseline < yBaseline)
+                yBaseline = yShapeBaseline;
+        }
+
+        xPrev = pShape->get_right();
+    }
+
+    //align the last group
+    set_base_line_for_range(itGroupBegin, m_shapes.end(), yBaseline, pVProfile, idxStaff);
+}
+
+//---------------------------------------------------------------------------------------
+void AuxShapesAligner::set_base_line_for_range(ShapeIterator rangeBegin, ShapeIterator rangeEnd,
+                                              LUnits yBaseline, VerticalProfile* pVProfile, int idxStaff)
+{
+    for (auto it = rangeBegin; it != rangeEnd; ++it)
+    {
+        GmoShape* pShape = it->second;
+        const LUnits yShift = yBaseline - pShape->get_baseline_y();
+
+        if (yShift)
+        {
+            pShape->shift_origin(USize(0, yShift));
+            pVProfile->update(pShape, idxStaff);
+        }
+    }
+}
+
+//---------------------------------------------------------------------------------------
+GmoShape* AuxShapesAligner::find_shape(LUnits x) const
+{
+    auto it = m_shapes.upper_bound(x);
+
+    if (it != m_shapes.end())
+    {
+        GmoShape* pShape = it->second;
+
+        if (pShape->get_left() <= x)
+            return pShape;
+    }
+
+    return nullptr;
+}
+
+//---------------------------------------------------------------------------------------
+LUnits AuxShapesAligner::find_nearest_free_point_left(LUnits x) const
+{
+    auto it = m_shapes.upper_bound(x);
+
+    if (it != m_shapes.end())
+    {
+        const GmoShape* pShape = it->second;
+
+        if (pShape->get_left() <= x)
+            return pShape->get_left();
+    }
+
+    return x;
+}
+
+//---------------------------------------------------------------------------------------
+LUnits AuxShapesAligner::find_nearest_free_point_right(LUnits x) const
+{
+    auto it = m_shapes.upper_bound(x);
+
+    if (it != m_shapes.end())
+    {
+        const GmoShape* pShape = it->second;
+
+        if (pShape->get_left() <= x)
+            return pShape->get_right();
+    }
+
+    return x;
+}
+
+//---------------------------------------------------------------------------------------
+LUnits AuxShapesAligner::find_nearest_occupied_point_left(LUnits x) const
+{
+    auto it = m_shapes.upper_bound(x);
+
+    if (it != m_shapes.end() && it->second->get_left() <= x)
+        return x;
+
+    if (it == m_shapes.begin())
+        return m_xAbsLeft;
+
+    --it;
+    return it->first;
+}
+
+//---------------------------------------------------------------------------------------
+LUnits AuxShapesAligner::find_nearest_occupied_point_right(LUnits x) const
+{
+    auto it = m_shapes.upper_bound(x);
+
+    if (it != m_shapes.end() && x <= it->second->get_left())
+        return it->second->get_left();
+
+    return x;
+}
+
+//=======================================================================================
+// AuxShapesAlignersSystem implementation
+//=======================================================================================
+AuxShapesAlignersSystem::AuxShapesAlignersSystem(size_t numStaves, LUnits xAbsLeft, LUnits xAbsRight,
+                                             LUnits maxAlignDistance)
+    : m_alignersAbove(numStaves, { xAbsLeft, xAbsRight })
+    , m_alignersBelow(numStaves, { xAbsLeft, xAbsRight })
+    , m_maxAlignDistance(maxAlignDistance)
+{
+}
+
+//---------------------------------------------------------------------------------------
+void AuxShapesAlignersSystem::align_shape_base_lines(VerticalProfile* pVProfile)
+{
+    for (size_t i = 0; i < m_alignersAbove.size(); ++i)
+    {
+        m_alignersAbove[i].align_shape_base_lines(m_maxAlignDistance, pVProfile, i, false);
+    }
+
+    for (size_t i = 0; i < m_alignersBelow.size(); ++i)
+    {
+        m_alignersBelow[i].align_shape_base_lines(m_maxAlignDistance, pVProfile, i, true);
+    }
+}
+
+}  //namespace lomse

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -1212,7 +1212,8 @@ GmoShape* ShapesCreator::create_auxobj_shape(ImoAuxObj* pAO, int iInstr, int iSt
         case k_imo_dynamics_mark:
         {
             ImoDynamicsMark* pImo = static_cast<ImoDynamicsMark*>(pAO);
-            DynamicsMarkEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr, iStaff);
+            DynamicsMarkEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr, iStaff,
+                                       idxStaff, pVProfile);
             Color color = pImo->get_color();
             return engrv.create_shape(pImo, pos, color, pParentShape);
         }

--- a/src/graphic_model/layouters/lomse_vertical_profile.cpp
+++ b/src/graphic_model/layouters/lomse_vertical_profile.cpp
@@ -30,6 +30,7 @@
 #include "lomse_vertical_profile.h"
 
 #include "lomse_gm_basic.h"
+#include "lomse_aux_shapes_aligner.h"
 
 //for generating a debug shape
 #include "lomse_shapes.h"
@@ -480,5 +481,10 @@ vector<UPoint> VerticalProfile::get_max_profile_points(LUnits xStart, LUnits xEn
     return dataPoints;
 }
 
+//---------------------------------------------------------------------------------------
+AuxShapesAligner* VerticalProfile::get_current_aux_shapes_aligner(int staff, bool fAbove)
+{
+    return m_pCurrentAuxShapesAligner ? &m_pCurrentAuxShapesAligner->get_aligner(staff, fAbove) : nullptr;
+}
 
 }  //namespace lomse

--- a/src/graphic_model/lomse_shape_wedge.cpp
+++ b/src/graphic_model/lomse_shape_wedge.cpp
@@ -44,13 +44,15 @@ namespace lomse
 // GmoShapeWedge implementation
 //=======================================================================================
 GmoShapeWedge::GmoShapeWedge(ImoObj* pCreatorImo, ShapeId idx, UPoint points[],
-                             LUnits thickness, Color color, int niente, LUnits radius)
+                             LUnits thickness, Color color, int niente, LUnits radius,
+                             LUnits yBaseline)
     : GmoSimpleShape(pCreatorImo, GmoObj::k_shape_wedge, idx, color)
     , m_thickness(thickness)
     , m_niente(niente)
     , m_radiusNiente(radius)
 {
     save_points_and_compute_bounds(points);
+    m_yBaseline = yBaseline - m_origin.y;
 }
 
 //---------------------------------------------------------------------------------------
@@ -103,6 +105,12 @@ void GmoShapeWedge::on_draw(Drawer* pDrawer, RenderOptions& opt)
     pDrawer->render();
 
     GmoSimpleShape::on_draw(pDrawer, opt);
+}
+
+//---------------------------------------------------------------------------------------
+LUnits GmoShapeWedge::get_baseline_y() const
+{
+    return m_origin.y + m_yBaseline;
 }
 
 //---------------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request implements a mechanism to align auxiliary object with respect to each other, both horizontally and vertically. The implementation proposed here involves an introduction of a "horizontal layer" concept which basically means a set of objects which should be aligned with respect to each other if they are placed close enough. This concept is implemented by the `HorizontalLayer` and related classes, also the engraving order table was restructured to include the information about horizontal layers. There is one layer per placement per staff for each system (that is, shapes placed below and above staff are aligned separately). The information on shape placement doesn't seem to be readily available at the `SystemLayouter` level, so it is currently a responsibility of engravers to put their shapes to relevant horizontal layers.

Horizontal layers provide an information about objects already added to them (which is useful for engravers) and align sequences of shapes which are close to each other by a common baseline.

Currently engravers can access horizontal layers via `VerticalProfile` which is something I am not really sure about. On the one side these are separate concepts, but on the other side they both serve the purpose of improving placement of shapes with respect to other score objects, and it seems that every engraver which would need a `HorizontalLayer` would also really need a `VerticalProfile` as well. So for now I have included a pointer to the current horizontal layer system into `VerticalProfile` class to avoid explicitly passing another argument to engravers. This can certainly be changed though.

This alignment was applied to volta brackets and to wedge-dynamic combinations. Wedges are aligned both horizontally and vertically with other shapes so if a dynamic mark is placed at the same position where a wedge starts the wedge is no longer pushed away from the staff:
![satie](https://user-images.githubusercontent.com/6000747/132096926-1e947d04-bd83-428f-836b-8a1be3f10a93.png)

The alignment effect is limited by a distance of the aligned objects (for volta brackets the limit is infinite), so something like this will not be forcefully aligned by the horizontal layer:
![noalign](https://user-images.githubusercontent.com/6000747/132096988-848c7d28-1a69-463a-8bc3-2f21baaad965.png)

Also MusicXML scores may contain dynamic marks which are invisible in the original score but are not marked so in the MusicXML file due to a lack of `print-object` attribute for `direction` objects. In this PR newer shapes added to a horizontal layer exclude the existing overlapping shapes from the further alignment algorithm which allows to handle such situations more or less gracefully:
![invisible-dynamics](https://user-images.githubusercontent.com/6000747/132097140-f27d3e23-e726-4347-bab6-ca571e91dffa.png)

In addition to the relative object alignment this PR also includes the following changes:
 - Moves dynamic marks right before wedges in the engraving order. This is necessary to be able to properly align them as described above.
 - Adds shifting a dynamic mark shape with respect to the system's vertical profile. This is not exactly necessary for anything else in this pull request, still it helps to avoid collisions of dynamic marks with beams.