### PR TITLE
Enforce a minimum distance between systems

### DIFF
--- a/include/lomse_box_slice.h
+++ b/include/lomse_box_slice.h
@@ -65,8 +65,10 @@ public:
                                       const std::vector<LUnits>& heights,
                                       const std::vector<LUnits>& barlinesHeight,
                                       const std::vector<std::vector<LUnits>>& relStaffTopPositions,
+                                      LUnits bottomMarginIncr,
                                       SystemLayouter* pSysLayouter);
     GmoBoxSliceStaff* get_slice_staff_for(int iInstr, int iStaff);
+    void reduce_last_instrument_height(LUnits space);
 
 };
 

--- a/include/lomse_box_system.h
+++ b/include/lomse_box_system.h
@@ -61,16 +61,28 @@ protected:
     vector<int> m_nMeasures;        //number of measures in this system, per instrument
     LUnits m_dxFirstMeasure;        //shift from box left (virtual end barline of previous measure)
 
+    //free vertical space at top and bottom
+    LUnits m_uFreeAtTop = 0.0f;
+    LUnits m_uFreeAtBottom = 0.0f;
+
 public:
     GmoBoxSystem(ImoScore* pScore);
     ~GmoBoxSystem();
 
     //helpers for layout
+    inline void set_top_limit(LUnits minLimit) { m_uFreeAtTop = minLimit - get_top(); }
+    inline void set_bottom_limit(LUnits maxLimit) { m_uFreeAtBottom = get_bottom() - maxLimit; }
+    inline LUnits get_free_space_at_top() { return m_uFreeAtTop; }
+    inline LUnits get_free_space_at_bottom() { return m_uFreeAtBottom; }
+    inline void set_free_space_at_top(LUnits space) { m_uFreeAtTop = space; }
+    inline void set_free_space_at_bottom(LUnits space) { m_uFreeAtBottom = space; }
+
     /**  Move boxes and shapes to theirs final 'y' positions. */
     void reposition_slices_and_shapes(const std::vector<LUnits>& yOrgShifts,
                                       const std::vector<LUnits>& heights,
                                       const std::vector<LUnits>& barlinesHeight,
                                       const std::vector<std::vector<LUnits>>& relStaffTopPositions,
+                                      LUnits bottomMarginIncr,
                                       SystemLayouter* pSysLayouter);
 
     //slices
@@ -78,6 +90,8 @@ public:
     inline GmoBoxSlice* get_slice(int i) const { return (GmoBoxSlice*)m_childBoxes[i]; }
     GmoBoxSliceInstr* get_first_instr_slice(int iInstr);
     GmoBoxSliceStaff* get_first_slice_staff_for(int iInstr, int iStaff);
+    void reposition_slices(USize shift);
+    void remove_free_space_at_bottom_and_adjust_slices();
 
     //grid table: xPositions/timepos
     inline void set_time_grid_table(TimeGridTable* pGridTable) { m_pGridTable = pGridTable; }
@@ -139,6 +153,8 @@ protected:
     friend class GmoBoxScorePage;
     inline void set_system_number(int iSystem) { m_iSystem = iSystem; }
 
+    //overrides
+    void draw_box_bounds(Drawer* pDrawer, double xorg, double yorg, Color& color) override;
 
 };
 

--- a/include/lomse_engraving_options.h
+++ b/include/lomse_engraving_options.h
@@ -38,11 +38,15 @@ namespace lomse
 //---------------------------------------------------------------------------------------
 
 //Staff
+//---------------------------------------------------------------------------------------
 //Default values for instantiating scores when defaults are used.
 //**DO NOT** use these constants for other purposes. For engravers, take values from ImoScore.
 #define LOMSE_STAFF_LINE_THICKNESS      15.0f   // line thickness. LUnits: 0.15 millimeters
 #define LOMSE_STAFF_LINE_SPACING       180.0f   // LUnits: 1.8 mm (staff height = 7.2 mm)
 #define LOMSE_STAFF_TOP_MARGIN        1000.0f   // LUnits: 10 millimeters
+//** END of restricted values, only for instantiating scores
+//---------------------------------------------------------------------------------------
+
 
 //Barlines
 #define LOMSE_THIN_LINE_WIDTH            1.5f   // thin line width
@@ -77,8 +81,6 @@ namespace lomse
 #define LOMSE_LEGER_LINE_OUTGOING        5.0f
 #define LOMSE_GRACE_NOTES_SCALE          0.60f  //Scaling factor for grace notes size
 #define LOMSE_CUE_NOTES_SCALE            0.75f  //Scaling factor for cue notes size
-#define LOMSE_ARPEGGIO_SPACE_TO_CHORD    6.0f   //Spacing between an arpeggio and a chord
-#define LOMSE_ARPEGGIO_MAX_OUTGOING      3.0f   //Amount of space arpeggio is allowed to go beyond a chord's top or bottom note
 #define LOMSE_SHIFT_WHEN_NOTEHEADS_OVERLAP  3.0f   //Offset for notehead when collision with other voice notehead
 
 //System layouter
@@ -94,9 +96,9 @@ namespace lomse
 #define LOMSE_PROLOG_GAP_BEORE_KEY      10.0f
 #define LOMSE_PROLOG_GAP_BEFORE_TIME    10.0f
 #define LOMSE_SPACE_AFTER_PROLOG        15.0f
-    //staves distance
-#define LOMSE_MIN_SPACING_STAVES        15.0f   //Min. vertical space bitween staves
-
+    //staves/systems distances
+#define LOMSE_MIN_SPACING_STAVES        15.0f   //Min. vertical space between staves
+#define LOMSE_MIN_SPACING_SYSTEMS       30.0f   //Min. vertical space between systems
 
 //tuplets
 #define LOMSE_TUPLET_BORDER_LENGHT      10.0f
@@ -135,6 +137,10 @@ namespace lomse
 //lyrics
 #define LOMSE_LYRICS_SPACE_TO_MUSIC     12.0f //space between first lyric line and other music notation
 #define LOMSE_LYRICS_LINES_EXTRA_SPACE   3.0f //additional space between two lyric lines
+
+//arpeggios
+#define LOMSE_ARPEGGIO_SPACE_TO_CHORD    6.0f   //Spacing between an arpeggio and a chord
+#define LOMSE_ARPEGGIO_MAX_OUTGOING      3.0f   //Amount of space arpeggio is allowed to go beyond a chord's top or bottom note
 
 //playback
 #define LOMSE_STEAL_TIME_SHORT          20.0f //"Playback/Percentage of time to steal for acciaccatura grace notes"

--- a/include/lomse_gm_basic.h
+++ b/include/lomse_gm_basic.h
@@ -487,7 +487,7 @@ protected:
     void draw_border(Drawer* pDrawer, RenderOptions& opt);
     bool must_draw_bounds(RenderOptions& opt);
     Color get_box_color();
-    void draw_box_bounds(Drawer* pDrawer, double xorg, double yorg, Color& color);
+    virtual void draw_box_bounds(Drawer* pDrawer, double xorg, double yorg, Color& color);
     void draw_shapes(Drawer* pDrawer, RenderOptions& opt);
     void add_shapes_to_tables_in(GmoBoxDocPage* pPage);
 

--- a/include/lomse_score_layouter.h
+++ b/include/lomse_score_layouter.h
@@ -175,6 +175,7 @@ protected:
     ScoreStub*          m_pStub;
     GmoBoxScorePage*    m_pCurBoxPage;
     GmoBoxSystem*       m_pCurBoxSystem;
+    GmoBoxSystem*       m_pPrevBoxSystem = nullptr;
 
     //support for debug and unit test
     int                 m_iColumnToTrace;

--- a/include/lomse_system_layouter.h
+++ b/include/lomse_system_layouter.h
@@ -119,7 +119,8 @@ public:
     ~SystemLayouter();
 
     GmoBoxSystem* create_system_box(LUnits left, LUnits top, LUnits width, LUnits height);
-    void engrave_system(LUnits indent, int iFirstCol, int iLastCol, UPoint pos);
+    void engrave_system(LUnits indent, int iFirstCol, int iLastCol, UPoint pos,
+                        GmoBoxSystem* pPrevBoxSystem);
     void on_origin_shift(LUnits yShift);
     inline void set_constrains(int constrains) { m_constrains = constrains; }
 
@@ -160,10 +161,11 @@ protected:
     void engrave_system_details(int iSystem);
     void setup_aux_shapes_aligner(EAuxShapesAlignmentScope scope, Tenths maxAlignDistance = 0.0f);
     void add_instruments_info();
-    void move_staves_to_avoid_collisions();
+    void move_staves_to_avoid_collisions(GmoBoxSystem* pPrevBoxSystem);
     void reposition_staves_in_engravers(const std::vector<LUnits>& yOrgShifts);
     void reposition_slice_boxes_and_shapes(const vector<LUnits>& yOrgShifts,
-                                           vector<LUnits>& heights);
+                                           vector<LUnits>& heights,
+                                           LUnits bottomMarginIncr);
 
     void add_prolog_shapes_to_boxes();
     void add_system_prolog_if_necessary();

--- a/src/graphic_model/lomse_box_slice.cpp
+++ b/src/graphic_model/lomse_box_slice.cpp
@@ -68,6 +68,7 @@ void GmoBoxSlice::reposition_slices_and_shapes(const vector<LUnits>& yOrgShifts,
                                                const vector<LUnits>& heights,
                                                const vector<LUnits>& barlinesHeight,
                                                const vector<vector<LUnits>>& relStaffTopPositions,
+                                               LUnits bottomMarginIncr,
                                                SystemLayouter* pSysLayouter)
 
 {
@@ -81,9 +82,19 @@ void GmoBoxSlice::reposition_slices_and_shapes(const vector<LUnits>& yOrgShifts,
                                              pSysLayouter);
     }
 
-    //shift origin and increase height
-    m_origin.y += yOrgShifts[0];
-    m_size.height += yOrgShifts.back() + heights[0];
+    //increase height
+    m_size.height += (yOrgShifts.back() + bottomMarginIncr);
+}
+
+//---------------------------------------------------------------------------------------
+void GmoBoxSlice::reduce_last_instrument_height(LUnits space)
+{
+    //reduce height of this slice
+    m_size.height -= space;
+
+    //reduce height of last instrument slice
+    GmoBoxSliceInstr* pSlice = static_cast<GmoBoxSliceInstr*>(m_childBoxes.back());
+    pSlice->set_height( pSlice->get_height() - space );
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/lomse_box_slice_instr.cpp
+++ b/src/graphic_model/lomse_box_slice_instr.cpp
@@ -91,11 +91,12 @@ void GmoBoxSliceInstr::reposition_slices_and_shapes(const vector<LUnits>& yOrgSh
         GmoBoxSliceStaff* pSlice = static_cast<GmoBoxSliceStaff*>(*it);
         pSlice->reposition_shapes(yOrgShifts, barlinesHeight, relStaffTopPositions, pSysLayouter, staff);
 
-        m_size.height += heights[idxStaff];
+        m_size.height += heights[idxStaff+staff];
     }
 
     //shift origin
-    m_origin.y += yOrgShifts[m_idxStaff];
+    if (m_idxStaff > 0)
+        m_origin.y += yOrgShifts[m_idxStaff-1];
 }
 
 //---------------------------------------------------------------------------------------
@@ -127,6 +128,7 @@ void GmoBoxSliceStaff::reposition_shapes(const vector<LUnits>& yShifts,
 
 {
     LUnits yShift = yShifts[m_idxStaff];
+    LUnits yPrevShift = (m_idxStaff > 0 ? yShifts[m_idxStaff-1] : 0.0f);
 
     if (yShift == 0.0f)
     {
@@ -155,8 +157,8 @@ void GmoBoxSliceStaff::reposition_shapes(const vector<LUnits>& yShifts,
                 {
 //                    if (!pShapeBeam->has_chords())
 //                    {
-                        LUnits down = (yShift + yShifts[m_idxStaff-1]) / 2.0f;
-                        LUnits increment = (yShift - yShifts[m_idxStaff-1]) / 2.0f;
+                        LUnits down = (yShift + yPrevShift) / 2.0f;
+                        LUnits increment = (yShift - yPrevShift) / 2.0f;
                         pSysLayouter->increment_cross_staff_stems(pShapeBeam, increment);
                         (*it)->reposition_shape(down);
 //                    }
@@ -169,7 +171,7 @@ void GmoBoxSliceStaff::reposition_shapes(const vector<LUnits>& yShifts,
             else if ((*it)->is_shape_note())
             {
                 GmoShapeNote* pShapeNote = static_cast<GmoShapeNote*>(*it);
-                LUnits increment = (yShift - yShifts[m_idxStaff-1]);
+                LUnits increment = (yShift - yPrevShift);
                 pShapeNote->reposition_shape(yShift);
 
                 if (pShapeNote->is_cross_staff_chord())


### PR DESCRIPTION
This PR improves vertical spacing between systems by enforcing a minimal distance between them. In current Lomse code this is not checked and the distance can be minimal or even systems can overlap. For instance, in current rendition of score
[MahlFaGe4Sample.musicxml.txt](https://github.com/lenmus/lomse/files/7186909/MahlFaGe4Sample.musicxml.txt) , in third system the wedges are touching previous system:


![image](https://user-images.githubusercontent.com/5238679/133818807-991ca81e-bf95-4479-aec3-f2218336ed48.png)


The following image displays the result, after applying this PR:


![image](https://user-images.githubusercontent.com/5238679/133818851-bb0bac86-ae80-40c0-a2ab-3a15bbc35ab9.png)


This PR does not increment systems distance in other cases, it only ensures that a minimal distance always exists. It also includes the following related changes:

- Information about free space at top and bottom of a system is now available in its `GmoBoxSystem` object, as it is required for checking the space between two systems.

- This information is now also used in `ScoreLayouter::enough_space_in_page_for_system()` for page space optimization. Now, if a system is too high to fit in the page remaining space, Lomse checks if it could fit if bottom space is removed and, in that case, space is removed and the system is included in current page instead of in a new page.

- This PR also ensures a minimum distance between staves. Until now a minimum space was added only to avoid overlaps but not if the space was lower than the minimum required.
