### PR TITLE
Display naturals on a key change to Cmaj/Amin

### DIFF
--- a/include/lomse_engraving_options.h
+++ b/include/lomse_engraving_options.h
@@ -78,6 +78,7 @@ namespace lomse
 #define LOMSE_SPACE_BEFORE_DOT           5.0f
 #define LOMSE_SPACE_AFTER_ACCIDENTALS    1.5f
 #define LOMSE_SPACE_BETWEEN_ACCIDENTALS  1.5f
+#define LOMSE_SPACE_BETWEEN_KEY_NATURALS 2.0f
 #define LOMSE_LEGER_LINE_OUTGOING        5.0f
 #define LOMSE_GRACE_NOTES_SCALE          0.60f  //Scaling factor for grace notes size
 #define LOMSE_CUE_NOTES_SCALE            0.75f  //Scaling factor for cue notes size

--- a/include/lomse_key_engraver.h
+++ b/include/lomse_key_engraver.h
@@ -42,6 +42,7 @@ class ImoKeySignature;
 class GmoShape;
 class GmoShapeKeySignature;
 class ScoreMeter;
+class StaffObjsCursor;
 
 //---------------------------------------------------------------------------------------
 class KeyEngraver : public Engraver
@@ -60,6 +61,7 @@ public:
     ~KeyEngraver() {}
 
     GmoShape* create_shape(ImoKeySignature* pKey, int clefType, UPoint uPos,
+                           StaffObjsCursor* pCursor,
                            Color color=Color(0,0,0));
 
 protected:

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -1141,7 +1141,7 @@ GmoShape* ShapesCreator::create_staffobj_shape(ImoStaffObj* pSO, int iInstr, int
             ImoKeySignature* pImo = static_cast<ImoKeySignature*>(pSO);
             KeyEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr, iStaff);
             Color color = pImo->get_color();
-            return engrv.create_shape(pImo, clefType, pos, color);
+            return engrv.create_shape(pImo, clefType, pos, pCursor, color);
         }
         case k_imo_note_regular:
         case k_imo_note_grace:

--- a/src/graphic_model/layouters/lomse_spacing_algorithm.cpp
+++ b/src/graphic_model/layouters/lomse_spacing_algorithm.cpp
@@ -378,7 +378,7 @@ void ColumnsBuilder::collect_content_for_this_column()
                 bool fInProlog = determine_if_is_in_prolog(pSO, rTime, iInstr, idx);
                 int clefType = m_pSysCursor->get_applicable_clef_type();
                 pShape = m_pShapesCreator->create_staffobj_shape(pSO, iInstr, iStaff,
-                         pagePos, clefType, 0, flags);
+                         pagePos, clefType, 0, flags, m_pSysCursor);
                 pShape->assign_id_as_main_or_implicit_shape(iStaff);
                 m_pSpAlgorithm->include_object(m_pSysCursor->cur_entry(), m_iColumn,
                                                iInstr, iStaff, pSO, pShape, fInProlog);


### PR DESCRIPTION
Currently Lomse doesn't display anything on a key change if the new key doesn't have any accidentals. This makes it impossible for a performer to figure out that a key change has happened (example score: [key-change-naturals.musicxml.txt](https://github.com/lenmus/lomse/files/7192164/key-change-naturals.musicxml.txt)):
![Screenshot_20210919_163106](https://user-images.githubusercontent.com/6000747/133929439-39479a0e-7691-4440-89df-8f987986e3d1.png)

In such cases naturals are commonly displayed to inform a performer about a key change. This PR implements this way of displaying such key changes:
![Screenshot_20210919_163037](https://user-images.githubusercontent.com/6000747/133929465-6f7d991a-634e-4dc8-a460-0008e193e44d.png)

Some extra spacing between naturals was also required to avoid naturals in a key signature being visually glued together, so that was also added to the key engraver. 