### PR TITLE
Fix reading compressed MusicXML files encoded in UTF-16

### DIFF
--- a/include/lomse_compressed_mxl_compiler.h
+++ b/include/lomse_compressed_mxl_compiler.h
@@ -59,7 +59,7 @@ public:
 
 protected:
     std::string get_rootfile_path(ZipInputStream&);
-    std::string read_rootfile(ZipInputStream&);
+    std::vector<unsigned char> read_rootfile(ZipInputStream&);
 };
 
 

--- a/include/lomse_mxl_compiler.h
+++ b/include/lomse_mxl_compiler.h
@@ -64,6 +64,7 @@ public:
     //compilation
     ImoDocument* compile_file(const std::string& filename) override;
     ImoDocument* compile_string(const std::string& source) override;
+    ImoDocument* compile_buffer(const void* buffer, size_t size);
 
 protected:
     ImoDocument* compile_parsed_tree(XmlNode* root);

--- a/include/lomse_xml_parser.h
+++ b/include/lomse_xml_parser.h
@@ -129,6 +129,7 @@ public:
     void parse_file(const std::string& filename, bool fErrorMsg = true) override;
     void parse_text(const std::string& sourceText) override;
     void parse_cstring(char* sourceText);
+    void parse_buffer(const void* buffer, size_t size);
 
     inline const string& get_error() { return m_errorMsg; }
     inline const string& get_encoding() { return m_encoding; }

--- a/src/parser/lomse_xml_parser.cpp
+++ b/src/parser/lomse_xml_parser.cpp
@@ -193,6 +193,27 @@ void XmlParser::parse_char_string(char* str)
 }
 
 //---------------------------------------------------------------------------------------
+void XmlParser::parse_buffer(const void* buffer, size_t size)
+{
+    m_fOffsetDataReady = false;
+    m_filename.clear();
+    pugi::xml_parse_result result = m_doc.load_buffer(buffer, size,
+                                                      (pugi::parse_default |
+                                                       //pugi::parse_trim_pcdata |
+                                                       //pugi::parse_wnorm_attribute |
+                                                       pugi::parse_declaration)
+                                                     );
+
+    if (!result)
+    {
+        m_errorMsg = string(result.description());
+        m_errorOffset = int(result.offset);
+        m_reporter << "Pos: " << m_errorOffset << ". Error: " << m_errorMsg << endl;
+    }
+    find_root();
+}
+
+//---------------------------------------------------------------------------------------
 void XmlParser::find_root()
 {
     pugi::xml_node root = m_doc.first_child();

--- a/src/parser/mxl/lomse_mxl_compiler.cpp
+++ b/src/parser/mxl/lomse_mxl_compiler.cpp
@@ -118,6 +118,14 @@ ImoDocument* MxlCompiler::compile_string(const std::string& source)
 }
 
 //---------------------------------------------------------------------------------------
+ImoDocument* MxlCompiler::compile_buffer(const void* buffer, size_t size)
+{
+    m_fileLocator = "string:";
+    m_pXmlParser->parse_buffer(buffer, size);
+    return compile_parsed_tree( m_pXmlParser->get_tree_root() );
+}
+
+//---------------------------------------------------------------------------------------
 ImoDocument* MxlCompiler::compile_parsed_tree(XmlNode* root)
 {
     ImoDocument* pDoc = dynamic_cast<ImoDocument*>(


### PR DESCRIPTION
This PR fixes an issue with reading some compressed MusicXML files. Two example files are `MozaChloSample` and `MozaVeilSample` from this [example set](https://www.musicxml.com/music-in-musicxml/example-set) (these files also seem to be available in the [regression test](https://github.com/lenmus/vregress/tree/master/scores/recordare) repository). Uncompressed versions of these files are opened fine but compressed `.mxl` files cannot be loaded by Lomse.

The reason of the issue is that the implementation in #246 loads unzipped XML code via `MxlCompiler::compile_string()` function which internally calls [`load_string()`](https://github.com/dmitrio95/lomse/blob/5d6f53594a62418f7c47936043a420a237e93367/src/parser/lomse_xml_parser.cpp#L180) function from pugixml which assumes the string is already encoded in UTF-8. However the example scores listed above use UTF-16 encoding which is incompatible with UTF-8. File loading functions in pugixml do not assume any encoding by default and perform encoding detection which is why the uncompressed versions of the example scores are loaded correctly.

The issue can be fixed by using pugixml's [`load_buffer()`](https://github.com/lenmus/lomse/blob/8b74da7d51f110614824cad06a70ea28d4d179c9/packages/pugixml/pugixml.hpp#L1043-L1044) which takes an in-memory buffer as input and doesn't skip encoding detection. This solution is implemented in this pull request. After this patch any encoding supported by pugixml should work fine with both compressed and uncompressed MusicXML files.