### PR TITLE
MusicXML: Import <defaults> element

### DIFF
--- a/include/lomse_document.h
+++ b/include/lomse_document.h
@@ -88,18 +88,29 @@ public:
     float page_content_scale() const;
     void set_page_content_scale(float scale);
 
-    //Document page size
-    LUnits page_left_margin() const;
-    LUnits page_right_margin() const;
-    LUnits page_top_margin() const;
-    LUnits page_bottom_margin() const;
+    //Document page size and margins
+        //odd pages
+    LUnits page_left_margin_odd() const;
+    LUnits page_right_margin_odd() const;
+    LUnits page_top_margin_odd() const;
+    LUnits page_bottom_margin_odd() const;
+    void set_page_left_margin_odd(LUnits value);
+    void set_page_right_margin_odd(LUnits value);
+    void set_page_top_margin_odd(LUnits value);
+    void set_page_bottom_margin_odd(LUnits value);
+        //even pages
+    LUnits page_left_margin_even() const;
+    LUnits page_right_margin_even() const;
+    LUnits page_top_margin_even() const;
+    LUnits page_bottom_margin_even() const;
+    void set_page_left_margin_even(LUnits value);
+    void set_page_right_margin_even(LUnits value);
+    void set_page_top_margin_even(LUnits value);
+    void set_page_bottom_margin_even(LUnits value);
+
     USize page_size() const;
     LUnits page_width() const;
     LUnits page_height() const;
-    void set_page_left_margin(LUnits value);
-    void set_page_right_margin(LUnits value);
-    void set_page_top_margin(LUnits value);
-    void set_page_bottom_margin(LUnits value);
     void set_page_size(USize uPageSize);
     void set_page_width(LUnits value);
     void set_page_height(LUnits value);

--- a/include/lomse_mxl_analyser.h
+++ b/include/lomse_mxl_analyser.h
@@ -228,20 +228,6 @@ public:
 };
 
 //---------------------------------------------------------------------------------------
-// helper struct to store information for a font
-struct FontData
-{
-    std::string family;     //a comma-separated list of font names
-    std::string style;      //can be normal or italic
-    std::string size;       //one of the CSS sizes (xx-small, x-small, small, medium,
-                            //   large, x-large, xx-large) or a numeric point size
-    std::string weight;     //can be normal or bold
-    std::string language;   //language tags, as defined in RFC 3066 (e.g. "en-GB")
-
-    FontData() {}
-};
-
-//---------------------------------------------------------------------------------------
 //MxlAnalyser: responsible for parsing a tree of MusicXML nodes
 //             and building an internal model for it.
 class MxlAnalyser : public Analyser

--- a/include/lomse_mxl_analyser.h
+++ b/include/lomse_mxl_analyser.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -37,8 +37,6 @@
 #include "lomse_relation_builder.h"
 #include "lomse_internal_model.h"       //required to define MxlBeamsBuilder, MxlSlursBuilder
 #include "lomse_im_note.h"              //required for enum EAccidentals
-
-using namespace std;
 
 namespace lomse
 {
@@ -172,9 +170,9 @@ public:
 class PartList
 {
 protected:
-    vector<ImoInstrument*> m_instruments;
-    vector<bool> m_partAdded;
-    map<string, int> m_locators;
+    std::vector<ImoInstrument*> m_instruments;
+    std::vector<bool> m_partAdded;
+    std::map<std::string, int> m_locators;
     int m_numInstrs;
     bool m_fInstrumentsAdded;
 
@@ -183,9 +181,9 @@ public:
     ~PartList();
 
     int get_num_items() { return static_cast<int>(m_locators.size()); }
-    int add_score_part(const string& id, ImoInstrument* pInstrument);
-    ImoInstrument* get_instrument(const string& id);
-    bool mark_part_as_added(const string& id);
+    int add_score_part(const std::string& id, ImoInstrument* pInstrument);
+    ImoInstrument* get_instrument(const std::string& id);
+    bool mark_part_as_added(const std::string& id);
     void add_all_instruments(ImoScore* pScore);
     void check_if_missing_parts(ostream& reporter);
 
@@ -193,7 +191,7 @@ public:
     void do_not_delete_instruments_in_destructor() { m_fInstrumentsAdded = true; }
 
 protected:
-    int find_index_for(const string& id);
+    int find_index_for(const std::string& id);
 
 };
 
@@ -202,7 +200,7 @@ protected:
 class PartGroups
 {
 protected:
-    map<int, ImoInstrGroup*> m_groups;
+    std::map<int, ImoInstrGroup*> m_groups;
 
 //    int m_number;
 //    int m_symbol;
@@ -212,10 +210,10 @@ public:
     PartGroups();
     ~PartGroups();
 
-//    void set_name(const string& name);
-//    void set_name_display(const string& name);
-//    void set_abbreviation(const string& abbrev);
-//    void set_abbreviation_display(const string& abbrev);
+//    void set_name(const std::string& name);
+//    void set_name_display(const std::string& name);
+//    void set_abbreviation(const std::string& abbrev);
+//    void set_abbreviation_display(const std::string& abbrev);
 //    void set_number(int num);
 //    void set_symbol(int symbol);
 //    void set_barline(bool value);
@@ -229,7 +227,19 @@ public:
 
 };
 
+//---------------------------------------------------------------------------------------
+// helper struct to store information for a font
+struct FontData
+{
+    std::string family;     //a comma-separated list of font names
+    std::string style;      //can be normal or italic
+    std::string size;       //one of the CSS sizes (xx-small, x-small, small, medium,
+                            //   large, x-large, xx-large) or a numeric point size
+    std::string weight;     //can be normal or bold
+    std::string language;   //language tags, as defined in RFC 3066 (e.g. "en-GB")
 
+    FontData() {}
+};
 
 //---------------------------------------------------------------------------------------
 //MxlAnalyser: responsible for parsing a tree of MusicXML nodes
@@ -249,30 +259,31 @@ protected:
     MxlSlursBuilder*    m_pSlursBuilder;
     MxlVoltasBuilder*   m_pVoltasBuilder;
     MxlWedgesBuilder*   m_pWedgesBuilder;
-    MxlOctaveShiftBuilder*  m_pOctaveShiftBuilder;
-    vector<ImoDynamicsMark*> m_pendingDynamicsMarks;
-    map<string, int>    m_lyricIndex;
-    vector<ImoLyric*>   m_lyrics;
-    map<string, int>    m_soundIdToIdx;     //conversion sound-instrument id to index
-	vector<ImoMidiInfo*> m_latestMidiInfo;  //latest MidiInfo for each soundIdx
+    MxlOctaveShiftBuilder*          m_pOctaveShiftBuilder;
+    std::vector<ImoDynamicsMark*>   m_pendingDynamicsMarks;
+    std::map<std::string, int>      m_lyricIndex;
+    std::vector<ImoLyric*>          m_lyrics;
+    std::map<std::string, int>      m_soundIdToIdx;     //conversion sound-instrument id to index
+	std::vector<ImoMidiInfo*>       m_latestMidiInfo;  //latest MidiInfo for each soundIdx
+	std::map<int, LUnits>           m_staffDistance;    //<defaults> for staff-distance
 
 
-    int             m_musicxmlVersion;
-    ImoObj*         m_pNodeImo;
-    map<int, ImoId> m_tieIds;
-    int             m_tieNum;
-    map<int, ImoId> m_slurIds;
-    int             m_slurNum;
-    int             m_voltaNum;
-    map<int, ImoId> m_wedgeIds;
-    int             m_wedgeNum;
-    map<int, ImoId> m_octaveShiftIds;
-    int             m_octaveShiftNum;
+    int                  m_musicxmlVersion;
+    ImoObj*              m_pNodeImo;
+    std::map<int, ImoId> m_tieIds;
+    int                  m_tieNum;
+    std::map<int, ImoId> m_slurIds;
+    int                  m_slurNum;
+    int                  m_voltaNum;
+    std::map<int, ImoId> m_wedgeIds;
+    int                  m_wedgeNum;
+    std::map<int, ImoId> m_octaveShiftIds;
+    int                  m_octaveShiftNum;
 
 
     //analysis input
     XmlNode* m_pTree;
-    string m_fileLocator;
+    std::string m_fileLocator;
 
     // information maintained in MxlAnalyser
     ImoScore*       m_pCurScore;        //the score under construction
@@ -286,11 +297,17 @@ protected:
     TimeUnits       m_time;             //time-position counter
     TimeUnits       m_maxTime;          //max time-position reached
     float           m_divisions;        //fractions of quarter note to use as units for 'duration' values
-    string          m_curPartId;        //Part Id being analysed
-    string          m_curMeasureNum;    //Num of measure being analysed
+    std::string     m_curPartId;        //Part Id being analysed
+    std::string     m_curMeasureNum;    //Num of measure being analysed
     int             m_measuresCounter;  //counter for measures in current instrument
 
-    vector<ImoNote*> m_notes;           //last note for each staff
+    std::vector<ImoNote*> m_notes;           //last note for each staff
+
+    //default fonts
+    ImoFontStyleDto* m_pMusicFont = nullptr;
+    ImoFontStyleDto* m_pWordFont = nullptr;
+    std::map<int, ImoStyle*> m_lyricStyle;
+    std::map<int, std::string> m_lyricLang;
 
     //inherited values
 //    int m_curStaff;
@@ -299,7 +316,7 @@ protected:
 //    int m_nShowTupletNumber;
 
     //conversion from xml element name to int
-    std::map<std::string, int>	m_NameToEnum;
+    std::map<std::string, int> m_NameToEnum;
 
 public:
     MxlAnalyser(ostream& reporter, LibraryScope& libraryScope, Document* pDoc,
@@ -307,7 +324,7 @@ public:
     virtual ~MxlAnalyser();
 
     //access to results
-    ImoObj* analyse_tree(XmlNode* tree, const string& locator);
+    ImoObj* analyse_tree(XmlNode* tree, const std::string& locator);
     ImoObj* analyse_tree_and_get_object(XmlNode* tree);
 
     //analysis
@@ -317,12 +334,12 @@ public:
 
     //part-list
     bool part_list_is_valid() { return m_partList.get_num_items() > 0; }
-    void add_score_part(const string& id, ImoInstrument* pInstrument) {
+    void add_score_part(const std::string& id, ImoInstrument* pInstrument) {
         int iInstr = m_partList.add_score_part(id, pInstrument);
         m_partGroups.add_instrument_to_groups(iInstr);
     }
     void add_all_instruments(ImoScore* pScore) { m_partList.add_all_instruments(pScore); }
-    bool mark_part_as_added(const string& id) {
+    bool mark_part_as_added(const std::string& id) {
         return m_partList.mark_part_as_added(id);
     }
     void check_if_missing_parts() { m_partList.check_if_missing_parts(m_reporter); }
@@ -334,9 +351,9 @@ public:
     void check_if_all_groups_are_closed();
 
     //global info: setters, getters and checkers
-    int set_musicxml_version(const string& version);
+    int set_musicxml_version(const std::string& version);
     inline int get_musicxml_version() { return m_musicxmlVersion; }
-    ImoInstrument* get_instrument(const string& id) { return m_partList.get_instrument(id); }
+    ImoInstrument* get_instrument(const std::string& id) { return m_partList.get_instrument(id); }
     float current_divisions() { return m_divisions; }
     void set_current_divisions(float value) { m_divisions = value; }
     TimeUnits duration_to_time_units(int duration);
@@ -372,9 +389,29 @@ public:
     inline ImoNote* get_last_note() { return m_pLastNote; }
     ImoNote* get_last_note_for(int iStaff);
 
+    //
     void save_arpeggio_data(ImoArpeggioDto* pArpeggioDto);
     ImoArpeggioDto* get_arpeggio_data() { return m_pArpeggioDto; }
     void reset_arpeggio_data();
+
+    //default fonts
+        //music
+    inline ImoFontStyleDto* get_music_font() { return m_pMusicFont; }
+    inline void set_music_font(ImoFontStyleDto* pFont) {
+        delete m_pMusicFont;
+        m_pMusicFont = pFont;
+    }
+        //words
+    inline ImoFontStyleDto* get_word_font() { return m_pWordFont; }
+    inline void set_word_font(ImoFontStyleDto* pFont) {
+        delete m_pWordFont;
+        m_pWordFont = pFont;
+    }
+        //lyric lines
+    ImoStyle* get_lyric_style(int number);
+    void set_lyric_style(int number, ImoStyle* pStyle);
+    std::string get_lyric_language(int number);
+    void set_lyric_language(int number, const std::string& lang);
 
     //last barline added to current instrument
     inline void save_last_barline(ImoBarline* pBarline) { m_pLastBarline = pBarline; }
@@ -388,23 +425,28 @@ public:
     void save_current_instrument(ImoInstrument* pInstr);
     inline ImoInstrument* get_current_instrument() { return m_pCurInstrument; }
 
+    //access to default staves spacing, for current instrument being analysed
+    void save_default_staff_distance(int iStaff, LUnits distance);
+    LUnits get_default_staff_distance(int iStaff);
+
+
     //access to document being analysed
     inline Document* get_document_being_analysed() { return m_pDoc; }
-    inline const string& get_document_locator() { return m_fileLocator; }
+    inline const std::string& get_document_locator() { return m_fileLocator; }
 
     //access to root ImoDocument
     inline void save_root_imo_document(ImoDocument* pDoc) { m_pImoDoc = pDoc; }
     inline ImoDocument* get_root_imo_document() { return m_pImoDoc; }
 
     //sound-instruments and midi info management
-    int get_index_for_sound(const string& id);
-    int create_index_for_sound(const string& id);
-    ImoMidiInfo* get_latest_midi_info_for(const string& id);
-    void set_latest_midi_info_for(const string& id, ImoMidiInfo* pMidi);
+    int get_index_for_sound(const std::string& id);
+    int create_index_for_sound(const std::string& id);
+    ImoMidiInfo* get_latest_midi_info_for(const std::string& id);
+    void set_latest_midi_info_for(const std::string& id, ImoMidiInfo* pMidi);
 
     //for creating measures info
     inline int increment_measures_counter() { return ++m_measuresCounter; }
-    inline void save_current_measure_num(const string& num) { m_curMeasureNum = num; }
+    inline void save_current_measure_num(const std::string& num) { m_curMeasureNum = num; }
     inline int get_measures_counter() { return m_measuresCounter; }
 
     //interface for building relations
@@ -463,27 +505,27 @@ public:
     }
 
     //information for reporting errors
-    string get_element_info();
-    inline void save_current_part_id(const string& id) { m_curPartId = id; }
+    std::string get_element_info();
+    inline void save_current_part_id(const std::string& id) { m_curPartId = id; }
     int get_line_number(XmlNode* node);
 
 
-    int name_to_enum(const string& name) const;
-    bool to_integer(const string& text, int* pResult);
+    int name_to_enum(const std::string& name) const;
+    bool to_integer(const std::string& text, int* pResult);
 
 
 protected:
-    MxlElementAnalyser* new_analyser(const string& name, ImoObj* pAnchor=nullptr);
+    MxlElementAnalyser* new_analyser(const std::string& name, ImoObj* pAnchor=nullptr);
     void delete_relation_builders();
     void add_marging_space_for_lyrics(ImoNote* pNote, ImoLyric* pLyric);
 };
 
 //defined in WordsMxlAnalyser to simplify unit testing of the regex
-extern int mxl_type_of_repetion_mark(const string& value);
+extern int mxl_type_of_repetion_mark(const std::string& value);
 //defined in EndingMxlAnalyser to simplify unit testing of the regex
-extern bool mxl_is_valid_ending_number(const string& num);
+extern bool mxl_is_valid_ending_number(const std::string& num);
 //defined in EndingMxlAnalyser to simplify unit testing of the regex
-extern void mxl_extract_numbers_from_ending(const string& num, vector<int>* repetitions);
+extern void mxl_extract_numbers_from_ending(const std::string& num, std::vector<int>* repetitions);
 
 
 }   //namespace lomse

--- a/include/private/lomse_internal_model_p.h
+++ b/include/private/lomse_internal_model_p.h
@@ -3611,11 +3611,17 @@ public:
 class ImoPageInfo : public ImoSimpleObj
 {
 protected:
-    LUnits  m_uLeftMargin;
-    LUnits  m_uRightMargin;
-    LUnits  m_uTopMargin;
-    LUnits  m_uBottomMargin;
-    LUnits  m_uBindingMargin;
+    //odd pages
+    LUnits  m_uLeftMarginOdd;
+    LUnits  m_uRightMarginOdd;
+    LUnits  m_uTopMarginOdd;
+    LUnits  m_uBottomMarginOdd;
+    //even pages
+    LUnits  m_uLeftMarginEven;
+    LUnits  m_uRightMarginEven;
+    LUnits  m_uTopMarginEven;
+    LUnits  m_uBottomMarginEven;
+    //common
     USize   m_uPageSize;
     bool    m_fPortrait;
 
@@ -3627,27 +3633,37 @@ protected:
 public:
     virtual ~ImoPageInfo() {}
 
-    //getters
-    inline LUnits get_left_margin() { return m_uLeftMargin; }
-    inline LUnits get_right_margin() { return m_uRightMargin; }
-    inline LUnits get_top_margin() { return m_uTopMargin; }
-    inline LUnits get_bottom_margin() { return m_uBottomMargin; }
-    inline LUnits get_binding_margin() { return m_uBindingMargin; }
-    inline bool is_portrait() { return m_fPortrait; }
+    //margins, odd pages
+    inline LUnits get_left_margin_odd() { return m_uLeftMarginOdd; }
+    inline LUnits get_right_margin_odd() { return m_uRightMarginOdd; }
+    inline LUnits get_top_margin_odd() { return m_uTopMarginOdd; }
+    inline LUnits get_bottom_margin_odd() { return m_uBottomMarginOdd; }
+    inline void set_left_margin_odd(LUnits value) { m_uLeftMarginOdd = value; }
+    inline void set_right_margin_odd(LUnits value) { m_uRightMarginOdd = value; }
+    inline void set_top_margin_odd(LUnits value) { m_uTopMarginOdd = value; }
+    inline void set_bottom_margin_odd(LUnits value) { m_uBottomMarginOdd = value; }
+
+    //margins, even pages
+    inline LUnits get_left_margin_even() { return m_uLeftMarginEven; }
+    inline LUnits get_right_margin_even() { return m_uRightMarginEven; }
+    inline LUnits get_top_margin_even() { return m_uTopMarginEven; }
+    inline LUnits get_bottom_margin_even() { return m_uBottomMarginEven; }
+    inline void set_left_margin_even(LUnits value) { m_uLeftMarginEven = value; }
+    inline void set_right_margin_even(LUnits value) { m_uRightMarginEven = value; }
+    inline void set_top_margin_even(LUnits value) { m_uTopMarginEven = value; }
+    inline void set_bottom_margin_even(LUnits value) { m_uBottomMarginEven = value; }
+
+    //page size
     inline USize get_page_size() { return m_uPageSize; }
     inline LUnits get_page_width() { return m_uPageSize.width; }
     inline LUnits get_page_height() { return m_uPageSize.height; }
-
-    //setters
-    inline void set_left_margin(LUnits value) { m_uLeftMargin = value; }
-    inline void set_right_margin(LUnits value) { m_uRightMargin = value; }
-    inline void set_top_margin(LUnits value) { m_uTopMargin = value; }
-    inline void set_bottom_margin(LUnits value) { m_uBottomMargin = value; }
-    inline void set_binding_margin(LUnits value) { m_uBindingMargin = value; }
-    inline void set_portrait(bool value) { m_fPortrait = value; }
     inline void set_page_size(USize uPageSize) { m_uPageSize = uPageSize; }
     inline void set_page_width(LUnits value) { m_uPageSize.width = value; }
     inline void set_page_height(LUnits value) { m_uPageSize.height = value; }
+
+    //page orientation
+    inline bool is_portrait() { return m_fPortrait; }
+    inline void set_portrait(bool value) { m_fPortrait = value; }
 };
 
 
@@ -5102,6 +5118,9 @@ public:
     inline void set_instr_id(const std::string& id) { m_partId = id; }
     inline void set_last_measure_info(TypeMeasureInfo* pInfo) { m_pLastMeasureInfo = pInfo; }
 
+    //to change default settings at creation time (MusicXML importer)
+    void set_staff_margin(int iStaff, LUnits distance);
+
         //layout options
 
     /// Valid values for defining the policy to layout barlines.
@@ -5909,48 +5928,18 @@ public:
     virtual ~ImoSystemInfo() {}
 
     //getters
-    inline bool is_first()
-    {
-        return m_fFirst;
-    }
-    inline LUnits get_left_margin()
-    {
-        return m_leftMargin;
-    }
-    inline LUnits get_right_margin()
-    {
-        return m_rightMargin;
-    }
-    inline LUnits get_system_distance()
-    {
-        return m_systemDistance;
-    }
-    inline LUnits get_top_system_distance()
-    {
-        return m_topSystemDistance;
-    }
+    inline bool is_first() { return m_fFirst; }
+    inline LUnits get_left_margin() { return m_leftMargin; }
+    inline LUnits get_right_margin() { return m_rightMargin; }
+    inline LUnits get_system_distance() { return m_systemDistance; }
+    inline LUnits get_top_system_distance() { return m_topSystemDistance; }
 
     //setters
-    inline void set_first(bool fValue)
-    {
-        m_fFirst = fValue;
-    }
-    inline void set_left_margin(LUnits rValue)
-    {
-        m_leftMargin = rValue;
-    }
-    inline void set_right_margin(LUnits rValue)
-    {
-        m_rightMargin = rValue;
-    }
-    inline void set_system_distance(LUnits rValue)
-    {
-        m_systemDistance = rValue;
-    }
-    inline void set_top_system_distance(LUnits rValue)
-    {
-        m_topSystemDistance = rValue;
-    }
+    inline void set_first(bool fValue) { m_fFirst = fValue; }
+    inline void set_left_margin(LUnits rValue) { m_leftMargin = rValue; }
+    inline void set_right_margin(LUnits rValue) { m_rightMargin = rValue; }
+    inline void set_system_distance(LUnits rValue) { m_systemDistance = rValue; }
+    inline void set_top_system_distance(LUnits rValue) { m_topSystemDistance = rValue; }
 };
 
 //---------------------------------------------------------------------------------------
@@ -5960,9 +5949,9 @@ protected:
     int             m_version;
     ColStaffObjs*   m_pColStaffObjs;
     SoundEventsTable* m_pMidiTable;
+    float           m_scaling;              //global scaling tenths -> LUnits
     ImoSystemInfo   m_systemInfoFirst;
     ImoSystemInfo   m_systemInfoOther;
-    ImoPageInfo     m_pageInfo;
     std::list<ImoScoreTitle*> m_titles;     //titles are added as children nodes. This list is
                                             //kept for quick access. Do not delete in destructor.
     std::map<string, ImoStyle*> m_nameToStyle;
@@ -5984,6 +5973,8 @@ public:
     inline ColStaffObjs* get_staffobjs_table() { return m_pColStaffObjs; }
     void set_staffobjs_table(ColStaffObjs* pColStaffObjs);
     SoundEventsTable* get_midi_table();
+    void set_global_scaling(float millimeters, float tenths);
+    inline LUnits tenths_to_logical(Tenths value) { return m_scaling * value; }
 
     //required by Visitable parent class
     void accept_visitor(BaseVisitor& v) override;
@@ -6013,22 +6004,14 @@ public:
 
     //score layout
     void add_sytem_info(ImoSystemInfo* pSL);
-    inline ImoSystemInfo* get_first_system_info() { return &m_systemInfoFirst;
-    }
-    inline ImoSystemInfo* get_other_system_info() { return &m_systemInfoOther;
-    }
-    void add_page_info(ImoPageInfo* pPI);
-    inline ImoPageInfo* get_page_info() { return &m_pageInfo;
-    }
+    inline ImoSystemInfo* get_first_system_info() { return &m_systemInfoFirst; }
+    inline ImoSystemInfo* get_other_system_info() { return &m_systemInfoOther; }
     bool has_default_values(ImoSystemInfo* pInfo);
 
 
     //titles
     void add_title(ImoScoreTitle* pTitle);
-    inline std::list<ImoScoreTitle*>& get_titles()
-    {
-        return m_titles;
-    }
+    inline std::list<ImoScoreTitle*>& get_titles() { return m_titles; }
 
     //styles
     void add_style(ImoStyle* pStyle);
@@ -6294,44 +6277,20 @@ public:
          };
 
     //staff number
-    inline int get_staff_number()
-    {
-        return m_numStaff;
-    }
-    inline void set_staff_number(int num)
-    {
-        m_numStaff = num;
-    }
+    inline int get_staff_number() { return m_numStaff; }
+    inline void set_staff_number(int num) { m_numStaff = num; }
 
     //staff type
-    inline int get_staff_type()
-    {
-        return m_staffType;
-    }
-    inline void set_staff_type(int type)
-    {
-        m_staffType = type;
-    }
+    inline int get_staff_type() { return m_staffType; }
+    inline void set_staff_type(int type) { m_staffType = type; }
 
     //margins
-    inline LUnits get_staff_margin()
-    {
-        return m_uMarging;
-    }
-    inline void set_staff_margin(LUnits uSpace)
-    {
-        m_uMarging = uSpace;
-    }
+    inline LUnits get_staff_margin() { return m_uMarging; }
+    inline void set_staff_margin(LUnits uSpace) { m_uMarging = uSpace; }
 
     //spacing and size
-    inline LUnits get_line_spacing()
-    {
-        return m_uSpacing;
-    }
-    inline void set_line_spacing(LUnits uSpacing)
-    {
-        m_uSpacing = uSpacing;
-    }
+    inline LUnits get_line_spacing() { return m_uSpacing; }
+    inline void set_line_spacing(LUnits uSpacing) { m_uSpacing = uSpacing; }
     LUnits get_height()
     {
         if (m_nNumLines > 1)
@@ -6341,31 +6300,16 @@ public:
     }
 
     //lines
-    inline LUnits get_line_thickness()
-    {
-        return m_uLineThickness;
-    }
-    inline void set_line_thickness(LUnits uTickness)
-    {
-        m_uLineThickness = uTickness;
-    }
-    inline int get_num_lines()
-    {
-        return m_nNumLines;
-    }
-    inline void set_num_lines(int nLines)
-    {
-        m_nNumLines = nLines;
-    }
+    inline LUnits get_line_thickness() { return m_uLineThickness; }
+    inline void set_line_thickness(LUnits uTickness) { m_uLineThickness = uTickness; }
+    inline int get_num_lines() { return m_nNumLines; }
+    inline void set_num_lines(int nLines) { m_nNumLines = nLines; }
 
 protected:
     friend class MxlAnalyser;
     friend class LdpAnalyser;
     friend class MnxAnalyser;
-    inline void add_space_for_lyrics(LUnits space)
-    {
-        m_uMarging += space;
-    }
+    inline void add_space_for_lyrics(LUnits space) { m_uMarging += space; }
 
 };
 
@@ -7115,86 +7059,29 @@ public:
     virtual ~ImoLyric();
 
     //getters
-    inline int get_number()
-    {
-        return m_number;
-    }
-    inline int get_placement()
-    {
-        return m_placement;
-    }
-    inline bool is_laughing()
-    {
-        return m_fLaughing;
-    }
-    inline bool is_humming()
-    {
-        return m_fHumming;
-    }
-    inline bool is_end_line()
-    {
-        return m_fEndLine;
-    }
-    inline bool is_end_paragraph()
-    {
-        return m_fEndParagraph;
-    }
-    inline bool has_hyphenation()
-    {
-        return m_fHyphenation;
-    }
-    inline ImoLyric* get_prev_lyric()
-    {
-        return static_cast<ImoLyric*>(m_prevARO);
-    }
-    inline ImoLyric* get_next_lyric()
-    {
-        return static_cast<ImoLyric*>(m_nextARO);
-    }
+    inline int get_number() { return m_number; }
+    inline int get_placement() { return m_placement; }
+    inline bool is_laughing() { return m_fLaughing; }
+    inline bool is_humming() { return m_fHumming; }
+    inline bool is_end_line() { return m_fEndLine; }
+    inline bool is_end_paragraph() { return m_fEndParagraph; }
+    inline bool has_hyphenation() { return m_fHyphenation; }
+    inline ImoLyric* get_prev_lyric() { return static_cast<ImoLyric*>(m_prevARO); }
+    inline ImoLyric* get_next_lyric() { return static_cast<ImoLyric*>(m_nextARO); }
 
     //setters
-    inline void set_number(int number)
-    {
-        m_number = number;
-    }
-    inline void set_placement(int placement)
-    {
-        m_placement = placement;
-    }
-    inline void set_laughing(bool value)
-    {
-        m_fLaughing = value;
-    }
-    inline void set_humming(bool value)
-    {
-        m_fHumming = value;
-    }
-    inline void set_end_line(bool value)
-    {
-        m_fEndLine = value;
-    }
-    inline void set_end_paragraph(bool value)
-    {
-        m_fEndParagraph = value;
-    }
-    inline void set_melisma(bool value)
-    {
-        m_fMelisma = value;
-    }
-    inline void set_hyphenation(bool value)
-    {
-        m_fHyphenation = value;
-    }
+    inline void set_number(int number) { m_number = number; }
+    inline void set_placement(int placement) { m_placement = placement; }
+    inline void set_laughing(bool value) { m_fLaughing = value; }
+    inline void set_humming(bool value) { m_fHumming = value; }
+    inline void set_end_line(bool value) { m_fEndLine = value; }
+    inline void set_end_paragraph(bool value) { m_fEndParagraph = value; }
+    inline void set_melisma(bool value) { m_fMelisma = value; }
+    inline void set_hyphenation(bool value) { m_fHyphenation = value; }
 
     //information
-    inline int get_num_text_items()
-    {
-        return m_numTextItems;
-    }
-    inline bool has_melisma()
-    {
-        return m_fMelisma;
-    }
+    inline int get_num_text_items() { return m_numTextItems; }
+    inline bool has_melisma() { return m_fMelisma; }
 
     //data
     ImoLyricsTextInfo* get_text_item(int i);
@@ -7208,14 +7095,8 @@ protected:
     friend class MxlAnalyser;
     friend class MnxAnalyser;
     void add_text_item(ImoLyricsTextInfo* pText);
-    void link_to_next_lyric(ImoLyric* pNext)
-    {
-        link_to_next_ARO(pNext);
-    }
-    void set_prev_lyric(ImoLyric* pPrev)
-    {
-        set_prev_ARO(pPrev);
-    }
+    void link_to_next_lyric(ImoLyric* pNext) { link_to_next_ARO(pNext); }
+    void set_prev_lyric(ImoLyric* pPrev) { set_prev_ARO(pPrev); }
 
 };
 
@@ -7244,49 +7125,19 @@ public:
     enum { k_single, k_begin, k_end, k_middle, };
 
     //getters
-    inline int get_syllable_type()
-    {
-        return m_syllableType;
-    }
-    inline std::string& get_syllable_text()
-    {
-        return m_text.get_text();
-    }
-    inline std::string& get_syllable_language()
-    {
-        return m_text.get_language();
-    }
+    inline int get_syllable_type() { return m_syllableType; }
+    inline std::string& get_syllable_text() { return m_text.get_text(); }
+    inline std::string& get_syllable_language() { return m_text.get_language(); }
     ImoStyle* get_syllable_style();
-    inline bool has_elision()
-    {
-        return !m_elision.empty();
-    }
-    inline std::string& get_elision_text()
-    {
-        return m_elision;
-    }
+    inline bool has_elision() { return !m_elision.empty(); }
+    inline std::string& get_elision_text() { return m_elision; }
 
     //setters
-    inline void set_syllable_type(int value)
-    {
-        m_syllableType = value;
-    }
-    inline void set_syllable_text(const std::string& text)
-    {
-        m_text.set_text(text);
-    }
-    inline void set_syllable_style(ImoStyle* pStyle)
-    {
-        m_text.set_style(pStyle);
-    }
-    inline void set_syllable_language(const std::string& language)
-    {
-        m_text.set_language(language);
-    }
-    inline void set_elision_text(const std::string& text)
-    {
-        m_elision = text;
-    }
+    inline void set_syllable_type(int value) { m_syllableType = value; }
+    inline void set_syllable_text(const std::string& text) { m_text.set_text(text); }
+    inline void set_syllable_style(ImoStyle* pStyle) { m_text.set_style(pStyle); }
+    inline void set_syllable_language(const std::string& language) { m_text.set_language(language); }
+    inline void set_elision_text(const std::string& text) { m_elision = text; }
 
 };
 

--- a/src/document/lomse_document.cpp
+++ b/src/document/lomse_document.cpp
@@ -932,50 +932,98 @@ bool ADocument::append_child(const AObject& detachedObj)
 
 //---------------------------------------------------------------------------------------
 /** @memberof ADocument
-    Sets the left margin of the page. The new margin value is specified in logical
+    Sets the left margin in odd pages. The new margin value is specified in logical
     units (cents of a millimeter).
 */
-void ADocument::set_page_left_margin(LUnits value)
+void ADocument::set_page_left_margin_odd(LUnits value)
 {
     ImoDocument* pRoot = pimpl()->get_im_root();
 	ImoPageInfo* pageInfo = pRoot->get_page_info();
-    pageInfo->set_left_margin(value);
+    pageInfo->set_left_margin_odd(value);
 }
 
 //---------------------------------------------------------------------------------------
 /** @memberof ADocument
-    Sets the right margin of the page. The new margin value is specified in logical
+    Sets the right margin in odd pages. The new margin value is specified in logical
     units (cents of a millimeter).
 */
-void ADocument::set_page_right_margin(LUnits value)
+void ADocument::set_page_right_margin_odd(LUnits value)
 {
     ImoDocument* pRoot = pimpl()->get_im_root();
 	ImoPageInfo* pageInfo = pRoot->get_page_info();
-    pageInfo->set_right_margin(value);
+    pageInfo->set_right_margin_odd(value);
 }
 
 //---------------------------------------------------------------------------------------
 /** @memberof ADocument
-    Sets the top margin of the page. The new margin value is specified in logical
+    Sets the top margin in odd pages. The new margin value is specified in logical
     units (cents of a millimeter).
 */
-void ADocument::set_page_top_margin(LUnits value)
+void ADocument::set_page_top_margin_odd(LUnits value)
 {
     ImoDocument* pRoot = pimpl()->get_im_root();
 	ImoPageInfo* pageInfo = pRoot->get_page_info();
-    pageInfo->set_top_margin(value);
+    pageInfo->set_top_margin_odd(value);
 }
 
 //---------------------------------------------------------------------------------------
 /** @memberof ADocument
-    Sets the bottom margin of the page. The new margin value is specified in logical
+    Sets the bottom margin in odd pages. The new margin value is specified in logical
     units (cents of a millimeter).
 */
-void ADocument::set_page_bottom_margin(LUnits value)
+void ADocument::set_page_bottom_margin_odd(LUnits value)
 {
     ImoDocument* pRoot = pimpl()->get_im_root();
 	ImoPageInfo* pageInfo = pRoot->get_page_info();
-    pageInfo->set_bottom_margin(value);
+    pageInfo->set_bottom_margin_odd(value);
+}
+
+//---------------------------------------------------------------------------------------
+/** @memberof ADocument
+    Sets the left margin in even pages. The new margin value is specified in logical
+    units (cents of a millimeter).
+*/
+void ADocument::set_page_left_margin_even(LUnits value)
+{
+    ImoDocument* pRoot = pimpl()->get_im_root();
+	ImoPageInfo* pageInfo = pRoot->get_page_info();
+    pageInfo->set_left_margin_even(value);
+}
+
+//---------------------------------------------------------------------------------------
+/** @memberof ADocument
+    Sets the right margin in even pages. The new margin value is specified in logical
+    units (cents of a millimeter).
+*/
+void ADocument::set_page_right_margin_even(LUnits value)
+{
+    ImoDocument* pRoot = pimpl()->get_im_root();
+	ImoPageInfo* pageInfo = pRoot->get_page_info();
+    pageInfo->set_right_margin_even(value);
+}
+
+//---------------------------------------------------------------------------------------
+/** @memberof ADocument
+    Sets the top margin in even pages. The new margin value is specified in logical
+    units (cents of a millimeter).
+*/
+void ADocument::set_page_top_margin_even(LUnits value)
+{
+    ImoDocument* pRoot = pimpl()->get_im_root();
+	ImoPageInfo* pageInfo = pRoot->get_page_info();
+    pageInfo->set_top_margin_even(value);
+}
+
+//---------------------------------------------------------------------------------------
+/** @memberof ADocument
+    Sets the bottom margin in even pages. The new margin value is specified in logical
+    units (cents of a millimeter).
+*/
+void ADocument::set_page_bottom_margin_even(LUnits value)
+{
+    ImoDocument* pRoot = pimpl()->get_im_root();
+	ImoPageInfo* pageInfo = pRoot->get_page_info();
+    pageInfo->set_bottom_margin_even(value);
 }
 
 //---------------------------------------------------------------------------------------
@@ -1016,50 +1064,98 @@ void ADocument::set_page_height(LUnits value)
 
 //---------------------------------------------------------------------------------------
 /** @memberof ADocument
-    Returns the left margin of the page. The returned value is in logical
+    Returns the left margin for odd pages. The returned value is in logical
     units (cents of a millimeter).
 */
-LUnits ADocument::page_left_margin() const
+LUnits ADocument::page_left_margin_odd() const
 {
     ImoDocument* pRoot = pimpl()->get_im_root();
 	ImoPageInfo* pageInfo = pRoot->get_page_info();
-    return pageInfo->get_left_margin();
+    return pageInfo->get_left_margin_odd();
 }
 
 //---------------------------------------------------------------------------------------
 /** @memberof ADocument
-    Returns the right margin of the page. The returned value is in logical
+    Returns the right margin for odd pages. The returned value is in logical
     units (cents of a millimeter).
 */
-LUnits ADocument::page_right_margin() const
+LUnits ADocument::page_right_margin_odd() const
 {
     ImoDocument* pRoot = pimpl()->get_im_root();
 	ImoPageInfo* pageInfo = pRoot->get_page_info();
-    return pageInfo->get_right_margin();
+    return pageInfo->get_right_margin_odd();
 }
 
 //---------------------------------------------------------------------------------------
 /** @memberof ADocument
-    Returns the top margin of the page. The returned value is in logical
+    Returns the top margin for odd pages. The returned value is in logical
     units (cents of a millimeter).
 */
-LUnits ADocument::page_top_margin() const
+LUnits ADocument::page_top_margin_odd() const
 {
     ImoDocument* pRoot = pimpl()->get_im_root();
 	ImoPageInfo* pageInfo = pRoot->get_page_info();
-    return pageInfo->get_top_margin();
+    return pageInfo->get_top_margin_odd();
 }
 
 //---------------------------------------------------------------------------------------
 /** @memberof ADocument
-    Returns the bottom margin of the page. The returned value is in logical
+    Returns the bottom margin for odd pages. The returned value is in logical
     units (cents of a millimeter).
 */
-LUnits ADocument::page_bottom_margin() const
+LUnits ADocument::page_bottom_margin_odd() const
 {
     ImoDocument* pRoot = pimpl()->get_im_root();
 	ImoPageInfo* pageInfo = pRoot->get_page_info();
-    return pageInfo->get_bottom_margin();
+    return pageInfo->get_bottom_margin_odd();
+}
+
+//---------------------------------------------------------------------------------------
+/** @memberof ADocument
+    Returns the left margin for even pages. The returned value is in logical
+    units (cents of a millimeter).
+*/
+LUnits ADocument::page_left_margin_even() const
+{
+    ImoDocument* pRoot = pimpl()->get_im_root();
+	ImoPageInfo* pageInfo = pRoot->get_page_info();
+    return pageInfo->get_left_margin_even();
+}
+
+//---------------------------------------------------------------------------------------
+/** @memberof ADocument
+    Returns the right margin for even pages. The returned value is in logical
+    units (cents of a millimeter).
+*/
+LUnits ADocument::page_right_margin_even() const
+{
+    ImoDocument* pRoot = pimpl()->get_im_root();
+	ImoPageInfo* pageInfo = pRoot->get_page_info();
+    return pageInfo->get_right_margin_even();
+}
+
+//---------------------------------------------------------------------------------------
+/** @memberof ADocument
+    Returns the top margin for even pages. The returned value is in logical
+    units (cents of a millimeter).
+*/
+LUnits ADocument::page_top_margin_even() const
+{
+    ImoDocument* pRoot = pimpl()->get_im_root();
+	ImoPageInfo* pageInfo = pRoot->get_page_info();
+    return pageInfo->get_top_margin_even();
+}
+
+//---------------------------------------------------------------------------------------
+/** @memberof ADocument
+    Returns the bottom margin for even pages. The returned value is in logical
+    units (cents of a millimeter).
+*/
+LUnits ADocument::page_bottom_margin_even() const
+{
+    ImoDocument* pRoot = pimpl()->get_im_root();
+	ImoPageInfo* pageInfo = pRoot->get_page_info();
+    return pageInfo->get_bottom_margin_even();
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/layouters/lomse_document_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_document_layouter.cpp
@@ -162,14 +162,24 @@ void DocLayouter::assign_paper_size_to(GmoBox* pBox)
 void DocLayouter::add_margins_to_page(GmoBoxDocPage* pPage)
 {
     ImoPageInfo* pInfo = m_pDoc->get_page_info();
-    LUnits top = pInfo->get_top_margin() / m_pDoc->get_page_content_scale();
-    LUnits bottom = pInfo->get_bottom_margin() / m_pDoc->get_page_content_scale();
-    LUnits left = pInfo->get_left_margin() / m_pDoc->get_page_content_scale();
-    LUnits right = pInfo->get_right_margin() / m_pDoc->get_page_content_scale();
+    LUnits top = 0.0f;
+    LUnits bottom = 0.0f;
+    LUnits left = 0.0f;
+    LUnits right = 0.0f;
     if (pPage->get_number() % 2 == 0)
-        left += pInfo->get_binding_margin() / m_pDoc->get_page_content_scale();
+    {
+        top = pInfo->get_top_margin_even() / m_pDoc->get_page_content_scale();
+        bottom = pInfo->get_bottom_margin_even() / m_pDoc->get_page_content_scale();
+        left = pInfo->get_left_margin_even() / m_pDoc->get_page_content_scale();
+        right = pInfo->get_right_margin_even() / m_pDoc->get_page_content_scale();
+    }
     else
-        right += pInfo->get_binding_margin() / m_pDoc->get_page_content_scale();
+    {
+        top = pInfo->get_top_margin_odd() / m_pDoc->get_page_content_scale();
+        bottom = pInfo->get_bottom_margin_odd() / m_pDoc->get_page_content_scale();
+        left = pInfo->get_left_margin_odd() / m_pDoc->get_page_content_scale();
+        right = pInfo->get_right_margin_odd() / m_pDoc->get_page_content_scale();
+    }
 
     m_pageCursor.x = left;
     m_pageCursor.y = top;
@@ -215,7 +225,10 @@ void DocLayouter::fix_document_size()
 
             LUnits height = pBSys->get_size().height + pBSys->get_origin().y;
             ImoPageInfo* pInfo = m_pDoc->get_page_info();
-            height += pInfo->get_bottom_margin() / m_pDoc->get_page_content_scale();
+            if (pPage->get_number() % 2 == 0)
+                height += pInfo->get_bottom_margin_even() / m_pDoc->get_page_content_scale();
+            else
+                height += pInfo->get_bottom_margin_odd() / m_pDoc->get_page_content_scale();
             pPage->set_height(height);
         }
         else

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -371,22 +371,32 @@ void ScoreLayouter::create_system_box()
     m_iCurSystem++;
     m_pPrevBoxSystem = (m_fFirstSystemInPage ? nullptr : m_pPrevBoxSystem);
 
-    LUnits width = m_pCurBoxPage->get_width();
+    //get margins
+    ImoSystemInfo* pInfo = (m_iCurSystem == 0 ? m_pScore->get_first_system_info()
+                                              : m_pScore->get_other_system_info());
+    LUnits leftMargin = pInfo->get_left_margin();
+    LUnits rightMargin = pInfo->get_right_margin();
+
+    //determine top and left positions
     LUnits top = m_cursor.y
                  + distance_to_top_of_system(m_iCurSystem, m_fFirstSystemInPage);
-    LUnits left = m_cursor.x;
+    LUnits left = m_cursor.x + leftMargin;
 
-    //save info for repositioning system if necessary
-    m_iSysPage = m_iCurPage;
-    m_sysCursor = m_cursor;
-
-    ImoSystemInfo* pInfo = m_pScore->get_other_system_info();
-
+    //determine height
     LUnits height = determine_system_top_margin();      //top margin
     height += m_pSpAlgorithm->get_staves_height();      //staves height
     height += pInfo->get_system_distance() / 2.0f;      //bottom margin
 
+    //determine width
+    LUnits width = m_pCurBoxPage->get_width();
+    width -= (leftMargin + rightMargin);
+
+    //create the box
     m_pCurBoxSystem = m_pCurSysLyt->create_system_box(left, top, width, height);
+
+    //save info for repositioning system if necessary
+    m_iSysPage = m_iCurPage;
+    m_sysCursor = m_cursor;
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -2666,6 +2666,19 @@ void ImoInstrument::replace_staff_info(ImoStaffInfo* pInfo)
 }
 
 //---------------------------------------------------------------------------------------
+void ImoInstrument::set_staff_margin(int iStaff, LUnits distance)
+{
+    std::list<ImoStaffInfo*>::iterator it = m_staves.begin();
+    for (; it != m_staves.end() && iStaff > 0; ++it, --iStaff);
+
+    if (it != m_staves.end())
+    {
+        ImoStaffInfo* pInfo = *it;
+        pInfo->set_staff_margin(distance);
+    }
+}
+
+//---------------------------------------------------------------------------------------
 void ImoInstrument::set_name(ImoScoreText* pText)
 {
     m_name = *pText;
@@ -3386,9 +3399,9 @@ ImoScore::ImoScore(Document* pDoc)
     , m_version(0)
     , m_pColStaffObjs(nullptr)
     , m_pMidiTable(nullptr)
+    , m_scaling(LOMSE_STAFF_LINE_SPACING / 10.0f)     //default staff: 7.2mm = 40 tenths
     , m_systemInfoFirst()
     , m_systemInfoOther()
-    , m_pageInfo()
 {
     set_edit_terminal(true);
     m_pDoc = pDoc;
@@ -3534,6 +3547,13 @@ void ImoScore::set_staffobjs_table(ColStaffObjs* pColStaffObjs)
 {
     delete m_pColStaffObjs;
     m_pColStaffObjs = pColStaffObjs;
+}
+
+//---------------------------------------------------------------------------------------
+void ImoScore::set_global_scaling(float millimeters, float tenths)
+{
+    if (millimeters > 0.0f && tenths > 0.0f)
+        m_scaling = (millimeters * 100.0f) / tenths;
 }
 
 //---------------------------------------------------------------------------------------
@@ -3730,12 +3750,6 @@ void ImoScore::add_sytem_info(ImoSystemInfo* pSL)
         m_systemInfoFirst = *pSL;
     else
         m_systemInfoOther = *pSL;
-}
-
-//---------------------------------------------------------------------------------------
-void ImoScore::add_page_info(ImoPageInfo* pPI)
-{
-    m_pageInfo = *pPI;
 }
 
 //---------------------------------------------------------------------------------------
@@ -5149,11 +5163,17 @@ void ImoStyles::create_default_styles()
 //=======================================================================================
 ImoPageInfo::ImoPageInfo()
     : ImoSimpleObj(k_imo_page_info)
-    , m_uLeftMargin(1500.0f)
-    , m_uRightMargin(1500.0f)
-    , m_uTopMargin(2000.0f)
-    , m_uBottomMargin(2000.0f)
-    , m_uBindingMargin(0.0f)
+    //odd pages
+    , m_uLeftMarginOdd(1500.0f)
+    , m_uRightMarginOdd(1500.0f)
+    , m_uTopMarginOdd(2000.0f)
+    , m_uBottomMarginOdd(2000.0f)
+    //even pages
+    , m_uLeftMarginEven(1500.0f)
+    , m_uRightMarginEven(1500.0f)
+    , m_uTopMarginEven(2000.0f)
+    , m_uBottomMarginEven(2000.0f)
+    //size and orientation
     , m_uPageSize(21000.0f, 29700.0f)
     , m_fPortrait(true)
 {

--- a/src/parser/ldp/lomse_ldp_analyser.cpp
+++ b/src/parser/ldp/lomse_ldp_analyser.cpp
@@ -4447,25 +4447,38 @@ public:
             //pDto = &dto;
 
         //left
+        LUnits left = 1500.0f;
         if (get_mandatory(k_number))
-            pDto->set_left_margin( get_float_value(2000.0f) );
+            left = get_float_value(1500.0f);
 
         //top
         if (get_mandatory(k_number))
-            pDto->set_top_margin( get_float_value(2000.0f) );
+        {
+            pDto->set_top_margin_odd( get_float_value(2000.0f) );
+            pDto->set_top_margin_even( get_float_value(2000.0f) );
+        }
 
         //right
+        LUnits right = 1500.0f;
         if (get_mandatory(k_number))
-            pDto->set_right_margin( get_float_value(1500.0f) );
+            right = get_float_value(1500.0f);
 
         //bottom
         if (get_mandatory(k_number))
-            pDto->set_bottom_margin( get_float_value(2000.0f) );
+        {
+            pDto->set_bottom_margin_odd( get_float_value(2000.0f) );
+            pDto->set_bottom_margin_even( get_float_value(2000.0f) );
+        }
 
         //binding
+        LUnits binding = 0.0f;
         if (get_mandatory(k_number))
-            pDto->set_binding_margin( get_float_value(0.0f) );
+            binding = get_float_value(0.0f);
 
+        pDto->set_left_margin_odd(left + binding);
+        pDto->set_left_margin_even(left);
+        pDto->set_right_margin_odd(right);
+        pDto->set_right_margin_even(right + binding);
     }
 
 };

--- a/src/parser/lmd/lomse_lmd_analyser.cpp
+++ b/src/parser/lmd/lomse_lmd_analyser.cpp
@@ -3802,24 +3802,38 @@ public:
             //pDto = &dto;
 
         //left
+        LUnits left = 1500.0f;
         if (get_mandatory(k_number))
-            pDto->set_left_margin( get_float_value(2000.0f) );
+            left = get_float_value(1500.0f);
 
         //top
         if (get_mandatory(k_number))
-            pDto->set_top_margin( get_float_value(2000.0f) );
+        {
+            pDto->set_top_margin_odd( get_float_value(2000.0f) );
+            pDto->set_top_margin_even( get_float_value(2000.0f) );
+        }
 
         //right
+        LUnits right = 1500.0f;
         if (get_mandatory(k_number))
-            pDto->set_right_margin( get_float_value(1500.0f) );
+            right = get_float_value(1500.0f);
 
         //bottom
         if (get_mandatory(k_number))
-            pDto->set_bottom_margin( get_float_value(2000.0f) );
+        {
+            pDto->set_bottom_margin_odd( get_float_value(2000.0f) );
+            pDto->set_bottom_margin_even( get_float_value(2000.0f) );
+        }
 
         //binding
+        LUnits binding = 0.0f;
         if (get_mandatory(k_number))
-            pDto->set_binding_margin( get_float_value(0.0f) );
+            binding = get_float_value(0.0f);
+
+        pDto->set_left_margin_odd(left + binding);
+        pDto->set_left_margin_even(left);
+        pDto->set_right_margin_odd(right);
+        pDto->set_right_margin_even(right + binding);
 
         return pDto;
     }

--- a/src/parser/lomse_linker.cpp
+++ b/src/parser/lomse_linker.cpp
@@ -190,14 +190,7 @@ ImoObj* Linker::add_option(ImoOptionInfo* pOpt)
 //---------------------------------------------------------------------------------------
 ImoObj* Linker::add_page_info(ImoPageInfo* pPI)
 {
-    if (m_pParent && m_pParent->is_score())
-    {
-        ImoScore* pScore = static_cast<ImoScore*>(m_pParent);
-        pScore->add_page_info(pPI);
-        delete pPI;
-        return nullptr;
-    }
-    else if (m_pParent && m_pParent->is_document())
+    if (m_pParent && m_pParent->is_document())
     {
         ImoDocument* pDoc = static_cast<ImoDocument*>(m_pParent);
         pDoc->add_page_info(pPI);

--- a/src/tests/lomse_test_document_layouter.cpp
+++ b/src/tests/lomse_test_document_layouter.cpp
@@ -149,7 +149,7 @@ SUITE(DocLayouterTest)
         CHECK( pBox && pBox->is_box_doc_page_content() == true );
         CHECK( pBox && pBox->get_width() == 16000.0f );
         CHECK( pBox && pBox->get_height() == 2735.0f );
-        CHECK( pBox && pBox->get_left() == 1000.0f );
+        CHECK( pBox && pBox->get_left() == 5000.0f );
         CHECK( pBox && pBox->get_top() == 1500.0f );
         delete pGModel;
     }
@@ -173,7 +173,7 @@ SUITE(DocLayouterTest)
         CHECK( pBox && pBox->get_width() == 16000.0f );
         //cout << pBox->get_height() << endl;
         CHECK( pBox && pBox->get_height() == 2735.0f );     //system height
-        CHECK( pBox && pBox->get_left() == 1000.0f );
+        CHECK( pBox && pBox->get_left() == 5000.0f );
         CHECK( pBox && pBox->get_top() == 1500.0f );
         delete pGModel;
     }

--- a/src/tests/lomse_test_internal_model.cpp
+++ b/src/tests/lomse_test_internal_model.cpp
@@ -624,11 +624,14 @@ SUITE(InternalModelTest)
         ImoPageInfo* pInfo = static_cast<ImoPageInfo*>(
                                     ImFactory::inject(k_imo_page_info, &doc));
         CHECK( pInfo->is_page_info() == true );
-        CHECK( pInfo->get_top_margin() == 2000.0f );
-        CHECK( pInfo->get_bottom_margin() == 2000.0f );
-        CHECK( pInfo->get_left_margin() == 1500.0f );
-        CHECK( pInfo->get_right_margin() == 1500.0f );
-        CHECK( pInfo->get_binding_margin() == 0.0f );
+        CHECK( pInfo->get_top_margin_odd() == 2000.0f );
+        CHECK( pInfo->get_bottom_margin_odd() == 2000.0f );
+        CHECK( pInfo->get_left_margin_odd() == 1500.0f );
+        CHECK( pInfo->get_right_margin_odd() == 1500.0f );
+        CHECK( pInfo->get_top_margin_even() == 2000.0f );
+        CHECK( pInfo->get_bottom_margin_even() == 2000.0f );
+        CHECK( pInfo->get_left_margin_even() == 1500.0f );
+        CHECK( pInfo->get_right_margin_even() == 1500.0f );
         CHECK( pInfo->is_portrait() == true );
         delete pInfo;
     }

--- a/src/tests/lomse_test_ldp_analyser.cpp
+++ b/src/tests/lomse_test_ldp_analyser.cpp
@@ -8437,46 +8437,14 @@ SUITE(LdpAnalyserTest)
         ImoPageInfo* pInfo = static_cast<ImoPageInfo*>( pRoot );
         CHECK( pInfo != nullptr );
         CHECK( pInfo && pInfo->is_page_info() == true );
-        CHECK( pInfo && pInfo->get_left_margin() == 1000.0f );
-        CHECK( pInfo && pInfo->get_top_margin() == 1200.0f );
-        CHECK( pInfo && pInfo->get_right_margin() == 3000.0f );
-        CHECK( pInfo && pInfo->get_bottom_margin() == 2500.0f );
-        CHECK( pInfo && pInfo->get_binding_margin() == 4000.0f );
-        CHECK( pInfo && pInfo->get_page_width() == 14000.0f );
-        CHECK( pInfo && pInfo->get_page_height() == 10000.0f );
-        CHECK( pInfo && pInfo->is_portrait() == false );
-
-        delete tree->get_root();
-        // coverity[check_after_deref]
-        if (pRoot && !pRoot->is_document()) delete pRoot;
-    }
-
-    TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_PageLayout_AddedToScore)
-    {
-        stringstream errormsg;
-        Document doc(m_libraryScope);
-        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
-        stringstream expected;
-        //expected << "" << endl;
-        parser.parse_text("(score (vers 1.6)(pageLayout (pageSize 14000 10000)(pageMargins 1000 1200 3000 2500 4000) landscape)(instrument (musicData)))");
-        LdpTree* tree = parser.get_ldp_tree();
-        LdpAnalyser a(errormsg, m_libraryScope, &doc);
-        ImoObj* pRoot = a.analyse_tree(tree, "string:");
-
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
-
-        ImoScore* pScore = static_cast<ImoScore*>( pRoot );
-        CHECK( pScore != nullptr );
-        ImoPageInfo* pInfo = pScore->get_page_info();
-        CHECK( pInfo != nullptr );
-        CHECK( pInfo && pInfo->is_page_info() == true );
-        CHECK( pInfo && pInfo->get_left_margin() == 1000.0f );
-        CHECK( pInfo && pInfo->get_top_margin() == 1200.0f );
-        CHECK( pInfo && pInfo->get_right_margin() == 3000.0f );
-        CHECK( pInfo && pInfo->get_bottom_margin() == 2500.0f );
-        CHECK( pInfo && pInfo->get_binding_margin() == 4000.0f );
+        CHECK( pInfo && pInfo->get_left_margin_odd() == 5000.0f );
+        CHECK( pInfo && pInfo->get_top_margin_odd() == 1200.0f );
+        CHECK( pInfo && pInfo->get_right_margin_odd() == 3000.0f );
+        CHECK( pInfo && pInfo->get_bottom_margin_odd() == 2500.0f );
+        CHECK( pInfo && pInfo->get_left_margin_even() == 1000.0f );
+        CHECK( pInfo && pInfo->get_top_margin_even() == 1200.0f );
+        CHECK( pInfo && pInfo->get_right_margin_even() == 7000.0f );
+        CHECK( pInfo && pInfo->get_bottom_margin_even() == 2500.0f );
         CHECK( pInfo && pInfo->get_page_width() == 14000.0f );
         CHECK( pInfo && pInfo->get_page_height() == 10000.0f );
         CHECK( pInfo && pInfo->is_portrait() == false );
@@ -8507,11 +8475,14 @@ SUITE(LdpAnalyserTest)
         ImoPageInfo* pInfo = pDoc->get_page_info();
         CHECK( pInfo != nullptr );
         CHECK( pInfo && pInfo->is_page_info() == true );
-        CHECK( pInfo && pInfo->get_left_margin() == 1000.0f );
-        CHECK( pInfo && pInfo->get_top_margin() == 1200.0f );
-        CHECK( pInfo && pInfo->get_right_margin() == 3000.0f );
-        CHECK( pInfo && pInfo->get_bottom_margin() == 2500.0f );
-        CHECK( pInfo && pInfo->get_binding_margin() == 4000.0f );
+        CHECK( pInfo && pInfo->get_left_margin_odd() == 5000.0f );
+        CHECK( pInfo && pInfo->get_top_margin_odd() == 1200.0f );
+        CHECK( pInfo && pInfo->get_right_margin_odd() == 3000.0f );
+        CHECK( pInfo && pInfo->get_bottom_margin_odd() == 2500.0f );
+        CHECK( pInfo && pInfo->get_left_margin_even() == 1000.0f );
+        CHECK( pInfo && pInfo->get_top_margin_even() == 1200.0f );
+        CHECK( pInfo && pInfo->get_right_margin_even() == 7000.0f );
+        CHECK( pInfo && pInfo->get_bottom_margin_even() == 2500.0f );
         CHECK( pInfo && pInfo->get_page_width() == 14000.0f );
         CHECK( pInfo && pInfo->get_page_height() == 10000.0f );
         CHECK( pInfo && pInfo->is_portrait() == false );

--- a/src/tests/lomse_test_mxl_analyser.cpp
+++ b/src/tests/lomse_test_mxl_analyser.cpp
@@ -1751,6 +1751,473 @@ SUITE(MxlAnalyserTest)
     }
 
 
+    //@ defaults --------------------------------------------------------------
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, MxlAnalyser_defaults_01)
+    {
+        //@01. defaults: scaling parsed ok
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser(errormsg);
+        stringstream expected;
+        parser.parse_text(
+            "<score-partwise version='3.0'>"
+            "<defaults>"
+                "<scaling>"
+                  "<millimeters>6.35</millimeters>"
+                  "<tenths>40</tenths>"
+                "</scaling>"
+            "</defaults>"
+            "<part-list><score-part id='P1'><part-name/></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "<attributes>"
+                "<staves>2</staves>"
+            "</attributes>"
+            "</measure>"
+            "</part></score-partwise>"
+        );
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
+        CHECK( pDoc );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore );
+        CHECK( is_equal_float( pScore->tenths_to_logical(40.0f), 635.0f) );
+//        cout << test_name() << ". LUnits=" << pScore->tenths_to_logical(40.0f) << endl;
+
+        //page has default values (in LUnits)
+        ImoPageInfo* pInfo = pDoc->get_page_info();
+        CHECK( is_equal_float(pInfo->get_left_margin_odd(), 1500.0f) );
+        CHECK( is_equal_float(pInfo->get_right_margin_odd(), 1500.0f) );
+        CHECK( is_equal_float(pInfo->get_top_margin_odd(), 2000.0f) );
+        CHECK( is_equal_float(pInfo->get_bottom_margin_odd(), 2000.0f) );
+        CHECK( is_equal_float(pInfo->get_left_margin_even(), 1500.0f) );
+        CHECK( is_equal_float(pInfo->get_right_margin_even(), 1500.0f) );
+        CHECK( is_equal_float(pInfo->get_top_margin_even(), 2000.0f) );
+        CHECK( is_equal_float(pInfo->get_bottom_margin_even(), 2000.0f) );
+        CHECK( is_equal_float(pInfo->get_page_width(), 21000.0f) ); //DIN A4 (210.0 x 297.0 mm)
+        CHECK( is_equal_float(pInfo->get_page_height(), 29700.0f) );
+
+        delete pRoot;
+    }
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, MxlAnalyser_defaults_02)
+    {
+        //@02. defaults: page-layout parsed ok
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser(errormsg);
+        stringstream expected;
+        parser.parse_text(
+            "<score-partwise version='3.0'>"
+            "<defaults>"
+                "<page-layout>"
+                  "<page-height>1760</page-height>"
+                  "<page-width>1360</page-width>"
+                  "<page-margins type='both'>"
+                    "<left-margin>80</left-margin>"
+                    "<right-margin>100</right-margin>"
+                    "<top-margin>60</top-margin>"
+                    "<bottom-margin>120</bottom-margin>"
+                  "</page-margins>"
+                "</page-layout>"
+            "</defaults>"
+            "<part-list><score-part id='P1'><part-name/></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "<attributes>"
+                "<staves>2</staves>"
+            "</attributes>"
+            "</measure>"
+            "</part></score-partwise>"
+        );
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
+        CHECK( pDoc );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore );
+        CHECK( is_equal_float( pScore->tenths_to_logical(40.0f), 720.0f) );
+//        cout << test_name() << ". LUnits=" << pScore->tenths_to_logical(40.0f) << endl;
+
+        ImoPageInfo* pInfo = pDoc->get_page_info();
+        CHECK( is_equal_float(pInfo->get_left_margin_odd(), 1440.0f) );
+        CHECK( is_equal_float(pInfo->get_right_margin_odd(), 1800.0f) );
+        CHECK( is_equal_float(pInfo->get_top_margin_odd(), 1080.0f) );
+        CHECK( is_equal_float(pInfo->get_bottom_margin_odd(), 2160.0f) );
+        CHECK( is_equal_float(pInfo->get_left_margin_even(), 1440.0f) );
+        CHECK( is_equal_float(pInfo->get_right_margin_even(), 1800.0f) );
+        CHECK( is_equal_float(pInfo->get_top_margin_even(), 1080.0f) );
+        CHECK( is_equal_float(pInfo->get_bottom_margin_even(), 2160.0f) );
+        CHECK( is_equal_float(pInfo->get_page_width(), 24480.0f) );
+        CHECK( is_equal_float(pInfo->get_page_height(), 31680.0f) );
+
+        delete pRoot;
+    }
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, MxlAnalyser_defaults_03)
+    {
+        //@03. defaults: system-layout parsed ok
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser(errormsg);
+        stringstream expected;
+        parser.parse_text(
+            "<score-partwise version='3.0'>"
+            "<defaults>"
+                "<system-layout>"
+                  "<system-margins>"
+                    "<left-margin>80</left-margin>"
+                    "<right-margin>40</right-margin>"
+                  "</system-margins>"
+                  "<system-distance>120</system-distance>"
+                  "<top-system-distance>160</top-system-distance>"
+                "</system-layout>"
+            "</defaults>"
+            "<part-list><score-part id='P1'><part-name/></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "<attributes>"
+                "<staves>2</staves>"
+            "</attributes>"
+            "</measure>"
+            "</part></score-partwise>"
+        );
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
+        CHECK( pDoc );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore );
+        CHECK( is_equal_float( pScore->tenths_to_logical(40.0f), 720.0f) );
+//        cout << test_name() << ". LUnits=" << pScore->tenths_to_logical(40.0f) << endl;
+
+        ImoSystemInfo* pInfo = pScore->get_first_system_info();
+        CHECK( pInfo->is_first() == true );
+        CHECK( is_equal_float(pInfo->get_left_margin(), 1440.0f) );
+        CHECK( is_equal_float(pInfo->get_right_margin(), 720.0f) );
+        CHECK( is_equal_float(pInfo->get_system_distance(), 2160.0f) );
+        CHECK( is_equal_float(pInfo->get_top_system_distance(), 2880.0f) );
+        pInfo = pScore->get_other_system_info();
+        CHECK( pInfo->is_first() == false );
+        CHECK( is_equal_float(pInfo->get_left_margin(), 1440.0f) );
+        CHECK( is_equal_float(pInfo->get_right_margin(), 720.0f) );
+        CHECK( is_equal_float(pInfo->get_system_distance(), 2160.0f) );
+        CHECK( is_equal_float(pInfo->get_top_system_distance(), 2880.0f) );
+
+        delete pRoot;
+    }
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, MxlAnalyser_defaults_04)
+    {
+        //@04. defaults: staff-layout parsed ok
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser(errormsg);
+        stringstream expected;
+        parser.parse_text(
+            "<score-partwise version='3.0'>"
+            "<defaults>"
+                "<staff-layout>"
+                  "<staff-distance>80</staff-distance>"
+                "</staff-layout>"
+            "</defaults>"
+            "<part-list><score-part id='P1'><part-name/></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "<attributes>"
+                "<staves>2</staves>"
+            "</attributes>"
+            "</measure>"
+            "</part></score-partwise>"
+        );
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
+        CHECK( pDoc );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore != nullptr );
+        if (pScore)
+        {
+            CHECK( pScore->get_num_instruments() == 1 );
+            ImoInstrument* pInstr = pScore->get_instrument(0);
+            CHECK( pInstr != nullptr );
+            if (pInstr)
+            {
+                ImoStaffInfo* pInfo = pInstr->get_staff(0);
+                CHECK( is_equal_float( pInfo->get_staff_margin(), 1440.0f) );
+                pInfo = pInstr->get_staff(1);
+                CHECK( is_equal_float( pInfo->get_staff_margin(), 1000.0f) );
+            }
+        }
+
+        delete pRoot;
+    }
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, MxlAnalyser_defaults_05)
+    {
+        //@05. defaults: staff-layout transferred when more staves added
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser(errormsg);
+        stringstream expected;
+        parser.parse_text(
+            "<score-partwise version='3.0'>"
+            "<defaults>"
+                "<staff-layout number='1'>"
+                  "<staff-distance>80</staff-distance>"
+                "</staff-layout>"
+                "<staff-layout number='2'>"
+                  "<staff-distance>120</staff-distance>"
+                "</staff-layout>"
+            "</defaults>"
+            "<part-list><score-part id='P1'><part-name/></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "<attributes>"
+                "<staves>2</staves>"
+            "</attributes>"
+            "</measure>"
+            "</part></score-partwise>"
+        );
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
+        CHECK( pDoc );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore != nullptr );
+        if (pScore)
+        {
+            CHECK( pScore->get_num_instruments() == 1 );
+            ImoInstrument* pInstr = pScore->get_instrument(0);
+            CHECK( pInstr != nullptr );
+            if (pInstr)
+            {
+                ImoStaffInfo* pInfo = pInstr->get_staff(0);
+                CHECK( is_equal_float( pInfo->get_staff_margin(), 1440.0f) );
+                pInfo = pInstr->get_staff(1);
+                CHECK( is_equal_float( pInfo->get_staff_margin(), 2160.0f) );
+            }
+        }
+
+        delete pRoot;
+    }
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, MxlAnalyser_defaults_06)
+    {
+        //@06. defaults: word-font and music-font parsed and transferred
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser(errormsg);
+        stringstream expected;
+        parser.parse_text(
+            "<score-partwise version='3.0'>"
+            "<defaults>"
+                "<music-font font-family='Maestro,engraved' font-size='20.5'/>"
+                "<word-font font-family='Times New Roman' font-size='9'/>"
+            "</defaults>"
+            "<part-list><score-part id='P1'><part-name/></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "<attributes>"
+                "<staves>2</staves>"
+            "</attributes>"
+            "</measure>"
+            "</part></score-partwise>"
+        );
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
+        CHECK( pDoc );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore != nullptr );
+        if (pScore)
+        {
+            ImoStyle* pStyle = pScore->get_default_style();
+            CHECK( pStyle->font_name() == "Times New Roman" );
+            CHECK( is_equal_float(pStyle->font_size(), 9.0f) );
+//            cout << test_name() << ", name='" << pStyle->font_name()
+//                << "', size=" << pStyle->font_size() << endl;
+
+            ImoFontStyleDto* pFont = a.get_music_font();
+            CHECK( pFont );
+            if (pFont)
+            {
+                CHECK( pFont->name == "Maestro,engraved" );
+                CHECK( is_equal_float(pFont->size, 20.5f) );
+//                cout << test_name() << ", name='" << pFont->name
+//                    << "', size=" << pFont->size << endl;
+            }
+        }
+
+        delete pRoot;
+    }
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, MxlAnalyser_defaults_07)
+    {
+        //@07. defaults: lyric-font parsed and transferred. No: number, language
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser(errormsg);
+        stringstream expected;
+        parser.parse_text(
+            "<score-partwise version='3.0'>"
+            "<defaults>"
+                "<lyric-font font-family='ＭＳ ゴシック' font-size='10.25'/>"
+                "<lyric-language xml:lang='ja'/>"
+            "</defaults>"
+            "<part-list><score-part id='P1'><part-name/></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "<attributes>"
+                "<staves>2</staves>"
+            "</attributes>"
+            "</measure>"
+            "</part></score-partwise>"
+        );
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
+        CHECK( pDoc );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore != nullptr );
+        if (pScore)
+        {
+            ImoStyle* pStyle = pScore->find_style("Lyrics");
+            CHECK( pStyle->font_name() == "ＭＳ ゴシック" );
+            CHECK( is_equal_float(pStyle->font_size(), 10.25f) );
+//            cout << test_name() << ", name='" << pStyle->font_name()
+//                << "', size=" << pStyle->font_size() << endl;
+        }
+
+        delete pRoot;
+    }
+
+    TEST_FIXTURE(MxlAnalyserTestFixture, MxlAnalyser_defaults_08)
+    {
+        //@08. defaults: lyric-font for two lines
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser(errormsg);
+        stringstream expected;
+        parser.parse_text(
+            "<score-partwise version='3.0'>"
+            "<defaults>"
+                "<lyric-font number='1' font-family='Book Antiqua' font-size='10'/>"
+                "<lyric-font number='2' font-family='ＭＳ ゴシック' font-size='10.25'/>"
+                "<lyric-language number='1' xml:lang='en'/>"
+                "<lyric-language number='2' xml:lang='ja'/>"
+            "</defaults>"
+            "<part-list><score-part id='P1'><part-name/></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "<attributes>"
+                "<staves>2</staves>"
+            "</attributes>"
+            "</measure>"
+            "</part></score-partwise>"
+        );
+        MyMxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+
+//        cout << test_name() << endl;
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
+        CHECK( pDoc );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore != nullptr );
+        if (pScore)
+        {
+            ImoStyle* pStyle = pScore->find_style("Lyric-1");
+            CHECK( pStyle );
+            if (pStyle)
+            {
+                CHECK( pStyle->font_name() == "Book Antiqua" );
+                CHECK( is_equal_float(pStyle->font_size(), 10.0f) );
+//                cout << test_name() << ", name='" << pStyle->font_name()
+//                    << "', size=" << pStyle->font_size() << endl;
+            }
+            CHECK( pStyle );
+            pStyle = pScore->find_style("Lyric-2");
+            if (pStyle)
+            {
+                CHECK( pStyle->font_name() == "ＭＳ ゴシック" );
+                CHECK( is_equal_float(pStyle->font_size(), 10.25f) );
+//                cout << test_name() << ", name='" << pStyle->font_name()
+//                    << "', size=" << pStyle->font_size() << endl;
+            }
+
+            //languages
+            CHECK( a.get_lyric_language(1) == "en" );
+            CHECK( a.get_lyric_language(2) == "ja" );
+        }
+
+        delete pRoot;
+    }
+
+
     //@ direction -------------------------------------------------------------
 
     TEST_FIXTURE(MxlAnalyserTestFixture, MxlAnalyser_direction_01)


### PR DESCRIPTION
This PR imports the `<defaults>` element, with the exception of the `<concert-score>` element, useless for now, and the `<appearance>` values, also useless for now and because importing them will require to make engraving options not constant and this is not an urgent change.

The main achievements with this PR are:
- Page size and margins are now imported and taken into account. 
- System and staves distance and margins are also imported and taken into account. But, for distances (not for margins), the imported values could be overridden by the layout algorithm if more space was required.
- Font for words is now imported and used for texts.
- Font for lyrics and language for lyrics is now imported and used for lyric lines.
- Font for music is also imported but it is useless as Lomse will, for now, continue using Bravura font.

Imported scores should now properly display lyric lines when using non-Latin languages. For instance, test score 
[Echigo-Jishi.musicxml.txt](https://github.com/lenmus/lomse/files/7204803/Echigo-Jishi.musicxml.txt) from MusicXML test set:

Lomse, before this PR:


![image](https://user-images.githubusercontent.com/5238679/134210552-688988ad-bd72-4707-b46d-99bbb0e5b1d1.png)


Lomse, after this PR:


![image](https://user-images.githubusercontent.com/5238679/134210576-836d2712-b1df-433a-9997-31dbef8172f5.png)



This PR also:

- Adds method `ImoScore::tenths_to_logical(Tenths value)` to provide tenths to LUnits conversion when tenths not referred to an staff. This method will, perhaps in future, replace current method for conversion when no staff involved.
- Paper size and related methods has been removed from ImoScore. They were here by historical reasons but were not used.
- Lomse used a model with three values: left margin, right margin and binding margin. But MusicXML, instead of using a common binding margin, uses a model with four independent values. Also for top and bottom margins MusicXML allows to specify different values for odd and even pages. As MusicXML model is more flexible, and to fully support MusicXML, the Lomse internal model has been changed. Therefore, this PR introduces some backward incompatible changes in Document API: the methods for defining margins have been split into two groups: one for even pages and one for odd pages:
```
//Before this PR:
LUnits page_left_margin() const;
LUnits page_right_margin() const;
LUnits page_top_margin() const;
LUnits page_bottom_margin() const;
void set_page_left_margin(LUnits value);
void set_page_right_margin(LUnits value);
void set_page_top_margin(LUnits value);
void set_page_bottom_margin(LUnits value);

//After this PR:
    //odd pages
LUnits page_left_margin_odd() const;
LUnits page_right_margin_odd() const;
LUnits page_top_margin_odd() const;
LUnits page_bottom_margin_odd() const;
void set_page_left_margin_odd(LUnits value);
void set_page_right_margin_odd(LUnits value);
void set_page_top_margin_odd(LUnits value);
void set_page_bottom_margin_odd(LUnits value);
    //even pages
LUnits page_left_margin_even() const;
LUnits page_right_margin_even() const;
LUnits page_top_margin_even() const;
LUnits page_bottom_margin_even() const;
void set_page_left_margin_even(LUnits value);
void set_page_right_margin_even(LUnits value);
void set_page_top_margin_even(LUnits value);
void set_page_bottom_margin_even(LUnits value);
```

@dmitrio95 Probably you have some MusicXML samples with texts and lyrics in Russian language. If so and it is possible for you, I would appreciate if you could send me a couple of samples, for testing and reference, by PM if you prefer. Thank you!

