### PR TITLE
Fix a crash on engraving a tie if its end note is on the next system

### DIFF
--- a/src/graphic_model/engravers/lomse_tie_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_tie_engraver.cpp
@@ -107,7 +107,7 @@ void TieEngraver::decide_placement()
     {
         if (m_pStartNoteShape->has_stem())
             m_fTieBelowNote = m_pStartNoteShape->is_up();
-        else if (m_pEndNoteShape->has_stem())
+        else if (m_pEndNoteShape && m_pEndNoteShape->has_stem())
             m_fTieBelowNote = m_pEndNoteShape->is_up();
         else
             m_fTieBelowNote = true;     //can go either up or down. I prefer below


### PR DESCRIPTION
Steps to reproduce the crash:
1) Load this score: [tie-next-system-crash.musicxml.txt](https://github.com/lenmus/lomse/files/7318100/tie-next-system-crash.musicxml.txt)
2) Reduce page width so that the notes connected by the tie appear in different systems.
Result: crash.

The issue was introduced by [this change](https://github.com/lenmus/lomse/commit/8f83729ba24673ec2c28d6b5963ca7116490bb47#diff-284f1bfd13108b71e89b9901509fa7cec19e4aaf7a928084a7587fe18698a0e0) in #324. With that change the tie engraver may try to take the second note's stem into account when deciding the tie placement. However if the end note appears on the next system an information about the end note's shape is not yet available to the engraver by the time it needs to create its first shape, so `m_pEndNoteShape` is a null pointer at that point. This PR fixes the crash simply by adding a null pointer check here. A possible alternative solution is to make engravers know about all related object in advance but that would probably require more complex changes, not necessarily required for this case.