### PR TITLE
Fix a crash on fixing a chord-rest collision due to a missing pointer to the chord's base note

### DIFF
--- a/include/lomse_shape_note.h
+++ b/include/lomse_shape_note.h
@@ -151,6 +151,7 @@ public:
 
     //for chords
     inline GmoShapeChordBaseNote* get_base_note_shape() { return m_pBaseNoteShape; }
+    inline void set_base_note_shape(GmoShapeChordBaseNote* pShape) { m_pBaseNoteShape = pShape; }
 
     //used for debug
     void set_notehead_color(Color color);
@@ -163,7 +164,6 @@ protected:
     //for chords
     friend class GmoShapeChordBaseNote;
     inline void set_chord_note_type(int type) { m_chordNoteType = type; }
-    inline void set_base_note_shape(GmoShapeChordBaseNote* pShape) { m_pBaseNoteShape = pShape; }
 
 };
 

--- a/src/graphic_model/engravers/lomse_chord_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_chord_engraver.cpp
@@ -237,6 +237,11 @@ void ChordEngraver::find_reference_notes()
     if (m_pStartNoteData)
         pBaseNoteShape->set_start_note(m_pStartNoteData->pNoteShape);
 
+    //set pointers to the base note
+    for (ChordNoteData* pData : m_notes)
+    {
+        pData->pNoteShape->set_base_note_shape(pBaseNoteShape);
+    }
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/lomse_shape_note.cpp
+++ b/src/graphic_model/lomse_shape_note.cpp
@@ -391,7 +391,6 @@ void GmoShapeChordBaseNote::set_flag_note(GmoShapeNote* pNote)
 {
     m_pFlagNote = pNote;
     pNote->set_chord_note_type(k_chord_note_flag);
-    pNote->set_base_note_shape(this);
     //pNote->set_color( Color(255,0,0) );
 }
 
@@ -400,7 +399,6 @@ void GmoShapeChordBaseNote::set_link_note(GmoShapeNote* pNote)
 {
     m_pLinkNote = pNote;
     pNote->set_chord_note_type(k_chord_note_link);
-    pNote->set_base_note_shape(this);
 }
 
 //---------------------------------------------------------------------------------------
@@ -408,7 +406,6 @@ void GmoShapeChordBaseNote::set_start_note(GmoShapeNote* pNote)
 {
     m_pStartNote = pNote;
     pNote->set_chord_note_type(k_chord_note_start);
-    pNote->set_base_note_shape(this);
 }
 
 //---------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes a crash which happens on engraving this test score: [noterest-collision-fixer-crash.musicxml.txt](https://github.com/lenmus/lomse/files/7534155/noterest-collision-fixer-crash.musicxml.txt)
 
The crash happens at [this line](https://github.com/lenmus/lomse/blob/ca924db18798258d1d3b1e61cb2a4c23c1997442/src/graphic_model/layouters/lomse_noterests_collisions_fixer.cpp#L295) because the collision fixer tries to access the pointer to the chord's base note which is null in this case. This happens because this pointer is set only for some notes in a chord (which are marked as "start", "link" or "flag" notes) and for some notes this pointer may be left unassigned. The proposed fix is to explicitly set the pointer to the base note for all notes in a chord so that the collision fixer or any other parts of the engraving algorithm can always access the base note by that pointer.

To avoid duplication I have also removed `set_base_note_shape()` calls when setting start, link and flag notes for a base note but this is not a necessary part of this patch.