### PR TITLE
Fix bug in chord engraver that causes a crash

### DIFF
--- a/src/graphic_model/engravers/lomse_chord_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_chord_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -1016,9 +1016,10 @@ void BeamedChordHelper::find_applicable_clefs(ImoNote* pBaseNote, ImoNote* pLast
     //updated.
 
     ColStaffObjsEntry* pEntry = pLastNote->get_colstaffobjs_entry();
+    int iInstr = pEntry->num_instrument();
     while(pEntry && pEntry->imo_object() != pBaseNote)
     {
-        if (pEntry->imo_object()->is_clef())
+        if (pEntry->num_instrument() == iInstr && pEntry->imo_object()->is_clef())
         {
             ImoClef* clef = static_cast<ImoClef*>( pEntry->imo_object() );
             int staff = clef->get_staff();


### PR DESCRIPTION
Using [test-score.musicxml.txt](https://github.com/lenmus/lomse/files/7581217/test-score.musicxml.txt)  when going to engrave the chord in second instrument, chord engraver looks for the applicable clef but, incorrectly, finds the clef change in instrument 1 because the method does not check for the clef instrument, and tries to assign the clef to the second staff of instrument 2 that do not exist, causing the crash.

![image](https://user-images.githubusercontent.com/5238679/142867614-4920ff33-549e-4e8d-9c41-a8cdeecd3edf.png)
