### PR TITLE
Engravers receive too many parameters

### DIFF
--- a/include/lomse_accidentals_engraver.h
+++ b/include/lomse_accidentals_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -45,7 +45,7 @@ class GmoShape;
 class ScoreMeter;
 
 //---------------------------------------------------------------------------------------
-class AccidentalsEngraver : public Engraver
+class AccidentalsEngraver : public StaffSymbolEngraver
 {
 protected:
     EAccidentals m_accidentals;
@@ -57,17 +57,17 @@ protected:
 
 public:
     AccidentalsEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                        int iInstr, int iStaff, double fontSize);
+                        int iInstr, int iStaff);
     ~AccidentalsEngraver() {}
 
     GmoShapeAccidentals* create_shape(ImoNote* pNote, UPoint uPos,
-                                      EAccidentals accidentals,
-                                      bool fCautionary=false,
-                                      Color color=Color(0,0,0));
+                                      EAccidentals accidentals, double fontSize,
+                                      bool fCautionary=false, Color color=Color(0,0,0));
 
     //helper, for KeyEngraver or other
     GmoShapeAccidental* create_shape_for_glyph(int iGlyph, UPoint pos, Color color,
-                                               ImoObj* pCreatorImo, ShapeId idx);
+                                               double fontSize, ImoObj* pCreatorImo,
+                                               ShapeId idx);
     static int get_glyph_for(int accidental);
 
 

--- a/include/lomse_articulation_engraver.h
+++ b/include/lomse_articulation_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -45,7 +45,7 @@ class GmoShapeArticulation;
 class VerticalProfile;
 
 //---------------------------------------------------------------------------------------
-class ArticulationEngraver : public Engraver
+class ArticulationEngraver : public AuxObjEngraver
 {
 protected:
     ImoArticulation* m_pArticulation;
@@ -54,12 +54,9 @@ protected:
     bool m_fEnableShiftWhenCollision;
     GmoShape* m_pParentShape;
     GmoShapeArticulation* m_pArticulationShape;
-    int m_idxStaff;
-    VerticalProfile* m_pVProfile;
 
 public:
-    ArticulationEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                    int iInstr, int iStaff, int idxStaff, VerticalProfile* pVProfile);
+    ArticulationEngraver(const EngraverContext& ctx);
     ~ArticulationEngraver() {}
 
     GmoShapeArticulation* create_shape(ImoArticulation* pArticulation, UPoint pos,

--- a/include/lomse_barline_engraver.h
+++ b/include/lomse_barline_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -45,7 +45,7 @@ class GmoShape;
 class ScoreMeter;
 
 //---------------------------------------------------------------------------------------
-class BarlineEngraver : public Engraver
+class BarlineEngraver : public StaffObjEngraver
 {
 public:
     BarlineEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,

--- a/include/lomse_beam_engraver.h
+++ b/include/lomse_beam_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/include/lomse_beam_engraver.h
+++ b/include/lomse_beam_engraver.h
@@ -113,29 +113,13 @@ public:
     ~BeamEngraver();
 
     //implementation of virtual methods from RelObjEngraver
-    void set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                            GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                            int iSystem, int iCol,
-                            LUnits xStaffLeft, LUnits xStaffRight, LUnits yStaffTop,
-                            int idxStaff, VerticalProfile* pVProfile) override;
-    void set_middle_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                             GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                             int iSystem, int iCol,
-                             LUnits xStaffLeft, LUnits xStaffRight, LUnits yStaffTop,
-                             int idxStaff, VerticalProfile* pVProfile) override;
-    void set_end_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                          GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                          int iSystem, int iCol,
-                          LUnits xStaffLeft, LUnits xStaffRight, LUnits yStaffTop,
-                          int idxStaff, VerticalProfile* pVProfile) override;
+    void set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
+    void set_middle_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
+    void set_end_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
 
     //RelObjEngraver mandatory overrides
-    void set_prolog_width(LUnits UNUSED(width)) override {}
-    GmoShape* create_first_or_intermediate_shape(LUnits xStaffLeft, LUnits xStaffRight,
-                                                 LUnits yStaffTop, LUnits prologWidth,
-                                                 VerticalProfile* pVProfile,
-                                                 Color color=Color(0,0,0)) override;
-    GmoShape* create_last_shape(Color color=Color(0,0,0)) override;
+    GmoShape* create_first_or_intermediate_shape(const RelObjEngravingContext& ctx) override;
+    GmoShape* create_last_shape(const RelObjEngravingContext& ctx) override;
 
     //During layout, when more space is added between two staves, all shapes are shifted
     //down to account for the added extra space. If a beam is cross-staff, it is

--- a/include/lomse_chord_engraver.h
+++ b/include/lomse_chord_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/include/lomse_chord_engraver.h
+++ b/include/lomse_chord_engraver.h
@@ -106,21 +106,9 @@ public:
     virtual ~ChordEngraver();
 
     //implementation of virtual methods from RelObjEngraver
-    void set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                            GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                            int iSystem, int iCol,
-                            LUnits xStaffLeft, LUnits xStaffRight, LUnits yTop,
-                            int idxStaff, VerticalProfile* pVProfile) override;
-    void set_middle_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                             GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                             int iSystem, int iCol,
-                             LUnits xStaffLeft, LUnits xStaffRight, LUnits yTop,
-                             int idxStaff, VerticalProfile* pVProfile) override;
-    void set_end_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                          GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                          int iSystem, int iCol,
-                          LUnits xStaffLeft, LUnits xStaffRight, LUnits yTop,
-                          int idxStaff, VerticalProfile* pVProfile) override;
+    void set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
+    void set_middle_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
+    void set_end_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
     int create_shapes(Color color=Color(0,0,0));
 
     void save_applicable_clefs(StaffObjsCursor* pCursor, int iInstr);

--- a/include/lomse_clef_engraver.h
+++ b/include/lomse_clef_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -45,7 +45,7 @@ class GmoShape;
 class ScoreMeter;
 
 //---------------------------------------------------------------------------------------
-class ClefEngraver : public Engraver
+class ClefEngraver : public StaffObjEngraver
 {
 protected:
     int m_nClefType;

--- a/include/lomse_coda_segno_engraver.h
+++ b/include/lomse_coda_segno_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2017. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -44,7 +44,7 @@ class ScoreMeter;
 class GmoShapeCodaSegno;
 
 //---------------------------------------------------------------------------------------
-class CodaSegnoEngraver : public Engraver
+class CodaSegnoEngraver : public AuxObjEngraver
 {
 protected:
     ImoSymbolRepetitionMark* m_pRepetitionMark;
@@ -52,9 +52,7 @@ protected:
     GmoShapeCodaSegno* m_pCodaSegnoShape;
 
 public:
-    CodaSegnoEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                      int iInstr, int iStaff);
-    ~CodaSegnoEngraver() {}
+    CodaSegnoEngraver(const EngraverContext& ctx);
 
     GmoShapeCodaSegno* create_shape(ImoSymbolRepetitionMark* pRepetitionMark, UPoint pos,
                                     Color color=Color(0,0,0),

--- a/include/lomse_dynamics_mark_engraver.h
+++ b/include/lomse_dynamics_mark_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -45,7 +45,7 @@ class GmoShapeDynamicsMark;
 class VerticalProfile;
 
 //---------------------------------------------------------------------------------------
-class DynamicsMarkEngraver : public Engraver
+class DynamicsMarkEngraver : public AuxObjEngraver
 {
 protected:
     ImoDynamicsMark* m_pDynamicsMark;
@@ -53,12 +53,9 @@ protected:
     bool m_fAbove;
     GmoShape* m_pParentShape;
     GmoShapeDynamicsMark* m_pDynamicsMarkShape;
-    int m_idxStaff;
-    VerticalProfile* m_pVProfile;
 
 public:
-    DynamicsMarkEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                    int iInstr, int iStaff, int idxStaff, VerticalProfile* pVProfile);
+    DynamicsMarkEngraver(const EngraverContext& ctx);
     ~DynamicsMarkEngraver() {}
 
     GmoShapeDynamicsMark* create_shape(ImoDynamicsMark* pDynamicsMark, UPoint pos,

--- a/include/lomse_engraver.h
+++ b/include/lomse_engraver.h
@@ -69,7 +69,6 @@ struct EngraverContext
     int iStaff = 0;
     int idxStaff = 0;
 
-//    EngraverContext(LibraryScope& scope) : libraryScope(scope) {}
     EngraverContext(LibraryScope& scope, ScoreMeter* meter, int instr, int staff,
                     int idx, VerticalProfile* vprofile, AuxShapesAlignersSystem* aligner)
         : libraryScope(scope)

--- a/include/lomse_fermata_engraver.h
+++ b/include/lomse_fermata_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -44,7 +44,7 @@ class ScoreMeter;
 class GmoShapeFermata;
 
 //---------------------------------------------------------------------------------------
-class FermataEngraver : public Engraver
+class FermataEngraver : public AuxObjEngraver
 {
 protected:
     ImoFermata* m_pFermata;
@@ -54,8 +54,7 @@ protected:
     GmoShapeFermata* m_pFermataShape;
 
 public:
-    FermataEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                    int iInstr, int iStaff);
+    FermataEngraver(const EngraverContext& ctx);
     ~FermataEngraver() {}
 
     GmoShapeFermata* create_shape(ImoFermata* pFermata, UPoint pos,

--- a/include/lomse_instrument_engraver.h
+++ b/include/lomse_instrument_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/include/lomse_key_engraver.h
+++ b/include/lomse_key_engraver.h
@@ -47,7 +47,7 @@ class ScoreMeter;
 class StaffObjsCursor;
 
 //---------------------------------------------------------------------------------------
-class KeyEngraver : public Engraver
+class KeyEngraver : public StaffObjEngraver
 {
 protected:
     GmoShapeKeySignature* m_pKeyShape;

--- a/include/lomse_line_engraver.h
+++ b/include/lomse_line_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/include/lomse_lyric_engraver.h
+++ b/include/lomse_lyric_engraver.h
@@ -36,7 +36,6 @@
 
 #include <list>
 #include <vector>
-using namespace std;
 
 namespace lomse
 {
@@ -58,8 +57,8 @@ class LyricEngraver : public AuxRelObjEngraver
 protected:
     GmoShapeLyrics* m_pLyricsShape;
     InstrumentEngraver* m_pInstrEngrv;
-    list< pair<ImoLyric*, GmoShape*> > m_lyrics;
-    vector<ShapeBoxInfo*> m_shapesInfo;
+    std::list< std::pair<ImoLyric*, GmoShape*> > m_lyrics;
+    std::vector<ShapeBoxInfo*> m_shapesInfo;
     UPoint m_origin;
     USize m_size;
     bool m_fLyricAbove;
@@ -79,23 +78,11 @@ public:
     ~LyricEngraver();
 
     //implementation of virtual methods from AuxRelObjEngraver
-    void set_start_staffobj(ImoAuxRelObj* pARO, ImoStaffObj* pSO,
-                            GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                            int iSystem, int iCol,
-                            LUnits xStaffLeft, LUnits xStaffRight, LUnits yStaffTop,
-                            int idxStaff, VerticalProfile* pVProfile) override;
-    void set_middle_staffobj(ImoAuxRelObj* pARO, ImoStaffObj* pSO,
-                             GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                             int iSystem, int iCol,
-                             LUnits xStaffLeft, LUnits xStaffRight, LUnits yStaffTop,
-                             int idxStaff, VerticalProfile* pVProfile) override;
-    void set_end_staffobj(ImoAuxRelObj* pARO, ImoStaffObj* pSO,
-                          GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                          int iSystem, int iCol,
-                          LUnits xStaffLeft, LUnits xStaffRight, LUnits yStaffTop,
-                          int idxStaff, VerticalProfile* pVProfile) override;
+    void set_start_staffobj(ImoAuxRelObj* pARO, const AuxObjContext& aoc) override;
+    void set_middle_staffobj(ImoAuxRelObj* pARO, const AuxObjContext& aoc) override;
+    void set_end_staffobj(ImoAuxRelObj* pARO, const AuxObjContext& aoc) override;
 
-    int create_shapes(Color color=Color(0,0,0)) override;
+    int create_shapes(const RelObjEngravingContext& ctx) override;
     int get_num_shapes() override { return m_numShapes; }
     ShapeBoxInfo* get_shape_box_info(int i) override { return m_shapesInfo[i]; }
 

--- a/include/lomse_metronome_engraver.h
+++ b/include/lomse_metronome_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -45,7 +45,7 @@ class ScoreMeter;
 class ImoMetronomeMark;
 
 //---------------------------------------------------------------------------------------
-class MetronomeMarkEngraver : public Engraver
+class MetronomeMarkEngraver : public AuxObjEngraver
 {
 protected:
     GmoShapeMetronomeMark* m_pMainShape;
@@ -55,8 +55,7 @@ protected:
     Color m_color;
 
 public:
-    MetronomeMarkEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                          int iInstr, int iStaff);
+    MetronomeMarkEngraver(const EngraverContext& ctx);
     ~MetronomeMarkEngraver() {}
 
     GmoShape* create_shape(ImoMetronomeMark* pImo, UPoint uPos, Color color=Color(0,0,0));

--- a/include/lomse_note_engraver.h
+++ b/include/lomse_note_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -52,7 +52,7 @@ class StaffObjsCursor;
 class VoiceRelatedShape;
 
 //---------------------------------------------------------------------------------------
-class NoteEngraver : public Engraver
+class NoteEngraver : public StaffObjEngraver
 {
 protected:
     ImoNote* m_pNote;
@@ -133,11 +133,9 @@ protected:
 };
 
 //---------------------------------------------------------------------------------------
-class StemFlagEngraver : public Engraver
+class StemFlagEngraver : public StaffSymbolEngraver
 {
 protected:
-    int m_iInstr;
-    int m_iStaff;
     int m_noteType;
     bool m_fStemDown;
     bool m_fWithFlag;

--- a/include/lomse_octave_shift_engraver.h
+++ b/include/lomse_octave_shift_engraver.h
@@ -74,26 +74,15 @@ public:
                  InstrumentEngraver* pInstrEngrv);
     ~OctaveShiftEngraver() {}
 
-    void set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                            GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                            int iSystem, int iCol,
-                            LUnits xStaffLeft, LUnits xStaffRight, LUnits yTop,
-                            int idxStaff, VerticalProfile* pVProfile) override;
-    void set_end_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                          GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                          int iSystem, int iCol,
-                          LUnits xStaffLeft, LUnits xStaffRight, LUnits yTop,
-                          int idxStaff, VerticalProfile* pVProfile) override;
+    void set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
+    void set_end_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
 
     //RelObjEngraver mandatory overrides
-    void set_prolog_width(LUnits width) override;
-    GmoShape* create_first_or_intermediate_shape(LUnits xStaffLeft, LUnits xStaffRight,
-                                                 LUnits yStaffTop, LUnits prologWidth,
-                                                 VerticalProfile* pVProfile,
-                                                 Color color=Color(0,0,0)) override;
-    GmoShape* create_last_shape(Color color=Color(0,0,0)) override;
+    GmoShape* create_first_or_intermediate_shape(const RelObjEngravingContext& ctx) override;
+    GmoShape* create_last_shape(const RelObjEngravingContext& ctx) override;
 
 protected:
+    void save_context_parameters(const RelObjEngravingContext& ctx);
     void decide_placement();
     inline bool is_end_point_set() { return m_pEndNote != nullptr; }
     GmoShape* create_single_shape();

--- a/include/lomse_octave_shift_engraver.h
+++ b/include/lomse_octave_shift_engraver.h
@@ -50,16 +50,10 @@ class InstrumentEngraver;
 class OctaveShiftEngraver : public RelObjEngraver
 {
 protected:
-    InstrumentEngraver* m_pInstrEngrv;
-    LUnits m_uStaffTop;         //top line of current system
-    LUnits m_uStaffLeft;
-    LUnits m_uStaffRight;
-
     int m_numShapes;
     ImoOctaveShift* m_pOctaveShift;
     GmoShape* m_pShapeNumeral;
     GmoShapeOctaveShift* m_pMainShape;
-    LUnits m_uPrologWidth;
 
     ImoNote* m_pStartNote;
     ImoNote* m_pEndNote;
@@ -70,8 +64,7 @@ protected:
     UPoint m_points[2];  //points for a shape (top-left, bottom-left).
 
 public:
-    OctaveShiftEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                 InstrumentEngraver* pInstrEngrv);
+    OctaveShiftEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter);
     ~OctaveShiftEngraver() {}
 
     void set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
@@ -82,7 +75,6 @@ public:
     GmoShape* create_last_shape(const RelObjEngravingContext& ctx) override;
 
 protected:
-    void save_context_parameters(const RelObjEngravingContext& ctx);
     void decide_placement();
     inline bool is_end_point_set() { return m_pEndNote != nullptr; }
     GmoShape* create_single_shape();

--- a/include/lomse_ornament_engraver.h
+++ b/include/lomse_ornament_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021 All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -44,7 +44,7 @@ class ScoreMeter;
 class GmoShapeOrnament;
 
 //---------------------------------------------------------------------------------------
-class OrnamentEngraver : public Engraver
+class OrnamentEngraver : public AuxObjEngraver
 {
 protected:
     ImoOrnament* m_pOrnament;
@@ -54,8 +54,7 @@ protected:
     GmoShapeOrnament* m_pOrnamentShape;
 
 public:
-    OrnamentEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                     int iInstr, int iStaff);
+    OrnamentEngraver(const EngraverContext& ctx);
     ~OrnamentEngraver() {}
 
     GmoShapeOrnament* create_shape(ImoOrnament* pOrnament, UPoint pos,

--- a/include/lomse_pedal_engraver.h
+++ b/include/lomse_pedal_engraver.h
@@ -67,15 +67,9 @@ protected:
 class PedalLineEngraver : public RelObjEngraver
 {
 protected:
-
-    InstrumentEngraver* m_pInstrEngrv = nullptr;
-    LUnits m_uStaffTop = 0.0f;  //top line of current system
-    LUnits m_uStaffLeft = 0.0f;
-
     int m_numShapes = 0;
     ImoPedalLine* m_pPedal = nullptr;
     bool m_fPedalAbove = false;
-    LUnits m_uPrologWidth = 0.0f;
 
     ImoDirection* m_pStartDirection = nullptr;
     GmoShapeInvisible* m_pStartDirectionShape = nullptr;
@@ -90,8 +84,7 @@ protected:
     LUnits m_lineY = 0;
 
 public:
-    PedalLineEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                 InstrumentEngraver* pInstrEngrv);
+    PedalLineEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter);
 
     void set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
     void set_middle_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
@@ -102,7 +95,6 @@ public:
     GmoShape* create_last_shape(const RelObjEngravingContext& ctx) override;
 
 protected:
-    void save_context_parameters(const RelObjEngravingContext& ctx);
     double determine_font_size() override;
 
     void decide_placement();

--- a/include/lomse_pedal_engraver.h
+++ b/include/lomse_pedal_engraver.h
@@ -48,14 +48,10 @@ class InstrumentEngraver;
 class VerticalProfile;
 
 //---------------------------------------------------------------------------------------
-class PedalMarkEngraver : public Engraver
+class PedalMarkEngraver : public AuxObjEngraver
 {
-    int m_idxStaff;
-    VerticalProfile* m_pVProfile;
-
 public:
-    PedalMarkEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                      int iInstr, int iStaff, int idxStaff, VerticalProfile* pVProfile);
+    PedalMarkEngraver(const EngraverContext& ctx);
 
     GmoShapePedalGlyph* create_shape(ImoPedalMark* pPedalMark, UPoint pos,
                                      const Color& color,

--- a/include/lomse_pedal_engraver.h
+++ b/include/lomse_pedal_engraver.h
@@ -97,31 +97,16 @@ public:
     PedalLineEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
                  InstrumentEngraver* pInstrEngrv);
 
-    void set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                            GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                            int iSystem, int iCol,
-                            LUnits xStaffLeft, LUnits xStaffRight, LUnits yTop,
-                            int idxStaff, VerticalProfile* pVProfile) override;
-    void set_middle_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                             GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                             int iSystem, int iCol,
-                             LUnits xStaffLeft, LUnits xStaffRight, LUnits yTop,
-                             int idxStaff, VerticalProfile* pVProfile) override;
-    void set_end_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                          GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                          int iSystem, int iCol,
-                          LUnits xStaffLeft, LUnits xStaffRight, LUnits yTop,
-                          int idxStaff, VerticalProfile* pVProfile) override;
+    void set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
+    void set_middle_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
+    void set_end_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
 
     //RelObjEngraver mandatory overrides
-    void set_prolog_width(LUnits width) override;
-    GmoShape* create_first_or_intermediate_shape(LUnits xStaffLeft, LUnits xStaffRight,
-                                                 LUnits yStaffTop, LUnits prologWidth,
-                                                 VerticalProfile* pVProfile,
-                                                 Color color=Color(0,0,0)) override;
-    GmoShape* create_last_shape(Color color=Color(0,0,0)) override;
+    GmoShape* create_first_or_intermediate_shape(const RelObjEngravingContext& ctx) override;
+    GmoShape* create_last_shape(const RelObjEngravingContext& ctx) override;
 
 protected:
+    void save_context_parameters(const RelObjEngravingContext& ctx);
     double determine_font_size() override;
 
     void decide_placement();

--- a/include/lomse_rest_engraver.h
+++ b/include/lomse_rest_engraver.h
@@ -47,7 +47,7 @@ class GmoShapeBeam;
 class VoiceRelatedShape;
 
 //---------------------------------------------------------------------------------------
-class RestEngraver : public Engraver
+class RestEngraver : public StaffObjEngraver
 {
 protected:
     int m_restType;

--- a/include/lomse_score_layouter.h
+++ b/include/lomse_score_layouter.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -46,34 +46,35 @@ namespace lomse
 {
 
 //forward declarations
+class ColumnBreaker;
+class ColumnsBuilder;
+class ColumnStorage;
 class FontStorage;
-class GraphicModel;
-class ImoClef;
-class ImoContentObj;
-class ImoScore;
-class ImoStaffObj;
-class ImoAuxObj;
-class ImoInstrument;
-class ImoRelObj;
-class ImoAuxRelObj;
-class ImoTimeSignature;
 class GmoBoxScorePage;
 class GmoBoxSlice;
-class GmoBoxSystem;
 class GmoBoxSliceInstr;
-class InstrumentEngraver;
-class SystemLayouter;
-class StaffObjsCursor;
+class GmoBoxSystem;
 class GmoShape;
-class ScoreMeter;
-class ColumnStorage;
-class ColumnsBuilder;
-class ShapesCreator;
-class ScoreStub;
-class ColumnBreaker;
-class PartsEngraver;
-class LyricEngraver;
 class GmoShapeNote;
+class GraphicModel;
+class ImoAuxObj;
+class ImoAuxRelObj;
+class ImoClef;
+class ImoContentObj;
+class ImoInstrument;
+class ImoRelObj;
+class ImoScore;
+class ImoStaffObj;
+class ImoTimeSignature;
+class InstrumentEngraver;
+class LyricEngraver;
+class PartsEngraver;
+class ScoreMeter;
+class ScoreStub;
+class ShapesCreator;
+class StaffObjsCursor;
+class SystemLayouter;
+class SystemLayoutScope;
 
 //---------------------------------------------------------------------------------------
 // helper struct to store data about lyric shapes pending to be completed with details
@@ -387,9 +388,8 @@ public:
     GmoShape* create_staffobj_shape(ImoStaffObj* pSO, int iInstr, int iStaff,
                                     UPoint pos, ImoClef* pClef=nullptr, int octaveShift=0,
                                     unsigned flags=0, StaffObjsCursor* pCursor=nullptr);
-    GmoShape* create_auxobj_shape(ImoAuxObj* pAO, int iInstr, int iStaff,
-                                  int idxStaff, VerticalProfile* pVProfile,
-                                  GmoShape* pParentShape);
+    GmoShape* create_auxobj_shape(ImoAuxObj* pAO, const AuxObjContext& aoc,
+                                  const SystemLayoutScope& systemScope);
     GmoShape* create_invisible_shape(ImoObj* pSO, int iInstr, int iStaff,
                                      UPoint uPos, LUnits width);
 

--- a/include/lomse_shape_text.h
+++ b/include/lomse_shape_text.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/include/lomse_slur_engraver.h
+++ b/include/lomse_slur_engraver.h
@@ -50,14 +50,10 @@ class InstrumentEngraver;
 class SlurEngraver : public RelObjEngraver
 {
 protected:
-    InstrumentEngraver* m_pInstrEngrv;
-    LUnits m_uStaffTop = 0.0f;         //top line of current system
-
     int m_numShapes = 0;
     ImoSlur* m_pSlur = nullptr;
     bool m_fSlurBelow = false;
     bool m_fSlurForGraces = false;
-    LUnits m_uPrologWidth = 0.0f;
 
     ImoNote* m_pStartNote = nullptr;
     ImoNote* m_pEndNote = nullptr;
@@ -76,8 +72,7 @@ protected:
     UPoint m_dbgPeak;                   //debug: bezier point at peak point
 
 public:
-    SlurEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                 InstrumentEngraver* pInstrEngrv);
+    SlurEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter);
     ~SlurEngraver() {}
 
     void set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;

--- a/include/lomse_slur_engraver.h
+++ b/include/lomse_slur_engraver.h
@@ -80,24 +80,12 @@ public:
                  InstrumentEngraver* pInstrEngrv);
     ~SlurEngraver() {}
 
-    void set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                            GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                            int iSystem, int iCol,
-                            LUnits xStaffLeft, LUnits xStaffRight, LUnits yTop,
-                            int idxStaff, VerticalProfile* pVProfile) override;
-    void set_end_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                          GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                          int iSystem, int iCol,
-                          LUnits xStaffLeft, LUnits xStaffRight, LUnits yTop,
-                          int idxStaff, VerticalProfile* pVProfile) override;
+    void set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
+    void set_end_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
 
     //RelObjEngraver mandatory overrides
-    void set_prolog_width(LUnits width) override;
-    GmoShape* create_first_or_intermediate_shape(LUnits xStaffLeft, LUnits xStaffRight,
-                                                 LUnits yStaffTop, LUnits prologWidth,
-                                                 VerticalProfile* pVProfile,
-                                                 Color color=Color(0,0,0)) override;
-    GmoShape* create_last_shape(Color color=Color(0,0,0)) override;
+    GmoShape* create_first_or_intermediate_shape(const RelObjEngravingContext& ctx) override;
+    GmoShape* create_last_shape(const RelObjEngravingContext& ctx) override;
 
 protected:
     void decide_placement();

--- a/include/lomse_system_layouter.h
+++ b/include/lomse_system_layouter.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -92,9 +92,9 @@ protected:
 public:
     explicit SystemLayoutScope(SystemLayouter* pParent);
 
-    inline SystemLayouter* get_system_layouter() { return m_pSystemLayouter; }
-    inline VerticalProfile* get_vertical_profile() { return m_pVProfile; }
-    inline AuxShapesAlignersSystem* get_aux_shapes_aligner() { return m_pCurrentAuxShapesAligner; }
+    inline SystemLayouter* get_system_layouter() const { return m_pSystemLayouter; }
+    inline VerticalProfile* get_vertical_profile() const { return m_pVProfile; }
+    inline AuxShapesAlignersSystem* get_aux_shapes_aligner() const { return m_pCurrentAuxShapesAligner; }
 
 
 protected:

--- a/include/lomse_system_layouter.h
+++ b/include/lomse_system_layouter.h
@@ -36,6 +36,7 @@
 #include "lomse_logger.h"
 #include "lomse_injectors.h"
 #include "lomse_spacing_algorithm.h"
+#include "lomse_aux_shapes_aligner.h"
 
 #include <list>
 #include <memory>
@@ -46,13 +47,13 @@ namespace lomse
 
 //forward declarations
 class ColumnStorage;
+class EngraversMap;
 class GmoBoxSlice;
 class GmoBoxSliceInstr;
 class GmoShape;
 class GmoBoxSystem;
 class GmoShapeBeam;
 class GmoShapeNote;
-class AuxShapesAlignersSystem;
 class ImoAuxObj;
 class ImoRelObj;
 class ImoAuxRelObj;
@@ -63,22 +64,58 @@ class ImoStaffObj;
 class InstrumentEngraver;
 class PartsEngraver;
 class ScoreLayouter;
+class ScoreLayoutScope;
 class ScoreMeter;
 class ShapesCreator;
-class EngraversMap;
 class SpacingAlgorithm;
 class SystemLayouter;
 class TypeMeasureInfo;
 class VerticalProfile;
-struct PendingAuxObj;
+
+struct AuxObjContext;
 enum EAuxShapesAlignmentScope : int;
 
-//---------------------------------------------------------------------------------------
+
+//=======================================================================================
+// Helper class to store global information whose scope is the layout of one system.
+// It facilitates access to this global information and simplifies the list of parameters
+// to pass to all classes and methods related to layout
+//
+class SystemLayoutScope
+{
+protected:
+    SystemLayouter*     m_pSystemLayouter = nullptr;
+    VerticalProfile*    m_pVProfile = nullptr;
+    AuxShapesAlignersSystem* m_pCurrentAuxShapesAligner = nullptr;
+//    SystemLayoutOptions* m_pOptions = nullptr;
+
+public:
+    explicit SystemLayoutScope(SystemLayouter* pParent);
+
+    inline SystemLayouter* get_system_layouter() { return m_pSystemLayouter; }
+    inline VerticalProfile* get_vertical_profile() { return m_pVProfile; }
+    inline AuxShapesAlignersSystem* get_aux_shapes_aligner() { return m_pCurrentAuxShapesAligner; }
+
+
+protected:
+    //instantiation
+    friend class SystemLayouter;
+    void set_current_aux_shapes_aligner(AuxShapesAlignersSystem* p) { m_pCurrentAuxShapesAligner = p; }
+    void set_vertical_profile(VerticalProfile* p) { m_pVProfile = p; }
+
+};
+
+
+//=======================================================================================
 // SystemLayouter: algorithm to layout a system
-//---------------------------------------------------------------------------------------
+//
 class SystemLayouter
 {
 protected:
+    ScoreLayoutScope& m_scoreLayoutScope;
+    SystemLayoutScope m_systemLayoutScope;
+
+    //variables stored in ScoreLayoutScope
     ScoreLayouter*  m_pScoreLyt;
     LibraryScope&   m_libraryScope;
     ScoreMeter*     m_pScoreMeter;
@@ -86,37 +123,34 @@ protected:
     EngraversMap&   m_engravers;
     ShapesCreator*  m_pShapesCreator;
     PartsEngraver*  m_pPartsEngraver;
-    VerticalProfile* m_pVProfile;
+    SpacingAlgorithm* m_pSpAlgorithm;
 
-    LUnits m_uPrologWidth;
-    GmoBoxSystem* m_pBoxSystem;
-    LUnits m_yMin;
-    LUnits m_yMax;
+    //variables used in SystemLayoutScope but owned by this SystemLayouter
+    std::unique_ptr<VerticalProfile> m_pVProfile;
+    std::unique_ptr<AuxShapesAlignersSystem> m_curAuxShapesAligner;
 
-    int m_iSystem;
-    int m_iFirstCol;
-    int m_iLastCol;
-    LUnits m_uFreeSpace;    //free space available on current system
+
+    GmoBoxSystem* m_pBoxSystem = nullptr;
+
+    LUnits m_uPrologWidth = 0.0f;
+    LUnits m_yMin = 0.0f;
+    LUnits m_yMax = 0.0f;
+    LUnits m_uFreeSpace = 0.0f;    //free space available on current system
+
+    int m_iSystem = 0;
+    int m_iFirstCol = 0;
+    int m_iLastCol = 0;
+    int m_barlinesInfo = 0;     //info about barlines at end of this system
+    int m_constrains = 0;
     UPoint m_pagePos;
-    bool m_fFirstColumnInSystem;
-    int m_barlinesInfo;     //info about barlines at end of this system
+    bool m_fFirstColumnInSystem = true;
 
     //prolog shapes waiting to be added to slice staff box
     std::list< std::tuple<GmoShape*, int, int> > m_prologShapes;
 
-    SpacingAlgorithm* m_pSpAlgorithm;
-    int m_constrains;
-
-    std::unique_ptr<AuxShapesAlignersSystem> m_curAuxShapesAligner;
 
 public:
-    SystemLayouter(ScoreLayouter* pScoreLyt, LibraryScope& libraryScope,
-                   ScoreMeter* pScoreMeter, ImoScore* pScore,
-                   EngraversMap& engravers,
-                   ShapesCreator* pShapesCreator,
-                   PartsEngraver* pPartsEngraver,
-                   SpacingAlgorithm* pSpAlgorithm);
-    ~SystemLayouter();
+    explicit SystemLayouter(ScoreLayoutScope& scoreLayoutScope);
 
     GmoBoxSystem* create_system_box(LUnits left, LUnits top, LUnits width, LUnits height);
     void engrave_system(LUnits indent, int iFirstCol, int iLastCol, UPoint pos,
@@ -176,15 +210,15 @@ protected:
     bool measure_number_must_be_displayed(int policy, TypeMeasureInfo* pInfo,
                                           bool fFirstNumberInSystem);
 
-    void engrave_attached_object(ImoObj* pAR, PendingAuxObj* pPAO, int iSystem);
-    void engrave_not_finished_relobj(ImoRelObj* pRO, PendingAuxObj* pPAO, int iSystem);
-    void engrave_not_finished_lyrics(const std::string& tag, PendingAuxObj* pPAO, int iSystem);
+    void engrave_attached_object(ImoObj* pAR, const AuxObjContext& aoc, int iSystem);
+    void engrave_not_finished_relobj(ImoRelObj* pRO, const AuxObjContext& aoc);
+    void engrave_not_finished_lyrics(const std::string& tag, const AuxObjContext& aoc);
 
     void add_last_rel_shape_to_model(GmoShape* pShape, ImoRelObj* pRO, int layer,
                                      int iCol, int iInstr, int iStaff, int idxStaff);
     void delete_rel_obj_engraver(ImoRelObj* pRO);
     void add_lyrics_shapes_to_model(const std::string& tag, int layer, bool fLast,
-                                    int iStaff, int idxStaff);
+                                    int iInstr, int iStaff);
     void add_aux_shape_to_model(GmoShape* pShape, int layer, int iCol, int iInstr,
                                 int iStaff, int idxStaff);
 

--- a/include/lomse_technical_engraver.h
+++ b/include/lomse_technical_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -44,7 +44,7 @@ class ScoreMeter;
 class GmoShapeTechnical;
 
 //---------------------------------------------------------------------------------------
-class TechnicalEngraver : public Engraver
+class TechnicalEngraver : public AuxObjEngraver
 {
 protected:
     ImoTechnical* m_pTechnical;
@@ -54,9 +54,7 @@ protected:
     GmoShapeTechnical* m_pTechnicalShape;
 
 public:
-    TechnicalEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                      int iInstr, int iStaff);
-    ~TechnicalEngraver() {}
+    TechnicalEngraver(const EngraverContext& ctx);
 
     GmoShapeTechnical* create_shape(ImoTechnical* pTechnical, UPoint pos,
                                     Color color=Color(0,0,0),

--- a/include/lomse_text_engraver.h
+++ b/include/lomse_text_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/include/lomse_tie_engraver.h
+++ b/include/lomse_tie_engraver.h
@@ -66,27 +66,16 @@ public:
     TieEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter);
     ~TieEngraver() {}
 
-    void set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                            GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                            int iSystem, int iCol,
-                            LUnits xStaffLeft, LUnits xStaffRight, LUnits yTop,
-                            int idxStaff, VerticalProfile* pVProfile) override;
-    void set_end_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                          GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                          int iSystem, int iCol,
-                          LUnits xStaffLeft, LUnits xStaffRight, LUnits yTop,
-                          int idxStaff, VerticalProfile* pVProfile) override;
+    void set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
+    void set_end_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
 
     //RelObjEngraver mandatory overrides
-    void set_prolog_width(LUnits width) override { m_uStaffLeft += width; }
-    GmoShape* create_first_or_intermediate_shape(LUnits xStaffLeft, LUnits xStaffRight,
-                                                 LUnits yStaffTop, LUnits prologWidth,
-                                                 VerticalProfile* pVProfile,
-                                                 Color color=Color(0,0,0)) override;
-    GmoShape* create_last_shape(Color color=Color(0,0,0)) override;
+    GmoShape* create_first_or_intermediate_shape(const RelObjEngravingContext& ctx) override;
+    GmoShape* create_last_shape(const RelObjEngravingContext& ctx) override;
 
 
 protected:
+    void save_context_parameters(const RelObjEngravingContext& ctx);
     void decide_placement();
     inline bool is_end_point_set() { return m_pEndNoteShape != nullptr; }
     GmoShape* create_single_shape();

--- a/include/lomse_tie_engraver.h
+++ b/include/lomse_tie_engraver.h
@@ -49,9 +49,6 @@ class VoiceRelatedShape;
 class TieEngraver : public RelObjEngraver
 {
 protected:
-    LUnits m_uStaffTop;             //top line of current staff
-    LUnits m_uStaffLeft;
-    LUnits m_uStaffRight;
     ImoTie* m_pTie;
     int m_numShapes;
     ImoNote* m_pStartNote;
@@ -75,7 +72,6 @@ public:
 
 
 protected:
-    void save_context_parameters(const RelObjEngravingContext& ctx);
     void decide_placement();
     inline bool is_end_point_set() { return m_pEndNoteShape != nullptr; }
     GmoShape* create_single_shape();

--- a/include/lomse_time_engraver.h
+++ b/include/lomse_time_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -45,7 +45,7 @@ class ScoreMeter;
 class ImoTimeSignature;
 
 //---------------------------------------------------------------------------------------
-class TimeEngraver : public Engraver
+class TimeEngraver : public StaffObjEngraver
 {
 protected:
     GmoShapeTimeSignature* m_pTimeShape;

--- a/include/lomse_tuplet_engraver.h
+++ b/include/lomse_tuplet_engraver.h
@@ -71,29 +71,13 @@ public:
     ~TupletEngraver();
 
     //implementation of virtual methods from RelObjEngraver
-    void set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                            GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                            int iSystem, int iCol,
-                            LUnits xStaffLeft, LUnits xStaffRight, LUnits yStaffTop,
-                            int idxStaff, VerticalProfile* pVProfile) override;
-    void set_middle_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                             GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                             int iSystem, int iCol,
-                             LUnits xStaffLeft, LUnits xStaffRight, LUnits yStaffTop,
-                             int idxStaff, VerticalProfile* pVProfile) override;
-    void set_end_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                          GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                          int iSystem, int iCol,
-                          LUnits xStaffLeft, LUnits xStaffRight, LUnits yStaffTop,
-                          int idxStaff, VerticalProfile* pVProfile) override;
+    void set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
+    void set_middle_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
+    void set_end_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
 
     //RelObjEngraver mandatory overrides
-    void set_prolog_width(LUnits UNUSED(width)) override {}
-    GmoShape* create_first_or_intermediate_shape(LUnits xStaffLeft, LUnits xStaffRight,
-                                                 LUnits yStaffTop, LUnits prologWidth,
-                                                 VerticalProfile* pVProfile,
-                                                 Color color=Color(0,0,0)) override;
-    GmoShape* create_last_shape(Color color=Color(0,0,0)) override;
+    GmoShape* create_first_or_intermediate_shape(const RelObjEngravingContext& ctx) override;
+    GmoShape* create_last_shape(const RelObjEngravingContext& ctx) override;
 
 protected:
     void add_text_shape();

--- a/include/lomse_vertical_profile.h
+++ b/include/lomse_vertical_profile.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -96,8 +96,6 @@ protected:
 	std::vector<PointsRow*> m_xMax;         //ptrs. to max x pos vector for each staff
 	std::vector<PointsRow*> m_xMin;         //ptrs. to min x pos vector for each staff
 
-    AuxShapesAlignersSystem* m_pCurrentAuxShapesAligner = nullptr;
-
 public:
     VerticalProfile(LUnits xStart, LUnits xEnd, int numStaves);
     virtual ~VerticalProfile();
@@ -123,11 +121,6 @@ public:
     */
     std::vector<UPoint> get_min_profile_points(LUnits xStart, LUnits xEnd, int idxStaff);
     std::vector<UPoint> get_max_profile_points(LUnits xStart, LUnits xEnd, int idxStaff);
-
-    //auxiliary shapes aligner
-    void set_current_aux_shapes_aligner(AuxShapesAlignersSystem* p) { m_pCurrentAuxShapesAligner = p; }
-    AuxShapesAlignersSystem* get_current_aux_shapes_aligner() { return m_pCurrentAuxShapesAligner; }
-    AuxShapesAligner* get_current_aux_shapes_aligner(int staff, bool fAbove);
 
     //debug
     void dbg_add_vertical_profile_shapes(GmoBox* pBoxSystem);

--- a/include/lomse_volta_engraver.h
+++ b/include/lomse_volta_engraver.h
@@ -63,32 +63,21 @@ protected:
     GmoShapeBarline* m_pStartBarlineShape;
     GmoShapeBarline* m_pStopBarlineShape;
 
-    LUnits m_uPrologWidth = 0.0f;
+//    LUnits m_uPrologWidth = 0.0f;
 
 public:
     VoltaBracketEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter);
     ~VoltaBracketEngraver() {}
 
-    void set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                            GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                            int iSystem, int iCol,
-                            LUnits xStaffLeft, LUnits xStaffRight, LUnits yTop,
-                            int idxStaff, VerticalProfile* pVProfile) override;
-    void set_end_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                          GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                          int iSystem, int iCol,
-                          LUnits xStaffLeft, LUnits xStaffRight, LUnits yTop,
-                          int idxStaff, VerticalProfile* pVProfile) override;
+    void set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
+    void set_end_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
 
     //RelObjEngraver mandatory overrides
-    void set_prolog_width(LUnits width) override { m_uStaffLeft += width; }
-    GmoShape* create_first_or_intermediate_shape(LUnits xStaffLeft, LUnits xStaffRight,
-                                                 LUnits yStaffTop, LUnits prologWidth,
-                                                 VerticalProfile* pVProfile,
-                                                 Color color=Color(0,0,0)) override;
-    GmoShape* create_last_shape(Color color=Color(0,0,0)) override;
+    GmoShape* create_first_or_intermediate_shape(const RelObjEngravingContext& ctx) override;
+    GmoShape* create_last_shape(const RelObjEngravingContext& ctx) override;
 
 protected:
+    void save_context_parameters(const RelObjEngravingContext& ctx);
     inline bool is_end_point_set() { return m_pStopBarline != nullptr; }
     GmoShape* create_single_shape();
     GmoShape* create_first_shape();

--- a/include/lomse_volta_engraver.h
+++ b/include/lomse_volta_engraver.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -50,24 +50,17 @@ class ImoStyle;
 class VoltaBracketEngraver : public RelObjEngraver
 {
 protected:
-    int m_numShapes;
+    int m_numShapes = 0;
     bool m_fFirstShapeAtSystemStart = false;
-    ImoVoltaBracket* m_pVolta;
-    LUnits m_uStaffTop;             //top line of current staff
-    LUnits m_uStaffLeft;
-    LUnits m_uStaffRight;
-    ImoStyle* m_pStyle;
-
-    ImoBarline* m_pStartBarline;
-    ImoBarline* m_pStopBarline;
-    GmoShapeBarline* m_pStartBarlineShape;
-    GmoShapeBarline* m_pStopBarlineShape;
-
-//    LUnits m_uPrologWidth = 0.0f;
+    ImoVoltaBracket* m_pVolta = nullptr;
+    ImoStyle* m_pStyle = nullptr;
+    ImoBarline* m_pStartBarline = nullptr;
+    ImoBarline* m_pStopBarline = nullptr;
+    GmoShapeBarline* m_pStartBarlineShape = nullptr;
+    GmoShapeBarline* m_pStopBarlineShape = nullptr;
 
 public:
     VoltaBracketEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter);
-    ~VoltaBracketEngraver() {}
 
     void set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
     void set_end_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
@@ -77,7 +70,6 @@ public:
     GmoShape* create_last_shape(const RelObjEngravingContext& ctx) override;
 
 protected:
-    void save_context_parameters(const RelObjEngravingContext& ctx);
     inline bool is_end_point_set() { return m_pStopBarline != nullptr; }
     GmoShape* create_single_shape();
     GmoShape* create_first_shape();

--- a/include/lomse_wedge_engraver.h
+++ b/include/lomse_wedge_engraver.h
@@ -73,26 +73,15 @@ public:
                  InstrumentEngraver* pInstrEngrv);
     ~WedgeEngraver() {}
 
-    void set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                            GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                            int iSystem, int iCol,
-                            LUnits xStaffLeft, LUnits xStaffRight, LUnits yTop,
-                            int idxStaff, VerticalProfile* pVProfile) override;
-    void set_end_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                          GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                          int iSystem, int iCol,
-                          LUnits xStaffLeft, LUnits xStaffRight, LUnits yTop,
-                          int idxStaff, VerticalProfile* pVProfile) override;
+    void set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
+    void set_end_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
 
     //RelObjEngraver mandatory overrides
-    void set_prolog_width(LUnits width) override;
-    GmoShape* create_first_or_intermediate_shape(LUnits xStaffLeft, LUnits xStaffRight,
-                                                 LUnits yStaffTop, LUnits prologWidth,
-                                                 VerticalProfile* pVProfile,
-                                                 Color color=Color(0,0,0)) override;
-    GmoShape* create_last_shape(Color color=Color(0,0,0)) override;
+    GmoShape* create_first_or_intermediate_shape(const RelObjEngravingContext& ctx) override;
+    GmoShape* create_last_shape(const RelObjEngravingContext& ctx) override;
 
 protected:
+    void save_context_parameters(const RelObjEngravingContext& ctx);
     void decide_placement();
     GmoShape* create_first_shape();
     GmoShape* create_intermediate_shape();

--- a/include/lomse_wedge_engraver.h
+++ b/include/lomse_wedge_engraver.h
@@ -51,26 +51,21 @@ class VerticalProfile;
 class WedgeEngraver : public RelObjEngraver
 {
 protected:
-    InstrumentEngraver* m_pInstrEngrv;
-    LUnits m_uStaffTop;         //top line of current system
-
-    int m_numShapes;
-    ImoWedge* m_pWedge;
-    bool m_fWedgeAbove;
+    int m_numShapes = 0;
+    ImoWedge* m_pWedge = nullptr;
+    bool m_fWedgeAbove = false;
     bool m_fFirstShapeAtSystemStart = false;
-    LUnits m_uPrologWidth;
 
-    ImoDirection* m_pStartDirection;
-    ImoDirection* m_pEndDirection;
-    GmoShapeInvisible* m_pStartDirectionShape;
-    GmoShapeInvisible* m_pEndDirectionShape;
+    ImoDirection* m_pStartDirection = nullptr;
+    ImoDirection* m_pEndDirection = nullptr;
+    GmoShapeInvisible* m_pStartDirectionShape = nullptr;
+    GmoShapeInvisible* m_pEndDirectionShape = nullptr;
 
     UPoint m_points[4];    //points for wedge
-    LUnits m_yAlignBaseline; //baseline coordinate for aligning with dynamic marks
+    LUnits m_yAlignBaseline = 0.0f; //baseline coordinate for aligning with dynamic marks
 
 public:
-    WedgeEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                 InstrumentEngraver* pInstrEngrv);
+    WedgeEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter);
     ~WedgeEngraver() {}
 
     void set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc) override;
@@ -81,7 +76,6 @@ public:
     GmoShape* create_last_shape(const RelObjEngravingContext& ctx) override;
 
 protected:
-    void save_context_parameters(const RelObjEngravingContext& ctx);
     void decide_placement();
     GmoShape* create_first_shape();
     GmoShape* create_intermediate_shape();

--- a/src/graphic_model/engravers/lomse_accidentals_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_accidentals_engraver.cpp
@@ -44,13 +44,12 @@ namespace lomse
 // AccidentalsEngraver implementation
 //---------------------------------------------------------------------------------------
 AccidentalsEngraver::AccidentalsEngraver(LibraryScope& libraryScope,
-                                         ScoreMeter* pScoreMeter, int iInstr, int iStaff,
-                                         double fontSize)
-    : Engraver(libraryScope, pScoreMeter, iInstr, iStaff)
+                                         ScoreMeter* pScoreMeter, int iInstr, int iStaff)
+    : StaffSymbolEngraver(libraryScope, pScoreMeter, iInstr, iStaff)
     , m_accidentals(k_no_accidentals)
     , m_fCautionary(false)
     , m_pContainer(nullptr)
-    , m_fontSize(fontSize)
+    , m_fontSize(12.0)
     , m_pNote(nullptr)
     , m_numGlyphs(0)
 {
@@ -60,6 +59,7 @@ AccidentalsEngraver::AccidentalsEngraver(LibraryScope& libraryScope,
 GmoShapeAccidentals* AccidentalsEngraver::create_shape(ImoNote* pNote,
                                                        UPoint uPos,
                                                        EAccidentals accidentals,
+                                                       double fontSize,
                                                        bool fCautionary,
                                                        Color color)
 {
@@ -67,6 +67,7 @@ GmoShapeAccidentals* AccidentalsEngraver::create_shape(ImoNote* pNote,
     m_fCautionary = fCautionary;
     m_pNote = pNote;
     m_color = color;
+    m_fontSize = fontSize;
 
     find_glyphs();
     create_container_shape(uPos);
@@ -183,7 +184,7 @@ void AccidentalsEngraver::add_glyphs_to_container_shape(UPoint pos)
     for (int i=0; i < m_numGlyphs; ++i)
     {
         GmoShapeAccidental* pShape =
-                create_shape_for_glyph(m_glyphs[i], pos, m_color, m_pNote, 0);
+                create_shape_for_glyph(m_glyphs[i], pos, m_color, m_fontSize, m_pNote, 0);
 
         add_voice(pShape);
         m_pContainer->add(pShape);
@@ -195,13 +196,14 @@ void AccidentalsEngraver::add_glyphs_to_container_shape(UPoint pos)
 //---------------------------------------------------------------------------------------
 GmoShapeAccidental* AccidentalsEngraver::create_shape_for_glyph(int iGlyph, UPoint pos,
                                                                 Color color,
+                                                                double fontSize,
                                                                 ImoObj* pCreatorImo,
                                                                 ShapeId idx)
 {
     pos.y += glyph_offset(iGlyph);
 
     return LOMSE_NEW GmoShapeAccidental(pCreatorImo, idx, iGlyph, pos, color,
-                                        m_libraryScope, m_fontSize);
+                                        m_libraryScope, fontSize);
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/engravers/lomse_articulation_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_articulation_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -44,19 +44,19 @@ namespace lomse
 //---------------------------------------------------------------------------------------
 // ArticulationEngraver implementation
 //---------------------------------------------------------------------------------------
-ArticulationEngraver::ArticulationEngraver(LibraryScope& libraryScope,
-                                           ScoreMeter* pScoreMeter,
-                                           int UNUSED(iInstr), int UNUSED(iStaff),
-                                           int idxStaff, VerticalProfile* pVProfile)
-    : Engraver(libraryScope, pScoreMeter)
+//ArticulationEngraver::ArticulationEngraver(LibraryScope& libraryScope,
+//                                           ScoreMeter* pScoreMeter,
+//                                           int iInstr, int iStaff,
+//                                           int idxStaff, VerticalProfile* pVProfile)
+ArticulationEngraver::ArticulationEngraver(const EngraverContext& ctx)
+    : AuxObjEngraver(ctx)
+//    : AuxObjEngraver(libraryScope, pScoreMeter, iInstr, iStaff)
     , m_pArticulation(nullptr)
     , m_placement(k_placement_default)
     , m_fAbove(true)
     , m_fEnableShiftWhenCollision(false)
     , m_pParentShape(nullptr)
     , m_pArticulationShape(nullptr)
-    , m_idxStaff(idxStaff)
-    , m_pVProfile(pVProfile)
 {
 }
 

--- a/src/graphic_model/engravers/lomse_barline_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_barline_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -46,7 +46,7 @@ namespace lomse
 //---------------------------------------------------------------------------------------
 BarlineEngraver::BarlineEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
                                  int iInstr, InstrumentEngraver* pInstrEngrv)
-    : Engraver(libraryScope, pScoreMeter, iInstr)
+    : StaffObjEngraver(libraryScope, pScoreMeter, iInstr, 0)
     , m_pBarlineShape(nullptr)
     , m_pInstrEngrv(pInstrEngrv)
 {
@@ -54,7 +54,7 @@ BarlineEngraver::BarlineEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreM
 
 //---------------------------------------------------------------------------------------
 BarlineEngraver::BarlineEngraver(LibraryScope& libraryScope)
-    : Engraver(libraryScope, nullptr)
+    : StaffObjEngraver(libraryScope, nullptr, 0, 0)
     , m_pBarlineShape(nullptr)
     , m_pInstrEngrv(nullptr)
 {

--- a/src/graphic_model/engravers/lomse_beam_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_beam_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/src/graphic_model/engravers/lomse_beam_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_beam_engraver.cpp
@@ -72,45 +72,27 @@ BeamEngraver::~BeamEngraver()
 }
 
 //---------------------------------------------------------------------------------------
-void BeamEngraver::set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                                      GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                                      int UNUSED(iSystem), int UNUSED(iCol),
-                                      LUnits UNUSED(xStaffLeft), LUnits UNUSED(xStaffRight),
-                                      LUnits UNUSED(yStaffTop),
-                                      int idxStaff, VerticalProfile* pVProfile)
+void BeamEngraver::set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc)
 {
-    m_iInstr = iInstr;
-    m_iStaff = iStaff;
+    m_iInstr = aoc.iInstr;
+    m_iStaff = aoc.iStaff;
+    m_idxStaff = aoc.idxStaff;
+
     m_pBeam = dynamic_cast<ImoBeam*>(pRO);
 
-    add_note_rest(pSO, pStaffObjShape);
-
-    m_idxStaff = idxStaff;
-    m_pVProfile = pVProfile;
+    add_note_rest(aoc.pSO, aoc.pStaffObjShape);
 }
 
 //---------------------------------------------------------------------------------------
-void BeamEngraver::set_middle_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* pSO,
-                                       GmoShape* pStaffObjShape, int UNUSED(iInstr),
-                                       int UNUSED(iStaff), int UNUSED(iSystem),
-                                       int UNUSED(iCol), LUnits UNUSED(xStaffLeft),
-                                       LUnits UNUSED(xStaffRight), LUnits UNUSED(yStaffTop),
-                                       int UNUSED(idxStaff),
-                                       VerticalProfile* UNUSED(pVProfile))
+void BeamEngraver::set_middle_staffobj(ImoRelObj* UNUSED(pRO), const AuxObjContext& aoc)
 {
-    add_note_rest(pSO, pStaffObjShape);
+    add_note_rest(aoc.pSO, aoc.pStaffObjShape);
 }
 
 //---------------------------------------------------------------------------------------
-void BeamEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* pSO,
-                                    GmoShape* pStaffObjShape, int UNUSED(iInstr),
-                                    int UNUSED(iStaff), int UNUSED(iSystem),
-                                    int UNUSED(iCol), LUnits UNUSED(xStaffLeft),
-                                    LUnits UNUSED(xStaffRight), LUnits UNUSED(yStaffTop),
-                                    int UNUSED(idxStaff),
-                                    VerticalProfile* UNUSED(pVProfile))
+void BeamEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), const AuxObjContext& aoc)
 {
-    add_note_rest(pSO, pStaffObjShape);
+    add_note_rest(aoc.pSO, aoc.pStaffObjShape);
 }
 
 //---------------------------------------------------------------------------------------
@@ -140,18 +122,17 @@ void BeamEngraver::add_note_rest(ImoStaffObj* pSO, GmoShape* pStaffObjShape)
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* BeamEngraver::create_first_or_intermediate_shape(LUnits UNUSED(xStaffLeft),
-                                LUnits UNUSED(xStaffRight), LUnits UNUSED(yStaffTop),
-                                LUnits UNUSED(prologWidth),
-                                VerticalProfile* UNUSED(pVProfile), Color color)
+GmoShape* BeamEngraver::create_first_or_intermediate_shape(const RelObjEngravingContext& ctx)
 {
     //TODO: It has been assumed that a beam cannot be split. This has to be revised
-    m_color = color;
+    m_color = ctx.color;
+    m_pVProfile = ctx.pVProfile;
+
     return nullptr;
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* BeamEngraver::create_last_shape(Color color)
+GmoShape* BeamEngraver::create_last_shape(const RelObjEngravingContext& ctx)
 {
     if (!m_numNotes)
     {
@@ -159,7 +140,9 @@ GmoShape* BeamEngraver::create_last_shape(Color color)
         return nullptr;
     }
 
-    m_color = color;
+    m_color = ctx.color;
+    m_pVProfile = ctx.pVProfile;
+
     decide_stems_direction();
     determine_number_of_beam_levels();
 

--- a/src/graphic_model/engravers/lomse_chord_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_chord_engraver.cpp
@@ -79,45 +79,30 @@ ChordEngraver::~ChordEngraver()
 }
 
 //---------------------------------------------------------------------------------------
-void ChordEngraver::set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                                       GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                                       int UNUSED(iSystem), int UNUSED(iCol),
-                                       LUnits UNUSED(xStaffLeft), LUnits UNUSED(xStaffRight),
-                                       LUnits UNUSED(yTop),
-                                       int idxStaff, VerticalProfile* UNUSED(pVProfile))
+void ChordEngraver::set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc)
 {
-    m_iInstr = iInstr;
-    m_iStaff = iStaff;
-    m_idxStaff = idxStaff;
+    m_iInstr = aoc.iInstr;
+    m_iStaff = aoc.iStaff;
+    m_idxStaff = aoc.idxStaff;
+
     m_pChord = dynamic_cast<ImoChord*>(pRO);
 
-    add_note(pSO, pStaffObjShape, idxStaff);
+    add_note(aoc.pSO, aoc.pStaffObjShape, aoc.idxStaff);
 }
 
 //---------------------------------------------------------------------------------------
-void ChordEngraver::set_middle_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* pSO,
-                                        GmoShape* pStaffObjShape, int UNUSED(iInstr),
-                                        int UNUSED(iStaff), int UNUSED(iSystem),
-                                        int UNUSED(iCol), LUnits UNUSED(xStaffLeft),
-                                        LUnits UNUSED(xStaffRight), LUnits UNUSED(yTop),
-                                        int idxStaff, VerticalProfile* UNUSED(pVProfile))
+void ChordEngraver::set_middle_staffobj(ImoRelObj* UNUSED(pRO), const AuxObjContext& aoc)
 {
-    add_note(pSO, pStaffObjShape, idxStaff);
+    add_note(aoc.pSO, aoc.pStaffObjShape, aoc.idxStaff);
 }
 
 //---------------------------------------------------------------------------------------
-void ChordEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* pSO,
-                                     GmoShape* pStaffObjShape, int UNUSED(iInstr),
-                                     int UNUSED(iStaff), int UNUSED(iSystem),
-                                     int UNUSED(iCol), LUnits UNUSED(xStaffLeft),
-                                     LUnits UNUSED(xStaffRight), LUnits UNUSED(yTop),
-                                     int idxStaff, VerticalProfile* UNUSED(pVProfile))
+void ChordEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), const AuxObjContext& aoc)
 {
-    add_note(pSO, pStaffObjShape, idxStaff);
+    add_note(aoc.pSO, aoc.pStaffObjShape, aoc.idxStaff);
     if (m_numNotesMissing != 0)
     {
-        LOMSE_LOG_ERROR("[ChordEngraver::set_end_staffobj] Num added notes doesn't match expected notes in chord");
-        throw runtime_error("[ChordEngraver::set_end_staffobj] Num added notes doesn't match expected notes in chord");
+        LOMSE_LOG_ERROR("Num added notes doesn't match expected notes in chord");
     }
 }
 

--- a/src/graphic_model/engravers/lomse_clef_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_clef_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -46,7 +46,7 @@ namespace lomse
 //---------------------------------------------------------------------------------------
 ClefEngraver::ClefEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
                            int iInstr, int iStaff)
-    : Engraver(libraryScope, pScoreMeter, iInstr, iStaff)
+    : StaffObjEngraver(libraryScope, pScoreMeter, iInstr, iStaff)
     , m_nClefType(0)
     , m_symbolSize(0)
     , m_iGlyph(0)
@@ -56,7 +56,7 @@ ClefEngraver::ClefEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
 
 //---------------------------------------------------------------------------------------
 ClefEngraver::ClefEngraver(LibraryScope& libraryScope)
-    : Engraver(libraryScope, nullptr)
+    : StaffObjEngraver(libraryScope, nullptr, 0, 0)
     , m_nClefType(0)
     , m_symbolSize(0)
     , m_iGlyph(0)
@@ -153,7 +153,7 @@ int ClefEngraver::find_glyph(int clefType)
 //---------------------------------------------------------------------------------------
 double ClefEngraver::determine_font_size()
 {
-    double fontSize = Engraver::determine_font_size();
+    double fontSize = StaffSymbolEngraver::determine_font_size();
 
     switch (m_symbolSize)
     {

--- a/src/graphic_model/engravers/lomse_coda_segno_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_coda_segno_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -42,9 +42,8 @@ namespace lomse
 //---------------------------------------------------------------------------------------
 // CodaSegnoEngraver implementation
 //---------------------------------------------------------------------------------------
-CodaSegnoEngraver::CodaSegnoEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                                     int UNUSED(iInstr), int UNUSED(iStaff))
-    : Engraver(libraryScope, pScoreMeter)
+CodaSegnoEngraver::CodaSegnoEngraver(const EngraverContext& ctx)
+    : AuxObjEngraver(ctx)
     , m_pRepetitionMark(nullptr)
     , m_pParentShape(nullptr)
     , m_pCodaSegnoShape(nullptr)

--- a/src/graphic_model/engravers/lomse_dynamics_mark_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_dynamics_mark_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -45,18 +45,13 @@ namespace lomse
 //---------------------------------------------------------------------------------------
 // DynamicsMarkEngraver implementation
 //---------------------------------------------------------------------------------------
-DynamicsMarkEngraver::DynamicsMarkEngraver(LibraryScope& libraryScope,
-                                           ScoreMeter* pScoreMeter,
-                                           int UNUSED(iInstr), int UNUSED(iStaff),
-                                           int idxStaff, VerticalProfile* pVProfile)
-    : Engraver(libraryScope, pScoreMeter)
+DynamicsMarkEngraver::DynamicsMarkEngraver(const EngraverContext& ctx)
+    : AuxObjEngraver(ctx)
     , m_pDynamicsMark(nullptr)
     , m_placement(k_placement_default)
     , m_fAbove(true)
     , m_pParentShape(nullptr)
     , m_pDynamicsMarkShape(nullptr)
-    , m_idxStaff(idxStaff)
-    , m_pVProfile(pVProfile)
 {
 }
 
@@ -85,9 +80,7 @@ GmoShapeDynamicsMark* DynamicsMarkEngraver::create_shape(ImoDynamicsMark* pDynam
     }
 
     shift_shape_if_collision();
-
-    if (AuxShapesAligner* pAligner = m_pVProfile->get_current_aux_shapes_aligner(m_idxStaff, m_fAbove))
-        pAligner->add_shape(m_pDynamicsMarkShape);
+    add_to_aux_shapes_aligner(m_pDynamicsMarkShape, m_fAbove);
 
     return m_pDynamicsMarkShape;
 }

--- a/src/graphic_model/engravers/lomse_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -38,33 +38,81 @@
 namespace lomse
 {
 
-//---------------------------------------------------------------------------------------
+//=======================================================================================
 // Engraver implementation
-//---------------------------------------------------------------------------------------
+//=======================================================================================
 LUnits Engraver::tenths_to_logical(Tenths value) const
 {
-    return m_pMeter->tenths_to_logical(value, m_iInstr, m_iStaff);
+    return m_pMeter->tenths_to_logical(value);
 }
 
-double Engraver::determine_font_size()
-{
-    return 21.0 * m_pMeter->line_spacing_for_instr_staff(m_iInstr, m_iStaff) / 180.0;
-}
+////---------------------------------------------------------------------------------------
+//double Engraver::determine_font_size()
+//{
+//    return 21.0 * m_pMeter->line_spacing_for_instr_staff(m_iInstr, m_iStaff) / 180.0;
+//}
 
+//---------------------------------------------------------------------------------------
 void Engraver::add_user_shift(ImoContentObj* pImo, UPoint* pos)
 {
     (*pos).x += tenths_to_logical(pImo->get_user_location_x());
     (*pos).y += tenths_to_logical(pImo->get_user_location_y());
 }
 
-//---------------------------------------------------------------------------------------
-// RelObjEngraver implementation
-//---------------------------------------------------------------------------------------
-void RelObjEngraver::add_to_aux_shapes_aligner(GmoShape* pShape, bool fAboveStaff)
+
+//=======================================================================================
+// StaffSymbolEngraver implementation
+//=======================================================================================
+LUnits StaffSymbolEngraver::tenths_to_logical(Tenths value) const
 {
-    AuxShapesAligner* pAligner = m_pVProfile->get_current_aux_shapes_aligner(m_idxStaff, fAboveStaff);
+    return m_pMeter->tenths_to_logical(value, m_iInstr, m_iStaff);
+}
+
+//---------------------------------------------------------------------------------------
+double StaffSymbolEngraver::determine_font_size()
+{
+    return 21.0 * m_pMeter->line_spacing_for_instr_staff(m_iInstr, m_iStaff) / 180.0;
+}
+
+////---------------------------------------------------------------------------------------
+//void StaffSymbolEngraver::add_user_shift(ImoContentObj* pImo, UPoint* pos)
+//{
+//    (*pos).x += tenths_to_logical(pImo->get_user_location_x());
+//    (*pos).y += tenths_to_logical(pImo->get_user_location_y());
+//}
+
+//=======================================================================================
+// AuxObjEngraver implementation
+//=======================================================================================
+void AuxObjEngraver::add_to_aux_shapes_aligner(GmoShape* pShape, bool fAboveStaff) const
+{
+    AuxShapesAligner* pAligner = get_aux_shapes_aligner(m_idxStaff, fAboveStaff);
     if (pAligner)
         pAligner->add_shape(pShape);
+}
+
+//---------------------------------------------------------------------------------------
+AuxShapesAligner* AuxObjEngraver::get_aux_shapes_aligner(int idxStaff, bool fAbove) const
+{
+    return m_pAuxShapesAligner ? &m_pAuxShapesAligner->get_aligner(idxStaff, fAbove) : nullptr;
+}
+
+
+//=======================================================================================
+// RelObjEngraver implementation
+//=======================================================================================
+void RelObjEngraver::add_to_aux_shapes_aligner(GmoShape* pShape, bool fAboveStaff) const
+{
+    //AuxShapesAligner* pAligner = m_pVProfile->get_current_aux_shapes_aligner(m_idxStaff, fAboveStaff);
+    AuxShapesAligner* pAligner = get_aux_shapes_aligner(m_idxStaff, fAboveStaff);
+    if (pAligner)
+        pAligner->add_shape(pShape);
+}
+
+//---------------------------------------------------------------------------------------
+AuxShapesAligner* RelObjEngraver::get_aux_shapes_aligner(int idxStaff, bool fAbove) const
+{
+    return m_pAuxShapesAligner ? &m_pAuxShapesAligner->get_aligner(idxStaff, fAbove) : nullptr;
 }
 
 

--- a/src/graphic_model/engravers/lomse_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_engraver.cpp
@@ -101,6 +101,19 @@ AuxShapesAligner* AuxObjEngraver::get_aux_shapes_aligner(int idxStaff, bool fAbo
 //=======================================================================================
 // RelObjEngraver implementation
 //=======================================================================================
+void RelObjEngraver::save_context_parameters(const RelObjEngravingContext& ctx)
+{
+    m_color = ctx.color;
+    m_uStaffLeft = ctx.xStaffLeft;
+    m_uStaffRight = ctx.xStaffRight;
+    m_uStaffTop = ctx.yStaffTop;
+    m_pVProfile = ctx.pVProfile;
+    m_pAuxShapesAligner = ctx.pAuxShapesAligner;
+    m_pInstrEngrv = ctx.pInstrEngrv;
+    m_uPrologWidth = ctx.prologWidth;
+}
+
+//---------------------------------------------------------------------------------------
 void RelObjEngraver::add_to_aux_shapes_aligner(GmoShape* pShape, bool fAboveStaff) const
 {
     //AuxShapesAligner* pAligner = m_pVProfile->get_current_aux_shapes_aligner(m_idxStaff, fAboveStaff);

--- a/src/graphic_model/engravers/lomse_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_engraver.cpp
@@ -46,12 +46,6 @@ LUnits Engraver::tenths_to_logical(Tenths value) const
     return m_pMeter->tenths_to_logical(value);
 }
 
-////---------------------------------------------------------------------------------------
-//double Engraver::determine_font_size()
-//{
-//    return 21.0 * m_pMeter->line_spacing_for_instr_staff(m_iInstr, m_iStaff) / 180.0;
-//}
-
 //---------------------------------------------------------------------------------------
 void Engraver::add_user_shift(ImoContentObj* pImo, UPoint* pos)
 {
@@ -73,13 +67,6 @@ double StaffSymbolEngraver::determine_font_size()
 {
     return 21.0 * m_pMeter->line_spacing_for_instr_staff(m_iInstr, m_iStaff) / 180.0;
 }
-
-////---------------------------------------------------------------------------------------
-//void StaffSymbolEngraver::add_user_shift(ImoContentObj* pImo, UPoint* pos)
-//{
-//    (*pos).x += tenths_to_logical(pImo->get_user_location_x());
-//    (*pos).y += tenths_to_logical(pImo->get_user_location_y());
-//}
 
 //=======================================================================================
 // AuxObjEngraver implementation

--- a/src/graphic_model/engravers/lomse_fermata_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_fermata_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -43,9 +43,8 @@ namespace lomse
 //---------------------------------------------------------------------------------------
 // FermataEngraver implementation
 //---------------------------------------------------------------------------------------
-FermataEngraver::FermataEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                                 int UNUSED(iInstr), int UNUSED(iStaff))
-    : Engraver(libraryScope, pScoreMeter)
+FermataEngraver::FermataEngraver(const EngraverContext& ctx)
+    : AuxObjEngraver(ctx)
     , m_pFermata(nullptr)
     , m_placement(k_placement_default)
     , m_fAbove(true)

--- a/src/graphic_model/engravers/lomse_instrument_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_instrument_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/src/graphic_model/engravers/lomse_key_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_key_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -46,7 +46,7 @@ namespace lomse
 //---------------------------------------------------------------------------------------
 KeyEngraver::KeyEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
                          int iInstr, int iStaff)
-    : Engraver(libraryScope, pScoreMeter, iInstr, iStaff)
+    : StaffObjEngraver(libraryScope, pScoreMeter, iInstr, iStaff)
     , m_pKeyShape(nullptr)
     , m_nKeyType(k_clef_undefined)
     , m_fontSize(0.0)
@@ -199,9 +199,9 @@ UPoint KeyEngraver::add_accidental(int acc, UPoint uPos, Tenths yShift)
     int iGlyph = AccidentalsEngraver::get_glyph_for(acc);
     LUnits y = uPos.y + tenths_to_logical(yShift);
 
-    AccidentalsEngraver engrv(m_libraryScope, m_pMeter, m_iInstr, m_iStaff, m_fontSize);
-    GmoShape* pSA = engrv.create_shape_for_glyph(iGlyph, UPoint(uPos.x, y),
-                                                 m_color, m_pCreatorImo, 0);
+    AccidentalsEngraver engrv(m_libraryScope, m_pMeter, m_iInstr, m_iStaff);
+    GmoShape* pSA = engrv.create_shape_for_glyph(iGlyph, UPoint(uPos.x, y), m_color,
+                                                 m_fontSize, m_pCreatorImo, 0);
     m_pKeyShape->add(pSA);
     uPos.x += pSA->get_width();
 
@@ -232,7 +232,7 @@ UPoint KeyEngraver::add_accidentals(int iStart, int iEnd, UPoint uPos, int iGlyp
     const int flats[7] = { k_step_B, k_step_E, k_step_A, k_step_D, k_step_G, k_step_C, k_step_F };
 
     LUnits x = uPos.x;
-    AccidentalsEngraver engrv(m_libraryScope, m_pMeter, m_iInstr, m_iStaff, m_fontSize);
+    AccidentalsEngraver engrv(m_libraryScope, m_pMeter, m_iInstr, m_iStaff);
 
     for (int i=iStart-1; i < iEnd; i++)
     {
@@ -243,8 +243,8 @@ UPoint KeyEngraver::add_accidentals(int iStart, int iEnd, UPoint uPos, int iGlyp
         Tenths shift = compute_accidental_shift(step, accOctave, pClef, fAtSharpPosition);
         LUnits y = uPos.y + tenths_to_logical(shift);
 
-        GmoShape* pSA = engrv.create_shape_for_glyph(iGlyph, UPoint(x, y),
-                                                     m_color, m_pCreatorImo, 0);
+        GmoShape* pSA = engrv.create_shape_for_glyph(iGlyph, UPoint(x, y), m_color,
+                                                     m_fontSize, m_pCreatorImo, 0);
         m_pKeyShape->add(pSA);
         x += pSA->get_width() + space;
     }

--- a/src/graphic_model/engravers/lomse_line_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_line_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/src/graphic_model/engravers/lomse_lyric_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_lyric_engraver.cpp
@@ -74,79 +74,52 @@ LyricEngraver::~LyricEngraver()
 }
 
 //---------------------------------------------------------------------------------------
-void LyricEngraver::set_start_staffobj(ImoAuxRelObj* pARO, ImoStaffObj* UNUSED(pSO),
-                                       GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                                       int iSystem, int iCol, LUnits xStaffLeft,
-                                       LUnits xStaffRight, LUnits yStaffTop,
-                                       int idxStaff, VerticalProfile* pVProfile)
+void LyricEngraver::set_start_staffobj(ImoAuxRelObj* pARO, const AuxObjContext& aoc)
 {
-    m_iInstr = iInstr;
-    m_iStaff = iStaff;
+    m_iInstr = aoc.iInstr;
+    m_iStaff = aoc.iStaff;
+    m_idxStaff = aoc.idxStaff;
+
     ImoLyric* pLyric = dynamic_cast<ImoLyric*>(pARO);
-    m_lyrics.push_back( make_pair(pLyric, pStaffObjShape) );
+    m_lyrics.push_back( make_pair(pLyric, aoc.pStaffObjShape) );
 
-    ShapeBoxInfo* pInfo = LOMSE_NEW ShapeBoxInfo(nullptr, iSystem, iCol, iInstr);
+    ShapeBoxInfo* pInfo =
+            LOMSE_NEW ShapeBoxInfo(nullptr, aoc.iCol, aoc.iInstr, aoc.iStaff, aoc.idxStaff);
     m_shapesInfo.push_back(pInfo);
-
-    m_uStaffLeft = xStaffLeft;
-    m_uStaffRight = xStaffRight;
-    m_uStaffTop = yStaffTop;
-
-    m_idxStaff = idxStaff;
-    m_pVProfile = pVProfile;
 }
 
 //---------------------------------------------------------------------------------------
-void LyricEngraver::set_middle_staffobj(ImoAuxRelObj* pARO, ImoStaffObj* UNUSED(pSO),
-                                        GmoShape* pStaffObjShape, int iInstr,
-                                        int UNUSED(iStaff), int iSystem, int iCol,
-                                        LUnits xStaffLeft, LUnits xStaffRight,
-                                        LUnits yStaffTop, int idxStaff,
-                                        VerticalProfile* pVProfile)
-
+void LyricEngraver::set_middle_staffobj(ImoAuxRelObj* pARO, const AuxObjContext& aoc)
 {
     ImoLyric* pLyric = dynamic_cast<ImoLyric*>(pARO);
-    m_lyrics.push_back( make_pair(pLyric, pStaffObjShape) );
+    m_lyrics.push_back( make_pair(pLyric, aoc.pStaffObjShape) );
 
-    ShapeBoxInfo* pInfo = LOMSE_NEW ShapeBoxInfo(nullptr, iSystem, iCol, iInstr);
+    ShapeBoxInfo* pInfo =
+            LOMSE_NEW ShapeBoxInfo(nullptr, aoc.iCol, aoc.iInstr, aoc.iStaff, aoc.idxStaff);
     m_shapesInfo.push_back(pInfo);
-
-    m_uStaffLeft = xStaffLeft;
-    m_uStaffRight = xStaffRight;
-    m_uStaffTop = yStaffTop;
-
-    m_idxStaff = idxStaff;
-    m_pVProfile = pVProfile;
 }
 
 //---------------------------------------------------------------------------------------
-void LyricEngraver::set_end_staffobj(ImoAuxRelObj* pARO, ImoStaffObj* UNUSED(pSO),
-                                     GmoShape* pStaffObjShape, int iInstr,
-                                     int UNUSED(iStaff), int iSystem, int iCol,
-                                     LUnits xStaffLeft, LUnits xStaffRight, LUnits yStaffTop,
-                                     int idxStaff, VerticalProfile* pVProfile)
-
+void LyricEngraver::set_end_staffobj(ImoAuxRelObj* pARO, const AuxObjContext& aoc)
 {
     ImoLyric* pLyric = static_cast<ImoLyric*>(pARO);
-    m_lyrics.push_back( make_pair(pLyric, pStaffObjShape) );
+    m_lyrics.push_back( make_pair(pLyric, aoc.pStaffObjShape) );
 
-    ShapeBoxInfo* pInfo = LOMSE_NEW ShapeBoxInfo(nullptr, iSystem, iCol, iInstr);
+    ShapeBoxInfo* pInfo =
+            LOMSE_NEW ShapeBoxInfo(nullptr, aoc.iCol, aoc.iInstr, aoc.iStaff, aoc.idxStaff);
     m_shapesInfo.push_back(pInfo);
-
-    m_uStaffLeft = xStaffLeft;
-    m_uStaffRight = xStaffRight;
-    m_uStaffTop = yStaffTop;
-
-    m_idxStaff = idxStaff;
-    m_pVProfile = pVProfile;
 }
 
 //---------------------------------------------------------------------------------------
-int LyricEngraver::create_shapes(Color color)
+int LyricEngraver::create_shapes(const RelObjEngravingContext& ctx)
 {
     //Create the shapes for one system
 
-    m_color = color;
+    m_color = ctx.color;
+    m_uStaffLeft = ctx.xStaffLeft;
+    m_uStaffRight = ctx.xStaffRight;
+    m_uStaffTop = ctx.yStaffTop;
+    m_pVProfile = ctx.pVProfile;
 
     //get xLeft and xRight for first and last notes
     LUnits xLeft = m_uStaffLeft;

--- a/src/graphic_model/engravers/lomse_metronome_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_metronome_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -45,10 +45,8 @@ namespace lomse
 //---------------------------------------------------------------------------------------
 // MetronomeMarkEngraver implementation
 //---------------------------------------------------------------------------------------
-MetronomeMarkEngraver::MetronomeMarkEngraver(LibraryScope& libraryScope,
-                                             ScoreMeter* pScoreMeter, int iInstr,
-                                             int iStaff)
-    : Engraver(libraryScope, pScoreMeter, iInstr, iStaff)
+MetronomeMarkEngraver::MetronomeMarkEngraver(const EngraverContext& ctx)
+    : AuxObjEngraver(ctx)
     , m_pMainShape(nullptr)
     , m_fontSize(0.0)
     , m_pCreatorImo(nullptr)

--- a/src/graphic_model/engravers/lomse_note_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_note_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -57,7 +57,7 @@ namespace lomse
 //=======================================================================================
 NoteEngraver::NoteEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
                            EngraversMap* pEngravers, int iInstr, int iStaff)
-    : Engraver(libraryScope, pScoreMeter, iInstr, iStaff)
+    : StaffObjEngraver(libraryScope, pScoreMeter, iInstr, iStaff)
     , m_pNote(nullptr)
     , m_clefType(k_clef_undefined)
     , m_octaveShift(0)
@@ -116,7 +116,7 @@ GmoShape* NoteEngraver::create_shape(ImoNote* pNote, int clefType, int octaveShi
 //---------------------------------------------------------------------------------------
 double NoteEngraver::determine_font_size()
 {
-    double fontSize = Engraver::determine_font_size();
+    double fontSize = StaffSymbolEngraver::determine_font_size();
 
     switch (m_symbolSize)
     {
@@ -348,9 +348,9 @@ void NoteEngraver::add_shapes_for_accidentals_if_required()
 {
     if (m_acc != k_no_accidentals)
     {
-        AccidentalsEngraver engrv(m_libraryScope, m_pMeter, m_iInstr, m_iStaff, m_fontSize);
+        AccidentalsEngraver engrv(m_libraryScope, m_pMeter, m_iInstr, m_iStaff);
         m_pAccidentalsShape = engrv.create_shape(m_pNote, UPoint(m_uxLeft, m_uyTop),
-                                                 m_acc, false /*cautionary accidentals*/,
+                                                 m_acc, m_fontSize, false /*cautionary accidentals*/,
                                                  m_color);
         m_pNoteShape->add_accidentals(m_pAccidentalsShape);
         m_uxLeft += m_pAccidentalsShape->get_width();
@@ -723,9 +723,7 @@ void NoteEngraver::layout_chord()
 StemFlagEngraver::StemFlagEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
                                    ImoObj* pCreatorImo, int iInstr, int iStaff,
                                    double fontSize)
-    : Engraver(libraryScope, pScoreMeter)
-    , m_iInstr(iInstr)
-    , m_iStaff(iStaff)
+    : StaffSymbolEngraver(libraryScope, pScoreMeter, iInstr, iStaff)
     , m_noteType(0)
     , m_fStemDown(false)
     , m_fWithFlag(false)

--- a/src/graphic_model/engravers/lomse_note_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_note_engraver.cpp
@@ -685,8 +685,8 @@ void NoteEngraver::create_chord()
         LOMSE_NEW ChordEngraver(m_libraryScope, m_pMeter, numNotes, m_fontSize, m_symbolSize);
     m_pEngravers->save_engraver(pEngrv, pChord);
 
-    pEngrv->set_start_staffobj(pChord, m_pNote, m_pNoteShape, m_iInstr, m_iStaff,
-                               0, 0, 0.0f, 0.0f, 0.0f, m_idxStaff, nullptr);
+    AuxObjContext aoc(m_pNote, m_pNoteShape, m_iInstr, m_iStaff, 0, 0, nullptr, m_idxStaff);
+    pEngrv->set_start_staffobj(pChord, aoc);
 }
 
 //---------------------------------------------------------------------------------------
@@ -696,8 +696,8 @@ void NoteEngraver::add_to_chord()
     ChordEngraver* pEngrv
         = static_cast<ChordEngraver*>(m_pEngravers->get_engraver(pChord));
 
-    pEngrv->set_middle_staffobj(pChord, m_pNote, m_pNoteShape, 0, 0, 0, 0,
-                                0.0f, 0.0f, 0.0f, m_idxStaff, nullptr);
+    AuxObjContext aoc(m_pNote, m_pNoteShape, 0, 0, 0, 0, nullptr, m_idxStaff);
+    pEngrv->set_middle_staffobj(pChord, aoc);
 }
 
 //---------------------------------------------------------------------------------------
@@ -706,9 +706,8 @@ void NoteEngraver::layout_chord()
     ImoChord* pChord = m_pNote->get_chord();
     ChordEngraver* pEngrv
         = static_cast<ChordEngraver*>(m_pEngravers->get_engraver(pChord));
-    pEngrv->set_end_staffobj(pChord, m_pNote, m_pNoteShape, 0, 0, 0, 0,
-                             0.0f, 0.0f, 0.0f, m_idxStaff, nullptr);
-
+    AuxObjContext aoc(m_pNote, m_pNoteShape, 0, 0, 0, 0, nullptr, m_idxStaff);
+    pEngrv->set_end_staffobj(pChord, aoc);
     pEngrv->save_applicable_clefs(m_pCursor, m_iInstr);
     pEngrv->create_shapes(pChord->get_color());
 

--- a/src/graphic_model/engravers/lomse_octave_shift_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_octave_shift_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/src/graphic_model/engravers/lomse_octave_shift_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_octave_shift_engraver.cpp
@@ -66,53 +66,40 @@ OctaveShiftEngraver::OctaveShiftEngraver(LibraryScope& libraryScope, ScoreMeter*
 }
 
 //---------------------------------------------------------------------------------------
-void OctaveShiftEngraver::set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                                       GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                                       int UNUSED(iSystem), int UNUSED(iCol), LUnits UNUSED(xStaffLeft),
-                                       LUnits UNUSED(xStaffRight), LUnits yTop,
-                                       int idxStaff, VerticalProfile* pVProfile)
+void OctaveShiftEngraver::set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc)
 {
-    m_iInstr = iInstr;
-    m_iStaff = iStaff;
+    m_iInstr = aoc.iInstr;
+    m_iStaff = aoc.iStaff;
+    m_idxStaff = aoc.idxStaff;
+
     m_pOctaveShift = static_cast<ImoOctaveShift*>(pRO);
 
-    m_pStartNote = static_cast<ImoNote*>(pSO);
-    m_pStartNoteShape = static_cast<GmoShapeNote*>(pStaffObjShape);
-
-    m_uStaffTop = yTop;
-
-    m_idxStaff = idxStaff;
-    m_pVProfile = pVProfile;
+    m_pStartNote = static_cast<ImoNote*>(aoc.pSO);
+    m_pStartNoteShape = static_cast<GmoShapeNote*>(aoc.pStaffObjShape);
 }
 
 //---------------------------------------------------------------------------------------
-void OctaveShiftEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* pSO,
-                                     GmoShape* pStaffObjShape, int UNUSED(iInstr),
-                                     int UNUSED(iStaff), int UNUSED(iSystem), int UNUSED(iCol),
-                                     LUnits UNUSED(xStaffLeft), LUnits UNUSED(xStaffRight),
-                                     LUnits yTop, int idxStaff, VerticalProfile* pVProfile)
+void OctaveShiftEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), const AuxObjContext& aoc)
 {
-    m_pEndNote = static_cast<ImoNote*>(pSO);
-    m_pEndNoteShape = static_cast<GmoShapeNote*>(pStaffObjShape);
-
-    m_uStaffTop = yTop;
-
-    m_idxStaff = idxStaff;
-    m_pVProfile = pVProfile;
+    m_pEndNote = static_cast<ImoNote*>(aoc.pSO);
+    m_pEndNoteShape = static_cast<GmoShapeNote*>(aoc.pStaffObjShape);
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* OctaveShiftEngraver::create_first_or_intermediate_shape(LUnits xStaffLeft,
-                                    LUnits xStaffRight, LUnits yStaffTop,
-                                    LUnits prologWidth, VerticalProfile* pVProfile,
-                                    Color color)
+void OctaveShiftEngraver::save_context_parameters(const RelObjEngravingContext& ctx)
 {
-    m_color = color;
-    m_uStaffLeft = xStaffLeft;
-    m_uStaffRight = xStaffRight;
-    m_uStaffTop = yStaffTop;
-    m_pVProfile = pVProfile;
-    m_uPrologWidth = prologWidth;
+    m_color = ctx.color;
+    m_uStaffLeft = ctx.xStaffLeft;
+    m_uStaffRight = ctx.xStaffRight;
+    m_uStaffTop = ctx.yStaffTop;
+    m_pVProfile = ctx.pVProfile;
+    m_uPrologWidth = ctx.prologWidth;
+}
+
+//---------------------------------------------------------------------------------------
+GmoShape* OctaveShiftEngraver::create_first_or_intermediate_shape(const RelObjEngravingContext& ctx)
+{
+    save_context_parameters(ctx);
 
     if (m_numShapes == 0)
     {
@@ -124,9 +111,10 @@ GmoShape* OctaveShiftEngraver::create_first_or_intermediate_shape(LUnits xStaffL
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* OctaveShiftEngraver::create_last_shape(Color color)
+GmoShape* OctaveShiftEngraver::create_last_shape(const RelObjEngravingContext& ctx)
 {
-    m_color = color;
+    save_context_parameters(ctx);
+
     if (m_numShapes == 0)
     {
         decide_placement();
@@ -346,12 +334,6 @@ void OctaveShiftEngraver::decide_placement()
 //    //    }
 //    //}
 //}
-
-//---------------------------------------------------------------------------------------
-void OctaveShiftEngraver::set_prolog_width(LUnits width)
-{
-    m_uPrologWidth = width;
-}
 
 
 }  //namespace lomse

--- a/src/graphic_model/engravers/lomse_octave_shift_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_octave_shift_engraver.cpp
@@ -47,16 +47,12 @@ namespace lomse
 //---------------------------------------------------------------------------------------
 // OctaveShiftEngraver implementation
 //---------------------------------------------------------------------------------------
-OctaveShiftEngraver::OctaveShiftEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                                         InstrumentEngraver* pInstrEngrv)
+OctaveShiftEngraver::OctaveShiftEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter)
     : RelObjEngraver(libraryScope, pScoreMeter)
-    , m_pInstrEngrv(pInstrEngrv)
-    , m_uStaffTop(0.0f)
     , m_numShapes(0)
     , m_pOctaveShift(nullptr)
     , m_pShapeNumeral(nullptr)
     , m_pMainShape(nullptr)
-    , m_uPrologWidth(0.0f)
     , m_pStartNote(nullptr)
     , m_pEndNote(nullptr)
     , m_pStartNoteShape(nullptr)
@@ -83,17 +79,6 @@ void OctaveShiftEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), const AuxObjC
 {
     m_pEndNote = static_cast<ImoNote*>(aoc.pSO);
     m_pEndNoteShape = static_cast<GmoShapeNote*>(aoc.pStaffObjShape);
-}
-
-//---------------------------------------------------------------------------------------
-void OctaveShiftEngraver::save_context_parameters(const RelObjEngravingContext& ctx)
-{
-    m_color = ctx.color;
-    m_uStaffLeft = ctx.xStaffLeft;
-    m_uStaffRight = ctx.xStaffRight;
-    m_uStaffTop = ctx.yStaffTop;
-    m_pVProfile = ctx.pVProfile;
-    m_uPrologWidth = ctx.prologWidth;
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/engravers/lomse_ornament_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_ornament_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -43,10 +43,8 @@ namespace lomse
 //---------------------------------------------------------------------------------------
 // OrnamentEngraver implementation
 //---------------------------------------------------------------------------------------
-OrnamentEngraver::OrnamentEngraver(LibraryScope& libraryScope,
-                                           ScoreMeter* pScoreMeter,
-                                           int UNUSED(iInstr), int UNUSED(iStaff))
-    : Engraver(libraryScope, pScoreMeter)
+OrnamentEngraver::OrnamentEngraver(const EngraverContext& ctx)
+    : AuxObjEngraver(ctx)
     , m_pOrnament(nullptr)
     , m_placement(k_placement_default)
     , m_fAbove(true)
@@ -57,8 +55,8 @@ OrnamentEngraver::OrnamentEngraver(LibraryScope& libraryScope,
 
 //---------------------------------------------------------------------------------------
 GmoShapeOrnament* OrnamentEngraver::create_shape(ImoOrnament* pOrnament,
-                                                         UPoint pos, Color color,
-                                                         GmoShape* pParentShape)
+                                                 UPoint pos, Color color,
+                                                 GmoShape* pParentShape)
 {
     m_pOrnament = pOrnament;
     m_placement = pOrnament->get_placement();

--- a/src/graphic_model/engravers/lomse_pedal_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_pedal_engraver.cpp
@@ -52,12 +52,8 @@ namespace lomse
 // PedalMarkEngraver implementation
 //---------------------------------------------------------------------------------------
 
-PedalMarkEngraver::PedalMarkEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                                     int iInstr, int iStaff,
-                                     int idxStaff, VerticalProfile* pVProfile)
-    : Engraver(libraryScope, pScoreMeter, iInstr, iStaff)
-    , m_idxStaff(idxStaff)
-    , m_pVProfile(pVProfile)
+PedalMarkEngraver::PedalMarkEngraver(const EngraverContext& ctx)
+    : AuxObjEngraver(ctx)
 {
 }
 
@@ -84,8 +80,7 @@ GmoShapePedalGlyph* PedalMarkEngraver::create_shape(ImoPedalMark* pPedalMark, UP
     const LUnits y = determine_y_pos(pShape->get_left(), pShape->get_right(), pos.y, pShape->get_relative_baseline_y(), fAbove);
     pShape->set_top(y);
 
-    if (AuxShapesAligner* aligner = m_pVProfile->get_current_aux_shapes_aligner(m_idxStaff, fAbove))
-        aligner->add_shape(pShape);
+    add_to_aux_shapes_aligner(pShape, fAbove);
 
     return pShape;
 }
@@ -181,6 +176,7 @@ void PedalLineEngraver::save_context_parameters(const RelObjEngravingContext& ct
     m_uStaffTop = ctx.yStaffTop;
     m_pVProfile = ctx.pVProfile;
     m_uPrologWidth = ctx.prologWidth;
+    m_pAuxShapesAligner = ctx.pAuxShapesAligner;
 }
 
 //---------------------------------------------------------------------------------------
@@ -232,9 +228,7 @@ GmoShape* PedalLineEngraver::create_shape()
     m_pedalChangeDirectionShapes.clear();
 
     add_line_info(pShape, m_pPedalStartShape, m_pPedalEndShape, first);
-
-    if (AuxShapesAligner* aligner = m_pVProfile->get_current_aux_shapes_aligner(m_idxStaff, m_fPedalAbove))
-        aligner->add_shape(pShape);
+    add_to_aux_shapes_aligner(pShape, m_fPedalAbove);
 
     return pShape;
 }
@@ -245,7 +239,7 @@ void PedalLineEngraver::compute_shape_position(bool first)
     m_xStart = determine_shape_position_left(first);
     m_xEnd = determine_shape_position_right();
 
-    if (AuxShapesAligner* aligner = m_pVProfile->get_current_aux_shapes_aligner(m_idxStaff, m_fPedalAbove))
+    if (AuxShapesAligner* aligner = get_aux_shapes_aligner(m_idxStaff, m_fPedalAbove))
     {
         GmoShape* pStartShape = aligner->find_shape(m_xStart);
 

--- a/src/graphic_model/engravers/lomse_pedal_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_pedal_engraver.cpp
@@ -136,10 +136,8 @@ LUnits PedalMarkEngraver::determine_y_pos(LUnits xLeft, LUnits xRight, LUnits yR
 //---------------------------------------------------------------------------------------
 // PedalLineEngraver implementation
 //---------------------------------------------------------------------------------------
-PedalLineEngraver::PedalLineEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                                     InstrumentEngraver* pInstrEngrv)
+PedalLineEngraver::PedalLineEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter)
     : RelObjEngraver(libraryScope, pScoreMeter)
-    , m_pInstrEngrv(pInstrEngrv)
 {
 }
 
@@ -167,16 +165,6 @@ void PedalLineEngraver::set_middle_staffobj(ImoRelObj* UNUSED(pRO), const AuxObj
 void PedalLineEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), const AuxObjContext& aoc)
 {
     m_pEndDirectionShape = static_cast<GmoShapeInvisible*>(aoc.pStaffObjShape);
-}
-
-//---------------------------------------------------------------------------------------
-void PedalLineEngraver::save_context_parameters(const RelObjEngravingContext& ctx)
-{
-    m_color = ctx.color;
-    m_uStaffTop = ctx.yStaffTop;
-    m_pVProfile = ctx.pVProfile;
-    m_uPrologWidth = ctx.prologWidth;
-    m_pAuxShapesAligner = ctx.pAuxShapesAligner;
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/engravers/lomse_rest_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_rest_engraver.cpp
@@ -49,7 +49,7 @@ namespace lomse
 RestEngraver::RestEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
                            EngraversMap* UNUSED(pEngravers), int iInstr, int iStaff,
                            int clefType, int octaveShift)
-    : Engraver(libraryScope, pScoreMeter, iInstr, iStaff)
+    : StaffObjEngraver(libraryScope, pScoreMeter, iInstr, iStaff)
     , m_restType(k_quarter)
     , m_numDots(0)
     , m_clefType(clefType)

--- a/src/graphic_model/engravers/lomse_slur_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_slur_engraver.cpp
@@ -49,10 +49,8 @@ namespace lomse
 //---------------------------------------------------------------------------------------
 // SlurEngraver implementation
 //---------------------------------------------------------------------------------------
-SlurEngraver::SlurEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                           InstrumentEngraver* pInstrEngrv)
+SlurEngraver::SlurEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter)
     : RelObjEngraver(libraryScope, pScoreMeter)
-    , m_pInstrEngrv(pInstrEngrv)
 {
 }
 
@@ -116,10 +114,7 @@ void SlurEngraver::decide_placement()
 //---------------------------------------------------------------------------------------
 GmoShape* SlurEngraver::create_first_or_intermediate_shape(const RelObjEngravingContext& ctx)
 {
-    m_color = ctx.color;
-    m_uStaffTop = ctx.yStaffTop;
-    m_pVProfile = ctx.pVProfile;
-    m_uPrologWidth = ctx.prologWidth;
+    save_context_parameters(ctx);
 
     if (m_numShapes == 0)
     {
@@ -133,10 +128,7 @@ GmoShape* SlurEngraver::create_first_or_intermediate_shape(const RelObjEngraving
 //---------------------------------------------------------------------------------------
 GmoShape* SlurEngraver::create_last_shape(const RelObjEngravingContext& ctx)
 {
-    m_color = ctx.color;
-    m_uStaffTop = ctx.yStaffTop;
-    m_pVProfile = ctx.pVProfile;
-    m_uPrologWidth = ctx.prologWidth;
+    save_context_parameters(ctx);
 
     if (m_numShapes == 0)
     {

--- a/src/graphic_model/engravers/lomse_slur_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_slur_engraver.cpp
@@ -57,45 +57,28 @@ SlurEngraver::SlurEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
 }
 
 //---------------------------------------------------------------------------------------
-void SlurEngraver::set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                                      GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                                      int UNUSED(iSystem), int UNUSED(iCol), LUnits UNUSED(xStaffLeft),
-                                      LUnits UNUSED(xStaffRight), LUnits yTop,
-                                      int idxStaff, VerticalProfile* pVProfile)
+void SlurEngraver::set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc)
 {
-    //data stored in base class
-    m_iInstr = iInstr;
-    m_iStaff = iStaff;
-    m_idxStaff = idxStaff;
-    m_idxStaffStart = idxStaff;
-    m_pVProfile = pVProfile;
+    m_iInstr = aoc.iInstr;
+    m_iStaff = aoc.iStaff;
+    m_idxStaff = aoc.idxStaff;
+    m_idxStaffStart = aoc.idxStaff;
 
-    //data specific for this class
     m_pSlur = static_cast<ImoSlur*>(pRO);
 
-    m_pStartNote = static_cast<ImoNote*>(pSO);
-    m_pStartNoteShape = static_cast<GmoShapeNote*>(pStaffObjShape);
-
-    m_uStaffTop = yTop;
+    m_pStartNote = static_cast<ImoNote*>(aoc.pSO);
+    m_pStartNoteShape = static_cast<GmoShapeNote*>(aoc.pStaffObjShape);
 }
 
 //---------------------------------------------------------------------------------------
-void SlurEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* pSO,
-                                    GmoShape* pStaffObjShape, int UNUSED(iInstr),
-                                    int UNUSED(iStaff), int UNUSED(iSystem), int UNUSED(iCol),
-                                    LUnits UNUSED(xStaffLeft), LUnits UNUSED(xStaffRight),
-                                    LUnits yTop, int idxStaff, VerticalProfile* pVProfile)
+void SlurEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), const AuxObjContext& aoc)
 {
-    m_pEndNote = static_cast<ImoNote*>(pSO);
-    m_pEndNoteShape = static_cast<GmoShapeNote*>(pStaffObjShape);
+    m_idxStaffEnd = aoc.idxStaff;
 
-    m_uStaffTop = yTop;
+    m_pEndNote = static_cast<ImoNote*>(aoc.pSO);
+    m_pEndNoteShape = static_cast<GmoShapeNote*>(aoc.pStaffObjShape);
 
     m_fSlurForGraces = m_pStartNote->is_grace_note() || m_pEndNote->is_grace_note();
-
-    m_idxStaff = idxStaff;
-    m_idxStaffEnd = idxStaff;
-    m_pVProfile = pVProfile;
 }
 
 //---------------------------------------------------------------------------------------
@@ -131,15 +114,12 @@ void SlurEngraver::decide_placement()
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* SlurEngraver::create_first_or_intermediate_shape(LUnits UNUSED(xStaffLeft),
-                                    LUnits UNUSED(xStaffRight), LUnits yStaffTop,
-                                    LUnits prologWidth, VerticalProfile* pVProfile,
-                                    Color color)
+GmoShape* SlurEngraver::create_first_or_intermediate_shape(const RelObjEngravingContext& ctx)
 {
-    m_color = color;
-    m_uStaffTop = yStaffTop;
-    m_pVProfile = pVProfile;
-    m_uPrologWidth = prologWidth;
+    m_color = ctx.color;
+    m_uStaffTop = ctx.yStaffTop;
+    m_pVProfile = ctx.pVProfile;
+    m_uPrologWidth = ctx.prologWidth;
 
     if (m_numShapes == 0)
     {
@@ -151,9 +131,13 @@ GmoShape* SlurEngraver::create_first_or_intermediate_shape(LUnits UNUSED(xStaffL
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* SlurEngraver::create_last_shape(Color color)
+GmoShape* SlurEngraver::create_last_shape(const RelObjEngravingContext& ctx)
 {
-    m_color = color;
+    m_color = ctx.color;
+    m_uStaffTop = ctx.yStaffTop;
+    m_pVProfile = ctx.pVProfile;
+    m_uPrologWidth = ctx.prologWidth;
+
     if (m_numShapes == 0)
     {
         decide_placement();
@@ -208,7 +192,7 @@ void SlurEngraver::compute_start_end_points(int type)
             break;
 
         case k_system_end:
-            //slur end at systme right. It is the first shape when the slur does not
+            //slur end at system right. It is the first shape when the slur does not
             //finish in current system
             compute_start_point();
             compute_end_of_staff_point();
@@ -954,12 +938,6 @@ void SlurEngraver::find_contour_reference_points()
 //    //    }
 //    //}
 //}
-
-//---------------------------------------------------------------------------------------
-void SlurEngraver::set_prolog_width(LUnits width)
-{
-    m_uPrologWidth = width;
-}
 
 //---------------------------------------------------------------------------------------
 void SlurEngraver::method_for_two_points()

--- a/src/graphic_model/engravers/lomse_technical_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_technical_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -43,10 +43,8 @@ namespace lomse
 //---------------------------------------------------------------------------------------
 // TechnicalEngraver implementation
 //---------------------------------------------------------------------------------------
-TechnicalEngraver::TechnicalEngraver(LibraryScope& libraryScope,
-                                           ScoreMeter* pScoreMeter,
-                                           int UNUSED(iInstr), int UNUSED(iStaff))
-    : Engraver(libraryScope, pScoreMeter)
+TechnicalEngraver::TechnicalEngraver(const EngraverContext& ctx)
+    : AuxObjEngraver(ctx)
     , m_pTechnical(nullptr)
     , m_placement(k_placement_default)
     , m_fAbove(true)

--- a/src/graphic_model/engravers/lomse_text_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_text_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/src/graphic_model/engravers/lomse_tie_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_tie_engraver.cpp
@@ -60,44 +60,33 @@ TieEngraver::TieEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter)
 }
 
 //---------------------------------------------------------------------------------------
-void TieEngraver::set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                                     GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                                     int UNUSED(iSystem), int UNUSED(iCol), LUnits xStaffLeft,
-                                     LUnits xStaffRight, LUnits yStaffTop,
-                                     int idxStaff, VerticalProfile* pVProfile)
+void TieEngraver::set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc)
 {
+    m_iInstr = aoc.iInstr;
+    m_iStaff = aoc.iStaff;
+    m_idxStaff = aoc.idxStaff;
+
     m_pTie = dynamic_cast<ImoTie*>( pRO );
 
-    m_pStartNote = dynamic_cast<ImoNote*>(pSO);
-    m_pStartNoteShape = dynamic_cast<GmoShapeNote*>(pStaffObjShape);
-    m_iInstr = iInstr;
-    m_iStaff = iStaff;
-
-    m_uStaffLeft = xStaffLeft;
-    m_uStaffRight = xStaffRight;
-    m_uStaffTop = yStaffTop;
-
-    m_idxStaff = idxStaff;
-    m_pVProfile = pVProfile;
+    m_pStartNote = dynamic_cast<ImoNote*>(aoc.pSO);
+    m_pStartNoteShape = dynamic_cast<GmoShapeNote*>(aoc.pStaffObjShape);
 }
 
 //---------------------------------------------------------------------------------------
-void TieEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* pSO,
-                                   GmoShape* pStaffObjShape, int UNUSED(iInstr),
-                                   int UNUSED(iStaff), int UNUSED(iSystem), int UNUSED(iCol),
-                                   LUnits xStaffLeft, LUnits xStaffRight,
-                                   LUnits yStaffTop, int idxStaff,
-                                   VerticalProfile* pVProfile)
+void TieEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), const AuxObjContext& aoc)
 {
-    m_pEndNote = dynamic_cast<ImoNote*>(pSO);
-    m_pEndNoteShape = dynamic_cast<GmoShapeNote*>(pStaffObjShape);
+    m_pEndNote = dynamic_cast<ImoNote*>(aoc.pSO);
+    m_pEndNoteShape = dynamic_cast<GmoShapeNote*>(aoc.pStaffObjShape);
+}
 
-    m_uStaffLeft = xStaffLeft;
-    m_uStaffRight = xStaffRight;
-    m_uStaffTop = yStaffTop;
-
-    m_idxStaff = idxStaff;
-    m_pVProfile = pVProfile;
+//---------------------------------------------------------------------------------------
+void TieEngraver::save_context_parameters(const RelObjEngravingContext& ctx)
+{
+    m_color = ctx.color;
+    m_uStaffLeft = ctx.xStaffLeft + ctx.prologWidth;
+    m_uStaffRight = ctx.xStaffRight;
+    m_uStaffTop = ctx.yStaffTop;
+    m_pVProfile = ctx.pVProfile;
 }
 
 //---------------------------------------------------------------------------------------
@@ -117,12 +106,10 @@ void TieEngraver::decide_placement()
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* TieEngraver::create_first_or_intermediate_shape(LUnits UNUSED(xStaffLeft),
-                                    LUnits UNUSED(xStaffRight), LUnits UNUSED(yStaffTop),
-                                    LUnits UNUSED(prologWidth),
-                                    VerticalProfile* UNUSED(pVProfile), Color color)
+GmoShape* TieEngraver::create_first_or_intermediate_shape(const RelObjEngravingContext& ctx)
 {
-    m_color = color;
+    save_context_parameters(ctx);
+
     if (m_numShapes == 0)
     {
         decide_placement();
@@ -133,9 +120,10 @@ GmoShape* TieEngraver::create_first_or_intermediate_shape(LUnits UNUSED(xStaffLe
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* TieEngraver::create_last_shape(Color color)
+GmoShape* TieEngraver::create_last_shape(const RelObjEngravingContext& ctx)
 {
-    m_color = color;
+    save_context_parameters(ctx);
+
     if (m_numShapes == 0)
     {
         decide_placement();

--- a/src/graphic_model/engravers/lomse_tie_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_tie_engraver.cpp
@@ -45,9 +45,6 @@ namespace lomse
 //---------------------------------------------------------------------------------------
 TieEngraver::TieEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter)
     : RelObjEngraver(libraryScope, pScoreMeter)
-    , m_uStaffTop(0.0f)
-    , m_uStaffLeft(0.0f)
-    , m_uStaffRight(0.0f)
     , m_pTie(nullptr)
     , m_numShapes(0)
     , m_pStartNote(nullptr)
@@ -77,16 +74,6 @@ void TieEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), const AuxObjContext& 
 {
     m_pEndNote = dynamic_cast<ImoNote*>(aoc.pSO);
     m_pEndNoteShape = dynamic_cast<GmoShapeNote*>(aoc.pStaffObjShape);
-}
-
-//---------------------------------------------------------------------------------------
-void TieEngraver::save_context_parameters(const RelObjEngravingContext& ctx)
-{
-    m_color = ctx.color;
-    m_uStaffLeft = ctx.xStaffLeft + ctx.prologWidth;
-    m_uStaffRight = ctx.xStaffRight;
-    m_uStaffTop = ctx.yStaffTop;
-    m_pVProfile = ctx.pVProfile;
 }
 
 //---------------------------------------------------------------------------------------
@@ -247,7 +234,7 @@ void TieEngraver::compute_end_point(UPoint* point)
 //---------------------------------------------------------------------------------------
 void TieEngraver::compute_start_of_staff_point()
 {
-    m_points[ImoBezierInfo::k_start].x = m_uStaffLeft;
+    m_points[ImoBezierInfo::k_start].x = m_uStaffLeft + m_uPrologWidth;
     m_points[ImoBezierInfo::k_start].y = m_points[ImoBezierInfo::k_end].y;
 }
 

--- a/src/graphic_model/engravers/lomse_time_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_time_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2016. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -43,7 +43,7 @@ namespace lomse
 //---------------------------------------------------------------------------------------
 TimeEngraver::TimeEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
                            int iInstr, int iStaff)
-    : Engraver(libraryScope, pScoreMeter, iInstr, iStaff)
+    : StaffObjEngraver(libraryScope, pScoreMeter, iInstr, iStaff)
     , m_pTimeShape(nullptr)
     , m_uTopWidth(0.0f)
     , m_uBottomWidth(0.0f)

--- a/src/graphic_model/engravers/lomse_tuplet_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_tuplet_engraver.cpp
@@ -69,75 +69,53 @@ TupletEngraver::~TupletEngraver()
 }
 
 //---------------------------------------------------------------------------------------
-void TupletEngraver::set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                                        GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                                        int UNUSED(iSystem), int UNUSED(iCol),
-                                        LUnits UNUSED(xStaffLeft),
-                                        LUnits UNUSED(xStaffRight), LUnits UNUSED(yStaffTop),
-                                        int idxStaff, VerticalProfile* pVProfile)
+void TupletEngraver::set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc)
 {
-    m_iInstr = iInstr;
-    m_iStaff = iStaff;
+    m_iInstr = aoc.iInstr;
+    m_iStaff = aoc.iStaff;
+    m_idxStaff = aoc.idxStaff;
+
     m_pTuplet = dynamic_cast<ImoTuplet*>( pRO );
 
-    ImoNoteRest* pNR = dynamic_cast<ImoNoteRest*>(pSO);
-    m_noteRests.push_back( make_pair(pNR, pStaffObjShape) );
-
-    m_idxStaff = idxStaff;
-    m_pVProfile = pVProfile;
+    ImoNoteRest* pNR = dynamic_cast<ImoNoteRest*>(aoc.pSO);
+    m_noteRests.push_back( make_pair(pNR, aoc.pStaffObjShape) );
 }
 
 //---------------------------------------------------------------------------------------
-void TupletEngraver::set_middle_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* pSO,
-                                         GmoShape* pStaffObjShape, int UNUSED(iInstr),
-                                         int UNUSED(iStaff), int UNUSED(iSystem),
-                                         int UNUSED(iCol), LUnits UNUSED(xStaffLeft),
-                                         LUnits UNUSED(xStaffRight), LUnits UNUSED(yStaffTop),
-                                         int idxStaff, VerticalProfile* pVProfile)
+void TupletEngraver::set_middle_staffobj(ImoRelObj* UNUSED(pRO), const AuxObjContext& aoc)
 {
-    ImoNoteRest* pNR = dynamic_cast<ImoNoteRest*>(pSO);
-    m_noteRests.push_back( make_pair(pNR, pStaffObjShape) );
-
-    m_idxStaff = idxStaff;
-    m_pVProfile = pVProfile;
+    ImoNoteRest* pNR = dynamic_cast<ImoNoteRest*>(aoc.pSO);
+    m_noteRests.push_back( make_pair(pNR, aoc.pStaffObjShape) );
 }
 
 //---------------------------------------------------------------------------------------
-void TupletEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* pSO,
-                                      GmoShape* pStaffObjShape, int UNUSED(iInstr),
-                                      int UNUSED(iStaff), int UNUSED(iSystem),
-                                      int UNUSED(iCol), LUnits UNUSED(xStaffLeft),
-                                      LUnits UNUSED(xStaffRight), LUnits UNUSED(yStaffTop),
-                                      int idxStaff, VerticalProfile* pVProfile)
+void TupletEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), const AuxObjContext& aoc)
 {
-    ImoNoteRest* pNR = dynamic_cast<ImoNoteRest*>(pSO);
-    m_noteRests.push_back( make_pair(pNR, pStaffObjShape) );
-
-    m_idxStaff = idxStaff;
-    m_pVProfile = pVProfile;
+    ImoNoteRest* pNR = dynamic_cast<ImoNoteRest*>(aoc.pSO);
+    m_noteRests.push_back( make_pair(pNR, aoc.pStaffObjShape) );
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* TupletEngraver::create_first_or_intermediate_shape(LUnits UNUSED(xStaffLeft),
-                                    LUnits UNUSED(xStaffRight), LUnits UNUSED(yStaffTop),
-                                    LUnits UNUSED(prologWidth),
-                                    VerticalProfile* UNUSED(pVProfile), Color color)
+GmoShape* TupletEngraver::create_first_or_intermediate_shape(const RelObjEngravingContext& ctx)
 {
     //TODO: It has been assumed that a tuplet cannot be split. This has to be revised
-    m_color = color;
+    m_color = ctx.color;
+    m_pVProfile = ctx.pVProfile;
+
     return nullptr;
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* TupletEngraver::create_last_shape(Color color)
+GmoShape* TupletEngraver::create_last_shape(const RelObjEngravingContext& ctx)
 {
     GmoShapeNote* pStart = get_first_note();
     GmoShapeNote* pEnd = get_last_note();
-
     if (!pStart || !pEnd)
         return nullptr;     //all group are rests or notes longer than quarter note!
 
-    m_color = color;
+    m_color = ctx.color;
+    m_pVProfile = ctx.pVProfile;
+
     decide_tuplet_placement();
     decide_if_show_bracket();
     determine_tuplet_text();

--- a/src/graphic_model/engravers/lomse_volta_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_volta_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -49,16 +49,6 @@ namespace lomse
 VoltaBracketEngraver::VoltaBracketEngraver(LibraryScope& libraryScope,
                                            ScoreMeter* pScoreMeter)
     : RelObjEngraver(libraryScope, pScoreMeter)
-    , m_numShapes(0)
-    , m_pVolta(nullptr)
-    , m_uStaffTop(0.0f)
-    , m_uStaffLeft(0.0f)
-    , m_uStaffRight(0.0f)
-    , m_pStyle(nullptr)
-    , m_pStartBarline(nullptr)
-    , m_pStopBarline(nullptr)
-    , m_pStartBarlineShape(nullptr)
-    , m_pStopBarlineShape(nullptr)
 {
     m_pStyle = m_pMeter->get_style_info("Volta brackets");
 }
@@ -81,17 +71,6 @@ void VoltaBracketEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), const AuxObj
 {
     m_pStopBarline = dynamic_cast<ImoBarline*>(aoc.pSO);
     m_pStopBarlineShape = dynamic_cast<GmoShapeBarline*>(aoc.pStaffObjShape);
-}
-
-//---------------------------------------------------------------------------------------
-void VoltaBracketEngraver::save_context_parameters(const RelObjEngravingContext& ctx)
-{
-    m_color = ctx.color;
-    m_uStaffLeft = ctx.xStaffLeft + ctx.prologWidth;
-    m_uStaffRight = ctx.xStaffRight;
-    m_uStaffTop = ctx.yStaffTop;
-    m_pVProfile = ctx.pVProfile;
-    m_pAuxShapesAligner = ctx.pAuxShapesAligner;
 }
 
 //---------------------------------------------------------------------------------------
@@ -214,7 +193,7 @@ void VoltaBracketEngraver::set_shape_details(GmoShapeVoltaBracket* pShape,
     LUnits uJogLength = tenths_to_logical(LOMSE_VOLTA_JOG_LENGHT);
 
     //determine xStart and xEnd
-    LUnits xStart = m_uStaffLeft;
+    LUnits xStart = m_uStaffLeft + m_uPrologWidth;
     LUnits xEnd = m_uStaffRight;
 
     if (!m_fFirstShapeAtSystemStart && (shapeType == k_single_shape || shapeType == k_first_shape))
@@ -245,7 +224,8 @@ void VoltaBracketEngraver::set_shape_details(GmoShapeVoltaBracket* pShape,
 
     //transfer data to shape
     pShape->set_layout_data(xStart, xEnd, yPos, uDistance, uJogLength, uLineThick,
-                            uLeftSpaceToText, uTopSpaceToText, m_uStaffLeft, m_uStaffRight);
+                            uLeftSpaceToText, uTopSpaceToText,
+                            m_uStaffLeft + m_uPrologWidth, m_uStaffRight);
 }
 
 

--- a/src/graphic_model/engravers/lomse_volta_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_volta_engraver.cpp
@@ -91,7 +91,7 @@ void VoltaBracketEngraver::save_context_parameters(const RelObjEngravingContext&
     m_uStaffRight = ctx.xStaffRight;
     m_uStaffTop = ctx.yStaffTop;
     m_pVProfile = ctx.pVProfile;
-//    m_uPrologWidth = ctx.prologWidth;
+    m_pAuxShapesAligner = ctx.pAuxShapesAligner;
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/engravers/lomse_volta_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_volta_engraver.cpp
@@ -64,58 +64,40 @@ VoltaBracketEngraver::VoltaBracketEngraver(LibraryScope& libraryScope,
 }
 
 //---------------------------------------------------------------------------------------
-void VoltaBracketEngraver::set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                                      GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                                      int UNUSED(iSystem), int UNUSED(iCol),
-                                      LUnits xStaffLeft, LUnits xStaffRight, LUnits yStaffTop,
-                                      int idxStaff, VerticalProfile* pVProfile)
+void VoltaBracketEngraver::set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc)
 {
-    m_iInstr = iInstr;
-    m_iStaff = iStaff;
+    m_iInstr = aoc.iInstr;
+    m_iStaff = aoc.iStaff;
+    m_idxStaff = aoc.idxStaff;
+
     m_pVolta = dynamic_cast<ImoVoltaBracket*>(pRO);
 
-    m_pStartBarline = dynamic_cast<ImoBarline*>(pSO);
-    m_pStartBarlineShape = dynamic_cast<GmoShapeBarline*>(pStaffObjShape);
-
-    m_uStaffLeft = xStaffLeft;
-    m_uStaffRight = xStaffRight;
-    m_uStaffTop = yStaffTop;
-
-    m_idxStaff = idxStaff;
-    m_pVProfile = pVProfile;
+    m_pStartBarline = dynamic_cast<ImoBarline*>(aoc.pSO);
+    m_pStartBarlineShape = dynamic_cast<GmoShapeBarline*>(aoc.pStaffObjShape);
 }
 
 //---------------------------------------------------------------------------------------
-void VoltaBracketEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* pSO,
-                                    GmoShape* pStaffObjShape, int UNUSED(iInstr),
-                                    int UNUSED(iStaff), int UNUSED(iSystem),
-                                    int UNUSED(iCol), LUnits xStaffLeft,
-                                    LUnits xStaffRight, LUnits yStaffTop,
-                                    int idxStaff, VerticalProfile* pVProfile)
+void VoltaBracketEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), const AuxObjContext& aoc)
 {
-    m_pStopBarline = dynamic_cast<ImoBarline*>(pSO);
-    m_pStopBarlineShape = dynamic_cast<GmoShapeBarline*>(pStaffObjShape);
-
-    m_uStaffLeft = xStaffLeft;
-    m_uStaffRight = xStaffRight;
-    m_uStaffTop = yStaffTop;
-
-    m_idxStaff = idxStaff;
-    m_pVProfile = pVProfile;
+    m_pStopBarline = dynamic_cast<ImoBarline*>(aoc.pSO);
+    m_pStopBarlineShape = dynamic_cast<GmoShapeBarline*>(aoc.pStaffObjShape);
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* VoltaBracketEngraver::create_first_or_intermediate_shape(LUnits xStaffLeft,
-                                    LUnits xStaffRight, LUnits yStaffTop,
-                                    LUnits prologWidth, VerticalProfile* pVProfile,
-                                    Color color)
+void VoltaBracketEngraver::save_context_parameters(const RelObjEngravingContext& ctx)
 {
-    m_color = color;
-    m_uStaffLeft = xStaffLeft;
-    m_uStaffRight = xStaffRight;
-    m_uStaffTop = yStaffTop;
-    m_pVProfile = pVProfile;
-    m_uPrologWidth = prologWidth;
+    m_color = ctx.color;
+    m_uStaffLeft = ctx.xStaffLeft + ctx.prologWidth;
+    m_uStaffRight = ctx.xStaffRight;
+    m_uStaffTop = ctx.yStaffTop;
+    m_pVProfile = ctx.pVProfile;
+//    m_uPrologWidth = ctx.prologWidth;
+}
+
+//---------------------------------------------------------------------------------------
+GmoShape* VoltaBracketEngraver::create_first_or_intermediate_shape(const RelObjEngravingContext& ctx)
+{
+    save_context_parameters(ctx);
 
     if (m_numShapes == 0)
         return create_first_shape();
@@ -124,9 +106,10 @@ GmoShape* VoltaBracketEngraver::create_first_or_intermediate_shape(LUnits xStaff
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* VoltaBracketEngraver::create_last_shape(Color color)
+GmoShape* VoltaBracketEngraver::create_last_shape(const RelObjEngravingContext& ctx)
 {
-    m_color = color;
+    save_context_parameters(ctx);
+
     if (m_numShapes == 0)
         return create_single_shape();
     return create_final_shape();
@@ -248,11 +231,11 @@ void VoltaBracketEngraver::set_shape_details(GmoShapeVoltaBracket* pShape,
             xEnd -= 30.0f;
     }
 
-    if (shapeType == k_intermediate_shape
-        || (m_fFirstShapeAtSystemStart && (shapeType == k_first_shape )) )
-    {
-        xStart += m_uPrologWidth;
-    }
+//    if (shapeType == k_intermediate_shape
+//        || (m_fFirstShapeAtSystemStart && (shapeType == k_first_shape )) )
+//    {
+//        xStart += m_uPrologWidth;
+//    }
 
     //determine yPos
     LUnits uDistance = tenths_to_logical(LOMSE_VOLTA_BRACKET_DISTANCE);

--- a/src/graphic_model/engravers/lomse_wedge_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_wedge_engraver.cpp
@@ -46,19 +46,8 @@ namespace lomse
 //---------------------------------------------------------------------------------------
 // WedgeEngraver implementation
 //---------------------------------------------------------------------------------------
-WedgeEngraver::WedgeEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter,
-                             InstrumentEngraver* pInstrEngrv)
+WedgeEngraver::WedgeEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter)
     : RelObjEngraver(libraryScope, pScoreMeter)
-    , m_pInstrEngrv(pInstrEngrv)
-    , m_uStaffTop(0.0f)
-    , m_numShapes(0)
-    , m_pWedge(nullptr)
-    , m_fWedgeAbove(false)
-    , m_uPrologWidth(0.0f)
-    , m_pStartDirection(nullptr)
-    , m_pEndDirection(nullptr)
-    , m_pStartDirectionShape(nullptr)
-    , m_pEndDirectionShape(nullptr)
 {
 }
 
@@ -80,16 +69,6 @@ void WedgeEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), const AuxObjContext
 {
     m_pEndDirection = static_cast<ImoDirection*>(aoc.pSO);
     m_pEndDirectionShape = static_cast<GmoShapeInvisible*>(aoc.pStaffObjShape);
-}
-
-//---------------------------------------------------------------------------------------
-void WedgeEngraver::save_context_parameters(const RelObjEngravingContext& ctx)
-{
-    m_color = ctx.color;
-    m_uStaffTop = ctx.yStaffTop;
-    m_pVProfile = ctx.pVProfile;
-    m_uPrologWidth = ctx.prologWidth;
-    m_pAuxShapesAligner = ctx.pAuxShapesAligner;
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/engravers/lomse_wedge_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_wedge_engraver.cpp
@@ -63,41 +63,32 @@ WedgeEngraver::WedgeEngraver(LibraryScope& libraryScope, ScoreMeter* pScoreMeter
 }
 
 //---------------------------------------------------------------------------------------
-void WedgeEngraver::set_start_staffobj(ImoRelObj* pRO, ImoStaffObj* pSO,
-                                       GmoShape* pStaffObjShape, int iInstr, int iStaff,
-                                       int UNUSED(iSystem), int UNUSED(iCol),
-                                       LUnits UNUSED(xStaffLeft),
-                                       LUnits UNUSED(xStaffRight), LUnits yTop,
-                                       int idxStaff, VerticalProfile* pVProfile)
+void WedgeEngraver::set_start_staffobj(ImoRelObj* pRO, const AuxObjContext& aoc)
 {
-    m_iInstr = iInstr;
-    m_iStaff = iStaff;
+    m_iInstr = aoc.iInstr;
+    m_iStaff = aoc.iStaff;
+    m_idxStaff = aoc.idxStaff;
+
     m_pWedge = static_cast<ImoWedge*>(pRO);
 
-    m_pStartDirection = static_cast<ImoDirection*>(pSO);
-    m_pStartDirectionShape = static_cast<GmoShapeInvisible*>(pStaffObjShape);
-
-    m_uStaffTop = yTop;
-
-    m_idxStaff = idxStaff;
-    m_pVProfile = pVProfile;
-
+    m_pStartDirection = static_cast<ImoDirection*>(aoc.pSO);
+    m_pStartDirectionShape = static_cast<GmoShapeInvisible*>(aoc.pStaffObjShape);
 }
 
 //---------------------------------------------------------------------------------------
-void WedgeEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), ImoStaffObj* pSO,
-                                     GmoShape* pStaffObjShape, int UNUSED(iInstr),
-                                     int UNUSED(iStaff), int UNUSED(iSystem), int UNUSED(iCol),
-                                     LUnits UNUSED(xStaffLeft), LUnits UNUSED(xStaffRight),
-                                     LUnits yTop, int idxStaff, VerticalProfile* pVProfile)
+void WedgeEngraver::set_end_staffobj(ImoRelObj* UNUSED(pRO), const AuxObjContext& aoc)
 {
-    m_pEndDirection = static_cast<ImoDirection*>(pSO);
-    m_pEndDirectionShape = static_cast<GmoShapeInvisible*>(pStaffObjShape);
+    m_pEndDirection = static_cast<ImoDirection*>(aoc.pSO);
+    m_pEndDirectionShape = static_cast<GmoShapeInvisible*>(aoc.pStaffObjShape);
+}
 
-    m_uStaffTop = yTop;
-
-    m_idxStaff = idxStaff;
-    m_pVProfile = pVProfile;
+//---------------------------------------------------------------------------------------
+void WedgeEngraver::save_context_parameters(const RelObjEngravingContext& ctx)
+{
+    m_color = ctx.color;
+    m_uStaffTop = ctx.yStaffTop;
+    m_pVProfile = ctx.pVProfile;
+    m_uPrologWidth = ctx.prologWidth;
 }
 
 //---------------------------------------------------------------------------------------
@@ -108,15 +99,9 @@ void WedgeEngraver::decide_placement()
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* WedgeEngraver::create_first_or_intermediate_shape(LUnits UNUSED(xStaffLeft),
-                                    LUnits UNUSED(xStaffRight), LUnits yStaffTop,
-                                    LUnits prologWidth, VerticalProfile* pVProfile,
-                                    Color color)
+GmoShape* WedgeEngraver::create_first_or_intermediate_shape(const RelObjEngravingContext& ctx)
 {
-    m_color = color;
-    m_uStaffTop = yStaffTop;
-    m_pVProfile = pVProfile;
-    m_uPrologWidth = prologWidth;
+    save_context_parameters(ctx);
 
     if (m_numShapes == 0)
     {
@@ -128,9 +113,10 @@ GmoShape* WedgeEngraver::create_first_or_intermediate_shape(LUnits UNUSED(xStaff
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* WedgeEngraver::create_last_shape(Color color)
+GmoShape* WedgeEngraver::create_last_shape(const RelObjEngravingContext& ctx)
 {
-    m_color = color;
+    save_context_parameters(ctx);
+
     if (m_numShapes == 0)
     {
         decide_placement();
@@ -440,12 +426,6 @@ LUnits WedgeEngraver::determine_center_line_of_shape(LUnits startSpread, LUnits 
 //    //    }
 //    //}
 //}
-
-//---------------------------------------------------------------------------------------
-void WedgeEngraver::set_prolog_width(LUnits width)
-{
-    m_uPrologWidth = width;
-}
 
 
 }  //namespace lomse

--- a/src/graphic_model/engravers/lomse_wedge_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_wedge_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -89,6 +89,7 @@ void WedgeEngraver::save_context_parameters(const RelObjEngravingContext& ctx)
     m_uStaffTop = ctx.yStaffTop;
     m_pVProfile = ctx.pVProfile;
     m_uPrologWidth = ctx.prologWidth;
+    m_pAuxShapesAligner = ctx.pAuxShapesAligner;
 }
 
 //---------------------------------------------------------------------------------------
@@ -309,7 +310,7 @@ LUnits WedgeEngraver::determine_shape_position_left(bool first) const
 {
     LUnits xLeft = determine_default_shape_position_left(first);
 
-    const AuxShapesAligner* pAligner = m_pVProfile->get_current_aux_shapes_aligner(m_idxStaff, m_fWedgeAbove);
+    const AuxShapesAligner* pAligner = get_aux_shapes_aligner(m_idxStaff, m_fWedgeAbove);
 
     if (!pAligner)
         return xLeft;
@@ -364,7 +365,7 @@ LUnits WedgeEngraver::determine_shape_position_right() const
 {
     LUnits xRight = determine_default_shape_position_right();
 
-    const AuxShapesAligner* pAligner = m_pVProfile->get_current_aux_shapes_aligner(m_idxStaff, m_fWedgeAbove);
+    const AuxShapesAligner* pAligner = get_aux_shapes_aligner(m_idxStaff, m_fWedgeAbove);
 
     if (!pAligner)
         return xRight;

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -1382,8 +1382,6 @@ void ShapesCreator::start_engraving_relobj(ImoRelObj* pRO, const AuxObjContext& 
 {
     //factory method to create the engraver for relation auxobjs
 
-    InstrumentEngraver* pInstrEngrv = m_pPartsEngraver->get_engraver_for(aoc.iInstr);
-
     RelObjEngraver* pEngrv = nullptr;
     switch (pRO->get_obj_type())
     {
@@ -1395,7 +1393,7 @@ void ShapesCreator::start_engraving_relobj(ImoRelObj* pRO, const AuxObjContext& 
 
         case k_imo_slur:
         {
-            pEngrv = LOMSE_NEW SlurEngraver(m_libraryScope, m_pScoreMeter, pInstrEngrv);
+            pEngrv = LOMSE_NEW SlurEngraver(m_libraryScope, m_pScoreMeter);
             break;
         }
 
@@ -1419,19 +1417,19 @@ void ShapesCreator::start_engraving_relobj(ImoRelObj* pRO, const AuxObjContext& 
 
         case k_imo_wedge:
         {
-            pEngrv = LOMSE_NEW WedgeEngraver(m_libraryScope, m_pScoreMeter, pInstrEngrv);
+            pEngrv = LOMSE_NEW WedgeEngraver(m_libraryScope, m_pScoreMeter);
             break;
         }
 
         case k_imo_octave_shift:
         {
-            pEngrv = LOMSE_NEW OctaveShiftEngraver(m_libraryScope, m_pScoreMeter, pInstrEngrv);
+            pEngrv = LOMSE_NEW OctaveShiftEngraver(m_libraryScope, m_pScoreMeter);
             break;
         }
 
         case k_imo_pedal_line:
         {
-            pEngrv = LOMSE_NEW PedalLineEngraver(m_libraryScope, m_pScoreMeter, pInstrEngrv);
+            pEngrv = LOMSE_NEW PedalLineEngraver(m_libraryScope, m_pScoreMeter);
             break;
         }
 

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -1257,14 +1257,22 @@ GmoShape* ShapesCreator::create_staffobj_shape(ImoStaffObj* pSO, int iInstr, int
 }
 
 //---------------------------------------------------------------------------------------
-GmoShape* ShapesCreator::create_auxobj_shape(ImoAuxObj* pAO, int iInstr, int iStaff,
-                                             int idxStaff, VerticalProfile* pVProfile,
-                                             GmoShape* pParentShape)
+GmoShape* ShapesCreator::create_auxobj_shape(ImoAuxObj* pAO, const AuxObjContext& aoc,
+                                             const SystemLayoutScope& systemScope)
 {
     //factory method to create shapes for auxobjs
 
+    int iInstr = aoc.iInstr;
+    int iStaff = aoc.iStaff;
+    int idxStaff = aoc.idxStaff;
+    GmoShape* pParentShape = aoc.pStaffObjShape;
+    VerticalProfile* pVProfile = systemScope.get_vertical_profile();
+    AuxShapesAlignersSystem* pAligner = systemScope.get_aux_shapes_aligner();
+
     InstrumentEngraver* pInstrEngrv = m_pPartsEngraver->get_engraver_for(iInstr);
     LUnits yTop = pInstrEngrv->get_top_line_of_staff(iStaff);
+
+    EngraverContext ctx(m_libraryScope, m_pScoreMeter, iInstr, iStaff, idxStaff, pVProfile, pAligner);
 
     UPoint pos((pParentShape->get_left() + pParentShape->get_width() / 2.0f), yTop);
     switch (pAO->get_obj_type())
@@ -1273,45 +1281,42 @@ GmoShape* ShapesCreator::create_auxobj_shape(ImoAuxObj* pAO, int iInstr, int iSt
         case k_imo_articulation_symbol:
         {
             ImoArticulation* pImo = static_cast<ImoArticulation*>(pAO);
-            ArticulationEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr, iStaff,
-                                       idxStaff, pVProfile);
+            ArticulationEngraver engrv(ctx);
             Color color = pImo->get_color();
             return engrv.create_shape(pImo, pos, color, pParentShape);
         }
         case k_imo_dynamics_mark:
         {
             ImoDynamicsMark* pImo = static_cast<ImoDynamicsMark*>(pAO);
-            DynamicsMarkEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr, iStaff,
-                                       idxStaff, pVProfile);
+            DynamicsMarkEngraver engrv(ctx);
             Color color = pImo->get_color();
             return engrv.create_shape(pImo, pos, color, pParentShape);
         }
         case k_imo_fermata:
         {
             ImoFermata* pImo = static_cast<ImoFermata*>(pAO);
-            FermataEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr, iStaff);
+            FermataEngraver engrv(ctx);
             Color color = pImo->get_color();
             return engrv.create_shape(pImo, pos, color, pParentShape);
         }
         case k_imo_metronome_mark:
         {
             ImoMetronomeMark* pImo = static_cast<ImoMetronomeMark*>(pAO);
-            MetronomeMarkEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr, iStaff);
+            MetronomeMarkEngraver engrv(ctx);
             Color color = pImo->get_color();
             return engrv.create_shape(pImo, pos, color);
         }
         case k_imo_ornament:
         {
             ImoOrnament* pImo = static_cast<ImoOrnament*>(pAO);
-            OrnamentEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr, iStaff);
+            OrnamentEngraver engrv(ctx);
             Color color = pImo->get_color();
             return engrv.create_shape(pImo, pos, color, pParentShape);
         }
         case k_imo_pedal_mark:
         {
             ImoPedalMark* pImo = static_cast<ImoPedalMark*>(pAO);
-            PedalMarkEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr, iStaff,
-                                    idxStaff, pVProfile);
+            PedalMarkEngraver engrv(ctx);
             return engrv.create_shape(pImo, pos, pImo->get_color(), pParentShape);
         }
         case k_imo_score_line:
@@ -1338,14 +1343,14 @@ GmoShape* ShapesCreator::create_auxobj_shape(ImoAuxObj* pAO, int iInstr, int iSt
         case k_imo_technical:
         {
             ImoTechnical* pImo = static_cast<ImoTechnical*>(pAO);
-            TechnicalEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr, iStaff);
+            TechnicalEngraver engrv(ctx);
             Color color = pImo->get_color();
             return engrv.create_shape(pImo, pos, color, pParentShape);
         }
         case k_imo_symbol_repetition_mark:
         {
             ImoSymbolRepetitionMark* pImo = static_cast<ImoSymbolRepetitionMark*>(pAO);
-            CodaSegnoEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr, iStaff);
+            CodaSegnoEngraver engrv(ctx);
             Color color = pImo->get_color();
             return engrv.create_shape(pImo, pos, color, pParentShape);
         }

--- a/src/graphic_model/layouters/lomse_spacing_algorithm.cpp
+++ b/src/graphic_model/layouters/lomse_spacing_algorithm.cpp
@@ -506,7 +506,7 @@ void ColumnsBuilder::store_info_about_attached_objects(ImoStaffObj* pSO,
     if (!pAuxObjs && !pRelObjs)
         return;
 
-    PendingAuxObj* data = LOMSE_NEW PendingAuxObj(pSO, pMainShape, iInstr, iStaff,
+    AuxObjContext* data = LOMSE_NEW AuxObjContext(pSO, pMainShape, iInstr, iStaff,
                            iCol, iLine, pInstr, idxStaff);
     m_pScoreLyt->m_pendingAuxObjs.push_back(data);
 }

--- a/src/graphic_model/layouters/lomse_spacing_algorithm_gourlay.cpp
+++ b/src/graphic_model/layouters/lomse_spacing_algorithm_gourlay.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/src/graphic_model/layouters/lomse_system_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_system_layouter.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -935,7 +935,6 @@ void SystemLayouter::setup_aux_shapes_aligner(EAuxShapesAlignmentScope scope, Te
                                                                    maxAlignDistance));
     }
 
-    m_pVProfile->set_current_aux_shapes_aligner(m_curAuxShapesAligner.get());
     m_systemLayoutScope.set_current_aux_shapes_aligner(m_curAuxShapesAligner.get());
 }
 
@@ -944,7 +943,6 @@ void SystemLayouter::engrave_attached_object(ImoObj* pAR, const AuxObjContext& a
                                              int iSystem)
 {
     ImoStaffObj* pSO = aoc.pSO;
-    GmoShape* pMainShape = aoc.pStaffObjShape;      //parent staffObj shape
     int iInstr = aoc.iInstr;
     int iStaff = aoc.iStaff;
     int iCol = aoc.iCol;
@@ -955,6 +953,7 @@ void SystemLayouter::engrave_attached_object(ImoObj* pAR, const AuxObjContext& a
     RelObjEngravingContext ctx;
     ctx.iSystem = iSystem;
     ctx.pVProfile = m_pVProfile.get();
+    ctx.pAuxShapesAligner = m_curAuxShapesAligner.get();
     ctx.xStaffRight = pInstrEngrv->get_staves_right();
     ctx.xStaffLeft = pInstrEngrv->get_staves_left();
     ctx.yStaffTop = pInstrEngrv->get_top_line_of_staff(iStaff);
@@ -1080,10 +1079,8 @@ void SystemLayouter::engrave_attached_object(ImoObj* pAR, const AuxObjContext& a
         else
         {
             GmoShape* pAuxShape =
-                        m_pShapesCreator->create_auxobj_shape(pAO, iInstr, iStaff,
-                                                              idxStaff, m_pVProfile.get(),
-                                                              pMainShape);
-//            pMainShape->accept_link_from(pAuxShape);
+                m_pShapesCreator->create_auxobj_shape(pAO, aoc, m_systemLayoutScope);
+
             add_aux_shape_to_model(pAuxShape, GmoShape::k_layer_aux_objs,
                                    iCol, iInstr, iStaff, idxStaff);
         }

--- a/src/graphic_model/layouters/lomse_system_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_system_layouter.cpp
@@ -954,6 +954,7 @@ void SystemLayouter::engrave_attached_object(ImoObj* pAR, const AuxObjContext& a
     ctx.iSystem = iSystem;
     ctx.pVProfile = m_pVProfile.get();
     ctx.pAuxShapesAligner = m_curAuxShapesAligner.get();
+    ctx.pInstrEngrv = pInstrEngrv;
     ctx.xStaffRight = pInstrEngrv->get_staves_right();
     ctx.xStaffLeft = pInstrEngrv->get_staves_left();
     ctx.yStaffTop = pInstrEngrv->get_top_line_of_staff(iStaff);
@@ -1097,6 +1098,7 @@ void SystemLayouter::engrave_not_finished_relobj(ImoRelObj* pRO, const AuxObjCon
     ctx.iSystem = m_iSystem;
     ctx.pVProfile = m_pVProfile.get();
     ctx.pAuxShapesAligner = m_curAuxShapesAligner.get();
+    ctx.pInstrEngrv = pInstrEngrv;
     ctx.xStaffRight = pInstrEngrv->get_staves_right();
     ctx.xStaffLeft = pInstrEngrv->get_staves_left();
     ctx.yStaffTop = pInstrEngrv->get_top_line_of_staff(aoc.iStaff);

--- a/src/graphic_model/layouters/lomse_vertical_profile.cpp
+++ b/src/graphic_model/layouters/lomse_vertical_profile.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -481,10 +481,10 @@ vector<UPoint> VerticalProfile::get_max_profile_points(LUnits xStart, LUnits xEn
     return dataPoints;
 }
 
-//---------------------------------------------------------------------------------------
-AuxShapesAligner* VerticalProfile::get_current_aux_shapes_aligner(int staff, bool fAbove)
-{
-    return m_pCurrentAuxShapesAligner ? &m_pCurrentAuxShapesAligner->get_aligner(staff, fAbove) : nullptr;
-}
+////---------------------------------------------------------------------------------------
+//AuxShapesAligner* VerticalProfile::get_current_aux_shapes_aligner(int staff, bool fAbove)
+//{
+//    return m_pCurrentAuxShapesAligner ? &m_pCurrentAuxShapesAligner->get_aligner(staff, fAbove) : nullptr;
+//}
 
 }  //namespace lomse

--- a/src/tests/lomse_test_beam_engraver.cpp
+++ b/src/tests/lomse_test_beam_engraver.cpp
@@ -190,7 +190,6 @@ public:
     {
         int iInstr = 0;
         int iStaff = 0;
-        int iSystem = 0;
         int iCol = 0;
 
         list< pair<ImoStaffObj*, ImoRelDataObj*> >& notes = pBeam->get_related_objects();
@@ -218,28 +217,23 @@ public:
         for (it = notes.begin(); it != notes.end(); ++it, ++i)
         {
             ImoNote* pNote = static_cast<ImoNote*>( (*it).first );
+            AuxObjContext aoc(pNote, m_shapes[i], iInstr, iStaff, iCol, 0, nullptr, -1);
             if (i == 0)
             {
                 //first note
                 m_pBeamEngrv = LOMSE_NEW MyBeamEngraver(m_libraryScope, m_pMeter);
-                m_pBeamEngrv->set_start_staffobj(pBeam, pNote, m_shapes[i],
-                                                 iInstr, iStaff, iSystem, iCol,
-                                                 0.0f, 0.0f, 0.0f, -1, nullptr);
+                m_pBeamEngrv->set_start_staffobj(pBeam, aoc);
                 m_pStorage->save_engraver(m_pBeamEngrv, pBeam);
             }
             else if (i == numNotes-1)
             {
                 //last note
-                m_pBeamEngrv->set_end_staffobj(pBeam, pNote, m_shapes[i],
-                                               iInstr, iStaff, iSystem, iCol,
-                                               0.0f, 0.0f, 0.0f, -1, nullptr);
+                m_pBeamEngrv->set_end_staffobj(pBeam, aoc);
             }
             else
             {
                 //intermediate note
-                m_pBeamEngrv->set_middle_staffobj(pBeam, pNote, m_shapes[i],
-                                                  iInstr, iStaff, iSystem, iCol,
-                                                  0.0f, 0.0f, 0.0f, -1, nullptr);
+                m_pBeamEngrv->set_middle_staffobj(pBeam, aoc);
             }
         }
     }
@@ -506,7 +500,8 @@ SUITE(BeamEngraverTest)
         ImoBeam* pBeam = create_beam(doc, "(n c4 e g+)(n f4 e g-)");
         prepare_to_engrave_beam(pBeam);
 
-        m_pBeamShape = dynamic_cast<GmoShapeBeam*>( m_pBeamEngrv->create_last_shape() );
+        RelObjEngravingContext ctx;
+        m_pBeamShape = dynamic_cast<GmoShapeBeam*>( m_pBeamEngrv->create_last_shape(ctx) );
         CHECK( m_pBeamShape != nullptr );
 
         delete_test_data();
@@ -519,7 +514,8 @@ SUITE(BeamEngraverTest)
         ImoBeam* pBeam = create_beam(doc, "(n c4 e g+)(n f4 e g-)");
         prepare_to_engrave_beam(pBeam);
 
-        m_pBeamShape = dynamic_cast<GmoShapeBeam*>( m_pBeamEngrv->create_last_shape() );
+        RelObjEngravingContext ctx;
+        m_pBeamShape = dynamic_cast<GmoShapeBeam*>( m_pBeamEngrv->create_last_shape(ctx) );
 
         std::vector<GmoShapeNote*>::iterator it;
         for (it = m_shapes.begin(); it != m_shapes.end(); ++it)

--- a/src/tests/lomse_test_chord_engraver.cpp
+++ b/src/tests/lomse_test_chord_engraver.cpp
@@ -216,32 +216,30 @@ public:
     {
         int iInstr = 0;
         int iStaff = 0;
-        int iSystem = 0;
         int iCol = 0;
 
         int numNotes = (m_pShape3 ? 3 : 2);
 
         //first note
         m_pChordEngrv = LOMSE_NEW MyChordEngraver(m_libraryScope, m_pMeter, numNotes);
-        m_pChordEngrv->set_start_staffobj(m_pChord, m_pNote1, m_pShape1, iInstr, iStaff,
-                                          iSystem, iCol, 0.0f, 0.0f, 0.0f, -1, nullptr);
+        AuxObjContext aoc1(m_pNote1, m_pShape1, iInstr, iStaff, iCol, 0, nullptr, -1);
+        m_pChordEngrv->set_start_staffobj(m_pChord, aoc1);
         m_pStorage->save_engraver(m_pChordEngrv, m_pChord);
 
         if (numNotes == 3)
         {
             //second note
-            m_pChordEngrv->set_middle_staffobj(m_pChord, m_pNote2, m_pShape2, iInstr,
-                                        iStaff, iSystem, iCol,
-                                        0.0f, 0.0f, 0.0f, -1, nullptr);
+            AuxObjContext aoc2(m_pNote2, m_pShape2, iInstr, iStaff, iCol, 0, nullptr, -1);
+            m_pChordEngrv->set_middle_staffobj(m_pChord, aoc2);
             //last note
-            m_pChordEngrv->set_end_staffobj(m_pChord, m_pNote3, m_pShape3, iInstr,
-                                     iStaff, iSystem, iCol,
-                                     0.0f, 0.0f, 0.0f, -1, nullptr);
+            AuxObjContext aoc3(m_pNote3, m_pShape3, iInstr, iStaff, iCol, 0, nullptr, -1);
+            m_pChordEngrv->set_end_staffobj(m_pChord, aoc3);
         }
         else
-            m_pChordEngrv->set_end_staffobj(m_pChord, m_pNote2, m_pShape2, iInstr,
-                                     iStaff, iSystem, iCol,
-                                     0.0f, 0.0f, 0.0f, -1, nullptr);
+        {
+            AuxObjContext aoc2(m_pNote2, m_pShape2, iInstr, iStaff, iCol, 0, nullptr, -1);
+            m_pChordEngrv->set_end_staffobj(m_pChord, aoc2);
+        }
     }
 
     //-----------------------------------------------------------------------------------

--- a/src/tests/lomse_test_tuplet_engraver.cpp
+++ b/src/tests/lomse_test_tuplet_engraver.cpp
@@ -101,7 +101,6 @@ public:
     {
         int iInstr = 0;
         int iStaff = 0;
-        int iSystem = 0;
         int iCol = 0;
 
         list< pair<ImoStaffObj*, ImoRelDataObj*> >& notes = pTuplet->get_related_objects();
@@ -139,28 +138,23 @@ public:
         for (it = notes.begin(); it != notes.end(); ++it, ++i)
         {
             ImoNoteRest* pNR = static_cast<ImoNoteRest*>( (*it).first );
+            AuxObjContext aoc(pNR, m_shapes[i], iInstr, iStaff, iCol, 0, nullptr, -1);
             if (i == 0)
             {
                 //first note
                 m_pTupletEngrv = LOMSE_NEW TupletEngraver(m_libraryScope, m_pMeter);
-                m_pTupletEngrv->set_start_staffobj(pTuplet, pNR, m_shapes[i],
-                                                 iInstr, iStaff, iSystem, iCol,
-                                                 0.0f, 0.0f, 0.0f, -1, nullptr);
+                m_pTupletEngrv->set_start_staffobj(pTuplet, aoc);
                 m_pStorage->save_engraver(m_pTupletEngrv, pTuplet);
             }
             else if (i == numNotes-1)
             {
                 //last note
-                m_pTupletEngrv->set_end_staffobj(pTuplet, pNR, m_shapes[i],
-                                               iInstr, iStaff, iSystem, iCol,
-                                               0.0f, 0.0f, 0.0f, -1, nullptr);
+                m_pTupletEngrv->set_end_staffobj(pTuplet, aoc);
             }
             else
             {
                 //intermediate note
-                m_pTupletEngrv->set_middle_staffobj(pTuplet, pNR, m_shapes[i],
-                                                  iInstr, iStaff, iSystem, iCol,
-                                                  0.0f, 0.0f, 0.0f, -1, nullptr);
+                m_pTupletEngrv->set_middle_staffobj(pTuplet, aoc);
             }
         }
     }
@@ -223,7 +217,8 @@ SUITE(TupletEngraverTest)
         ImoTuplet* pTuplet = create_tuplet(&doc, "(n c4 e (t + 2 3))(n f4 e (t -))");
         prepare_to_engrave_tuplet(pTuplet);
 
-        m_pTupletShape = dynamic_cast<GmoShapeTuplet*>( m_pTupletEngrv->create_last_shape() );
+        RelObjEngravingContext ctx;
+        m_pTupletShape = dynamic_cast<GmoShapeTuplet*>( m_pTupletEngrv->create_last_shape(ctx) );
         CHECK( m_pTupletShape != nullptr );
 
         delete_test_data();


### PR DESCRIPTION
Engravers were coded as there was a need, without any previous ideas for future needs. Currently, engravers receive too many parameters and there is a lack of consistency between them. Therefore, time has come to start putting order and normalizing all this a bit.

This PR neither fixes bugs nor adds new features. It just refactors the code to simplify and structure the parameters received by the engravers and other objects involved in the layout process. Also, classifies the engravers and creates a hierarchy of abstract classes for engravers.


**Summary of changes**

- Defined struct `ScoreLayoutScope` to store global information whose scope is the score layout process. It facilitates access to this global information and simplifies the list of parameters to pass to `SystemLayouters`. 

- Defined struct `SystemLayoutScope` to store global information whose scope is the layout of a system. It facilitates access to this global information and simplifies the of parameters to pass to other classes and methods related to layout.

- Engravers have been classified and a hierarchy of abstract classes for engravers have been defined, deriving each specific engraver from the appropriate class.

- Defined struct `EngraverContext` to store context information and simplify engravers constructor parameters list.

- Defined struct `RelObjEngravingContext` to store context information required to create a shape for a RelObj. This simplifies the list of parameters to pass to methods related to engraving a RelObj, as well as simplifies code maintenance. The list of parameters passed to the different RelObj engravers have been simplified.

- Struct `PendingAuxObj`, defined in `lomse_score_layouter.h` has been replaced by struct `AuxObjContext` in `lomse_engraver.h`. As it contains context information for AuxObjs and RelObjs, it is now also used to simplify the parameters list of some engravers methods.

- Access to `AuxShapesAligner` has been removed from `VProfile`. And `VProfile` is no longer a parameter for engravers. Both are now accessible in `SystemLayoutScope` struct, and from there a pointer is passed to engravers via the `EngraverContext` and the `RelObjEngravingContext` structs.

