### PR TITLE
Changes in IM (redesing AttObj and ImoTextInfo), memory leaks and fixes

### DIFF
--- a/include/lomse_chord_engraver.h
+++ b/include/lomse_chord_engraver.h
@@ -175,6 +175,7 @@ protected:
     size_t m_numStaves;
     int m_nUpForced;                    //number of forced chords/single notes up
     int m_nDownForced;                  //number of forced chords/single notes down
+    bool m_fTransferred = false;        //ownership of m_pStemsDir transferred to m_pBeam
     ImoBeam* m_pBeam;                   //the beam to compute
     std::vector<int>* m_pClefs;         //current clefs for each staff
     std::vector<ImoChord*> m_chords;     //the beamed chords
@@ -187,7 +188,7 @@ protected:
 
 public:
     BeamedChordHelper(ImoBeam* pBeam, std::vector<int>* pLastClefs);
-    ~BeamedChordHelper() {}
+    ~BeamedChordHelper();
 
 
     //methods and variables to determine stems direction for beamed chords

--- a/include/lomse_im_note.h
+++ b/include/lomse_im_note.h
@@ -90,6 +90,10 @@ protected:
 public:
     ImoNoteRest(int objtype) : ImoStaffObj(objtype) {}
     virtual ~ImoNoteRest() {}
+    ImoNoteRest(const ImoNoteRest&) = delete;
+    ImoNoteRest& operator= (const ImoNoteRest&) = delete;
+    ImoNoteRest(ImoNoteRest&&) = delete;
+    ImoNoteRest& operator= (ImoNoteRest&&) = delete;
 
     //overrides to ImoStaffObj
     TimeUnits get_duration() override { return m_duration; }
@@ -155,6 +159,7 @@ public:
     ImoTuplet* get_first_tuplet();
 
     //IM attributes interface
+//    void set_attribute(TIntAttribute attrib, int value) override;
     void set_int_attribute(TIntAttribute attrib, int value) override;
     int get_int_attribute(TIntAttribute attrib) override;
     list<TIntAttribute> get_supported_attributes() override;
@@ -194,6 +199,10 @@ protected:
 
 public:
     virtual ~ImoRest() {}
+    ImoRest(const ImoRest&) = delete;
+    ImoRest& operator= (const ImoRest&) = delete;
+    ImoRest(ImoRest&&) = delete;
+    ImoRest& operator= (ImoRest&&) = delete;
 
     inline bool is_go_fwd() { return m_fGoFwd; }
     inline bool is_full_measure() { return m_fFullMeasureRest; }
@@ -235,6 +244,10 @@ protected:
 
 public:
     virtual ~ImoNote();
+    ImoNote(const ImoNote&) = delete;
+    ImoNote& operator= (const ImoNote&) = delete;
+    ImoNote(ImoNote&&) = delete;
+    ImoNote& operator= (ImoNote&&) = delete;
 
     //options for notated accidentals
     enum ENotatedAcc
@@ -383,6 +396,10 @@ protected:
 
 public:
     virtual ~ImoGraceNote() {}
+    ImoGraceNote(const ImoGraceNote&) = delete;
+    ImoGraceNote& operator= (const ImoGraceNote&) = delete;
+    ImoGraceNote(ImoGraceNote&&) = delete;
+    ImoGraceNote& operator= (ImoGraceNote&&) = delete;
 
     inline void set_align_timepos(TimeUnits value) { m_alignTime = value; }
     inline TimeUnits get_align_timepos() { return m_alignTime; }

--- a/include/lomse_mnx_analyser.h
+++ b/include/lomse_mnx_analyser.h
@@ -42,13 +42,19 @@ namespace lomse
 {
 
 //forward declarations
+class AnalysisData;
+class ImoData;
+class JumpData;
+class EventData;
+
+class AnalysisResult;
+class ImoNote;
+class ImoObj;
+class ImoRest;
+class LdpFactory;
 class LibraryScope;
 class MnxElementAnalyser;
-class LdpFactory;
 class MnxAnalyser;
-class ImoObj;
-class ImoNote;
-class ImoRest;
 
 typedef std::vector<XmlNode> MeasuresVector;    //global measures for a part
 
@@ -211,7 +217,7 @@ protected:
     std::string m_fileLocator;
 
     //analysis output
-    void*           m_pResult;
+    std::unique_ptr<AnalysisResult> m_result;
 
     // information maintained in MnxAnalyser
     ImoScore*       m_pCurScore;        //the score under construction
@@ -264,7 +270,12 @@ public:
     bool analyse_node(XmlNode* pNode, ImoObj* pAnchor=nullptr);
     ImoMusicData* analyse_global_measure(XmlNode* pNode);
     void prepare_for_new_instrument_content();
-    void* get_result() { return m_pResult; }
+
+    //access to analysers' result
+    std::unique_ptr<AnalysisData> get_result();
+    std::unique_ptr<ImoData> get_imo_result();
+    std::unique_ptr<JumpData> get_jump_result();
+    std::unique_ptr<EventData> get_event_result();
 
     //part-list
     bool part_list_is_valid() { return m_partList.get_num_items() > 0; }
@@ -432,11 +443,18 @@ public:
     //bool get_measure_location_value(const string& value, );
     //bool get_smufl_glyph_name(const string& value, );
 
+    //additional types for set_result()
+    enum {
+        k_jump_data = 10000,
+        k_event_data,
+    };
 
 protected:
     friend class MnxElementAnalyser;
     MnxElementAnalyser* new_analyser(const std::string& name, ImoObj* pAnchor=nullptr);
-    void set_result(void* pValue) { m_pResult = pValue; }
+    void set_result(AnalysisData* pData);
+    void delete_result();
+
 
     void delete_relation_builders();
     void delete_globals();

--- a/src/exporters/lomse_ldp_exporter.cpp
+++ b/src/exporters/lomse_ldp_exporter.cpp
@@ -1157,19 +1157,19 @@ protected:
         if (m_pObj->has_name())
         {
             start_element("name", k_no_imoid);
-            ImoScoreText& txt = m_pObj->get_name();
-            m_source << " \"" << txt.get_text() << "\"";
+            TypeTextInfo& txt = m_pObj->get_name();
+            m_source << " \"" << txt.text << "\"";
             space_needed();
-            add_style( txt.get_style() );
+            add_style( m_pObj->get_name_style() );
             end_element(k_in_same_line);
         }
         if (m_pObj->has_abbrev())
         {
             start_element("abbrev", k_no_imoid);
-            ImoScoreText& txt = m_pObj->get_abbrev();
-            m_source << " \"" << txt.get_text() << "\"";
+            TypeTextInfo& txt = m_pObj->get_abbrev();
+            m_source << " \"" << txt.text << "\"";
             space_needed();
-            add_style( txt.get_style() );
+            add_style( m_pObj->get_abbrev_style() );
             end_element(k_in_same_line);
         }
     }

--- a/src/graphic_model/engravers/lomse_chord_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_chord_engraver.cpp
@@ -834,6 +834,13 @@ BeamedChordHelper::BeamedChordHelper(ImoBeam* pBeam, std::vector<int>* pClefs)
 }
 
 //---------------------------------------------------------------------------------------
+BeamedChordHelper::~BeamedChordHelper()
+{
+    if (!m_fTransferred)
+        delete m_pStemsDir;
+}
+
+//---------------------------------------------------------------------------------------
 bool BeamedChordHelper::compute_stems_directions()
 {
     //returns first chord/single note stem direction
@@ -1128,6 +1135,7 @@ void BeamedChordHelper::transfer_stem_directions_to_notes(ImoBeam* pBeam, int be
     }
 
     pBeam->set_stems_direction(m_pStemsDir);
+    m_fTransferred = true;
 }
 
 

--- a/src/graphic_model/engravers/lomse_instrument_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_instrument_engraver.cpp
@@ -443,12 +443,12 @@ void GroupEngraver::measure_name_abbrev()
     LUnits uSpaceAfterName = tenths_to_logical(LOMSE_INSTR_SPACE_AFTER_NAME);
     if (m_pGroup->has_name())
     {
-        ImoScoreText& text = m_pGroup->get_name();
-        ImoStyle* pStyle = text.get_style();
+        TypeTextInfo& text = m_pGroup->get_name();
+        ImoStyle* pStyle = m_pGroup->get_name_style();
         if (!pStyle)
             pStyle = m_pScore->get_default_style();
-        TextEngraver engr(m_libraryScope, m_pMeter, text.get_text(),
-                          text.get_language(), pStyle);
+        TextEngraver engr(m_libraryScope, m_pMeter, text.text,
+                          text.language, pStyle);
 
         m_nameBox.width = engr.measure_width() + uSpaceAfterName;
         m_nameBox.height = engr.measure_height();
@@ -457,12 +457,12 @@ void GroupEngraver::measure_name_abbrev()
     }
     if (m_pGroup->has_abbrev())
     {
-        ImoScoreText& text = m_pGroup->get_abbrev();
-        ImoStyle* pStyle = text.get_style();
+        TypeTextInfo& text = m_pGroup->get_abbrev();
+        ImoStyle* pStyle = m_pGroup->get_abbrev_style();
         if (!pStyle)
             pStyle = m_pScore->get_default_style();
-        TextEngraver engr(m_libraryScope, m_pMeter, text.get_text(),
-                          text.get_language(), pStyle);
+        TextEngraver engr(m_libraryScope, m_pMeter, text.text,
+                          text.language, pStyle);
 
         m_abbrevBox.width = engr.measure_width() + uSpaceAfterName;
         m_abbrevBox.height = engr.measure_height();
@@ -521,12 +521,12 @@ void GroupEngraver::add_name_abbrev(GmoBoxSystem* pBox, int iSystem)
         {
             LUnits xLeft = m_nameBox.x + pBox->get_left();
 
-            ImoScoreText& text = m_pGroup->get_name();
-            ImoStyle* pStyle = text.get_style();
+            TypeTextInfo& text = m_pGroup->get_name();
+            ImoStyle* pStyle = m_pGroup->get_name_style();
             if (!pStyle)
                 pStyle = m_pScore->get_default_style();
-            TextEngraver engr(m_libraryScope, m_pMeter, text.get_text(),
-                              text.get_language(), pStyle);
+            TextEngraver engr(m_libraryScope, m_pMeter, text.text,
+                              text.language, pStyle);
             GmoShape* pShape = engr.create_shape(m_pGroup, xLeft, yTop);
             pBox->add_shape(pShape, GmoShape::k_layer_staff);
         }
@@ -537,12 +537,12 @@ void GroupEngraver::add_name_abbrev(GmoBoxSystem* pBox, int iSystem)
         {
             LUnits xLeft = m_abbrevBox.x + pBox->get_left();
 
-            ImoScoreText& text = m_pGroup->get_abbrev();
-            ImoStyle* pStyle = text.get_style();
+            TypeTextInfo& text = m_pGroup->get_abbrev();
+            ImoStyle* pStyle = m_pGroup->get_abbrev_style();
             if (!pStyle)
                 pStyle = m_pScore->get_default_style();
-            TextEngraver engr(m_libraryScope, m_pMeter, text.get_text(),
-                              text.get_language(), pStyle);
+            TextEngraver engr(m_libraryScope, m_pMeter, text.text,
+                              text.language, pStyle);
             GmoShape* pShape = engr.create_shape(m_pGroup, xLeft, yTop);
             pBox->add_shape(pShape, GmoShape::k_layer_staff);
         }
@@ -646,12 +646,11 @@ void InstrumentEngraver::measure_name_abbrev()
     LUnits uSpaceAfterName = tenths_to_logical(LOMSE_INSTR_SPACE_AFTER_NAME);
     if (m_pInstr->has_name())
     {
-        ImoScoreText& text = m_pInstr->get_name();
-        ImoStyle* pStyle = text.get_style();
+        TypeTextInfo& text = m_pInstr->get_name();
+        ImoStyle* pStyle = m_pInstr->get_name_style();
         if (!pStyle)
             pStyle = m_pScore->get_default_style();
-        TextEngraver engr(m_libraryScope, m_pMeter, text.get_text(),
-                          text.get_language(), pStyle);
+        TextEngraver engr(m_libraryScope, m_pMeter, text.text, text.language, pStyle);
 
         m_nameBox.width = engr.measure_width() + uSpaceAfterName;
         m_nameBox.height = engr.measure_height();
@@ -660,12 +659,11 @@ void InstrumentEngraver::measure_name_abbrev()
     }
     if (m_pInstr->has_abbrev())
     {
-        ImoScoreText& text = m_pInstr->get_abbrev();
-        ImoStyle* pStyle = text.get_style();
+        TypeTextInfo& text = m_pInstr->get_abbrev();
+        ImoStyle* pStyle = m_pInstr->get_abbrev_style();
         if (!pStyle)
             pStyle = m_pScore->get_default_style();
-        TextEngraver engr(m_libraryScope, m_pMeter, text.get_text(),
-                          text.get_language(), pStyle);
+        TextEngraver engr(m_libraryScope, m_pMeter, text.text, text.language, pStyle);
 
         m_abbrevBox.width = engr.measure_width() + uSpaceAfterName;
         m_abbrevBox.height = engr.measure_height();
@@ -720,12 +718,11 @@ void InstrumentEngraver::add_name_abbrev(GmoBoxSystem* pBox, int iSystem)
             m_nameBox.y = (get_staff_top_position() + get_staff_bottom_position()) / 2.0f;
             LUnits yTop = m_nameBox.y + m_org.y;
 
-            ImoScoreText& text = m_pInstr->get_name();
-            ImoStyle* pStyle = text.get_style();
+            TypeTextInfo& text = m_pInstr->get_name();
+            ImoStyle* pStyle = m_pInstr->get_name_style();
             if (!pStyle)
                 pStyle = m_pScore->get_default_style();
-            TextEngraver engr(m_libraryScope, m_pMeter, text.get_text(),
-                              text.get_language(), pStyle);
+            TextEngraver engr(m_libraryScope, m_pMeter, text.text, text.language, pStyle);
             GmoShape* pShape = engr.create_shape(m_pInstr, xLeft, yTop);
             pBox->add_shape(pShape, GmoShape::k_layer_staff);
         }
@@ -738,12 +735,11 @@ void InstrumentEngraver::add_name_abbrev(GmoBoxSystem* pBox, int iSystem)
             m_abbrevBox.y = (get_staff_top_position() + get_staff_bottom_position()) / 2.0f;
             LUnits yTop = m_abbrevBox.y + m_org.y;
 
-            ImoScoreText& text = m_pInstr->get_abbrev();
-            ImoStyle* pStyle = text.get_style();
+            TypeTextInfo& text = m_pInstr->get_abbrev();
+            ImoStyle* pStyle = m_pInstr->get_abbrev_style();
             if (!pStyle)
                 pStyle = m_pScore->get_default_style();
-            TextEngraver engr(m_libraryScope, m_pMeter, text.get_text(),
-                              text.get_language(), pStyle);
+            TextEngraver engr(m_libraryScope, m_pMeter, text.text, text.language, pStyle);
             GmoShape* pShape = engr.create_shape(m_pInstr, xLeft, yTop);
             pBox->add_shape(pShape, GmoShape::k_layer_staff);
         }

--- a/src/internal_model/lomse_api_internal_model.cpp
+++ b/src/internal_model/lomse_api_internal_model.cpp
@@ -1211,8 +1211,8 @@ LOMSE_IMPLEMENT_IM_API_CLASS(AInstrument, ImoInstrument, AObject)
 std::string& AInstrument::name_string() const
 {
     ensure_validity();
-    ImoScoreText& text = const_cast<ImoInstrument*>(pimpl())->get_name();
-    return text.get_text();
+    TypeTextInfo& text = const_cast<ImoInstrument*>(pimpl())->get_name();
+    return text.text;
 }
 
 //---------------------------------------------------------------------------------------
@@ -1223,8 +1223,8 @@ std::string& AInstrument::name_string() const
 std::string& AInstrument::abbreviation_string() const
 {
     ensure_validity();
-    ImoScoreText& text = const_cast<ImoInstrument*>(pimpl())->get_abbrev();
-    return text.get_text();
+    TypeTextInfo& text = const_cast<ImoInstrument*>(pimpl())->get_abbrev();
+    return text.text;
 }
 
 //---------------------------------------------------------------------------------------
@@ -1384,8 +1384,8 @@ EGroupSymbol AInstrGroup::symbol() const
 const std::string& AInstrGroup::name_string() const
 {
     ensure_validity();
-    ImoScoreText& text = const_cast<ImoInstrGroup*>(pimpl())->get_name();
-    return text.get_text();
+    TypeTextInfo& text = const_cast<ImoInstrGroup*>(pimpl())->get_name();
+    return text.text;
 }
 
 //---------------------------------------------------------------------------------------
@@ -1396,8 +1396,8 @@ const std::string& AInstrGroup::name_string() const
 const std::string& AInstrGroup::abbreviation_string() const
 {
     ensure_validity();
-    ImoScoreText& text = const_cast<ImoInstrGroup*>(pimpl())->get_abbrev();
-    return text.get_text();
+    TypeTextInfo& text = const_cast<ImoInstrGroup*>(pimpl())->get_abbrev();
+    return text.text;
 }
 
 //@}    //Access to group properties

--- a/src/internal_model/lomse_im_factory.cpp
+++ b/src/internal_model/lomse_im_factory.cpp
@@ -139,7 +139,6 @@ ImoObj* ImFactory::inject(int type, Document* pDoc, ImoId id)
         case k_imo_technical:           pObj = LOMSE_NEW ImoTechnical();          break;
         case k_imo_textblock_info:      pObj = LOMSE_NEW ImoTextBlockInfo();      break;
         case k_imo_text_box:            pObj = LOMSE_NEW ImoTextBox();            break;
-        case k_imo_text_info:           pObj = LOMSE_NEW ImoTextInfo();           break;
         case k_imo_text_item:           pObj = LOMSE_NEW ImoTextItem();           break;
         case k_imo_text_repetition_mark:   pObj = LOMSE_NEW ImoTextRepetitionMark();   break;
         case k_imo_tie:                 pObj = LOMSE_NEW ImoTie();                break;

--- a/src/parser/lmd/lomse_lmd_analyser.cpp
+++ b/src/parser/lmd/lomse_lmd_analyser.cpp
@@ -2223,7 +2223,8 @@ public:
         {
             ImoScoreText* pText = get_name_abbrev();
             if (pText)
-                pGrp->set_name(pText);
+                pGrp->set_name(pText->get_text_info());
+            delete pText;
         }
 
         // grpAbbrev?
@@ -2231,7 +2232,8 @@ public:
         {
             ImoScoreText* pText = get_name_abbrev();
             if (pText)
-                pGrp->set_abbrev(pText);
+                pGrp->set_abbrev(pText->get_text_info());
+            delete pText;
         }
 
         // grpSymbol?
@@ -2443,7 +2445,8 @@ public:
         {
             ImoScoreText* pText = get_name_abbrev();
             if (pText)
-                pInstrument->set_name(pText);
+                pInstrument->set_name(pText->get_text_info());
+            delete pText;
         }
 
         // instrAbbrev?
@@ -2451,7 +2454,8 @@ public:
         {
             ImoScoreText* pText = get_name_abbrev();
             if (pText)
-                pInstrument->set_abbrev(pText);
+                pInstrument->set_abbrev(pText->get_text_info());
+            delete pText;
         }
 
         // staves?

--- a/src/parser/lomse_linker.cpp
+++ b/src/parser/lomse_linker.cpp
@@ -281,8 +281,11 @@ ImoObj* Linker::add_sound_change(ImoSoundChange* pInfo)
     }
     else
     {
-       LOMSE_LOG_ERROR("Parent of ImoSoundChange is neither <music-data> nor <direction>.");
-       return pInfo;
+        stringstream ss;
+        ss << "Parent of ImoSoundChange is neither <music-data> nor <direction>. Parent=";
+        ss << (m_pParent != nullptr ? m_pParent->get_name() : "nullptr");
+        LOMSE_LOG_ERROR(ss.str());
+        return pInfo;
     }
 
 //        //TODO: Move this to linker
@@ -373,9 +376,16 @@ ImoObj* Linker::add_text(ImoScoreText* pText)
             ImoInstrument* pInstr = static_cast<ImoInstrument*>(m_pParent);
             //could be 'name' or 'abbrev'
             if (m_ldpChildType == k_name)
-                pInstr->set_name(pText);
+            {
+                pInstr->set_name(pText->get_text_info());
+                pInstr->set_name_style(pText->get_style());
+            }
             else
-                pInstr->set_abbrev(pText);
+            {
+                pInstr->set_abbrev(pText->get_text_info());
+                pInstr->set_abbrev_style(pText->get_style());
+            }
+            delete pText;
             return nullptr;
         }
 
@@ -384,9 +394,16 @@ ImoObj* Linker::add_text(ImoScoreText* pText)
             ImoInstrGroup* pGrp = static_cast<ImoInstrGroup*>(m_pParent);
             //could be 'name' or 'abbrev'
             if (m_ldpChildType == k_name)
-                pGrp->set_name(pText);
+            {
+                pGrp->set_name(pText->get_text_info());
+                pGrp->set_name_style(pText->get_style());
+            }
             else
-                pGrp->set_abbrev(pText);
+            {
+                pGrp->set_abbrev(pText->get_text_info());
+                pGrp->set_abbrev_style(pText->get_style());
+            }
+            delete pText;
             return nullptr;
         }
 

--- a/src/parser/mxl/lomse_mxl_analyser.cpp
+++ b/src/parser/mxl/lomse_mxl_analyser.cpp
@@ -3249,6 +3249,8 @@ protected:
             pStyle->font_style(pFont->style);
             pStyle->font_weight(pFont->weight);
         }
+
+        delete pFont;
     }
 
     //-----------------------------------------------------------------------------------
@@ -4385,10 +4387,12 @@ public:
         error_if_more_elements();
 
         ImoObj* pSO = static_cast<ImoStaffObj*>(pMD->get_last_child());
-        if (pSO == nullptr || !pSO->is_barline())
-            add_barline(pInfo);
+        if (pSO == nullptr)
+            delete pInfo;   //TODO: What is the scenario for this case?
         else if (pSO->is_barline())
             static_cast<ImoBarline*>(pSO)->set_measure_info(pInfo);
+        else
+            add_barline(pInfo);
 
         return pMD;
     }
@@ -6019,11 +6023,7 @@ public:
 
         // group-name?
         if (get_optional("group-name"))
-        {
-            ImoScoreText* pText = get_name_abbrev();
-            if (pText)
-                pGrp->set_name(pText);
-        }
+            pGrp->set_name(m_childToAnalyse.value());
 
         // group-name-display?
         if (get_optional("group-name-display"))
@@ -6033,11 +6033,7 @@ public:
 
         // group-abbreviation?
         if (get_optional("group-abbreviation"))
-        {
-            ImoScoreText* pText = get_name_abbrev();
-            if (pText)
-                pGrp->set_abbrev(pText);
-        }
+            pGrp->set_abbrev(m_childToAnalyse.value());
 
         // group-abbreviation-display?
         if (get_optional("group-abbreviation-display"))
@@ -6103,25 +6099,6 @@ protected:
         }
     }
 
-    ImoScoreText* get_name_abbrev()
-    {
-        string name = m_childToAnalyse.value();
-        if (!name.empty())
-        {
-            Document* pDoc = m_pAnalyser->get_document_being_analysed();
-            ImoScoreText* pText = static_cast<ImoScoreText*>(
-                                        ImFactory::inject(k_imo_score_text, pDoc));
-            pText->set_text(name);
-
-            ImoScore* pScore = m_pAnalyser->get_score_being_analysed();
-            ImoStyle* pStyle = nullptr;
-            if (pScore)     //in unit tests the score might not exist
-                pStyle = pScore->get_default_style();
-            pText->set_style(pStyle);
-            return pText;
-        }
-        return nullptr;
-    }
 };
 
 

--- a/src/tests/lomse_test_internal_model.cpp
+++ b/src/tests/lomse_test_internal_model.cpp
@@ -1790,12 +1790,12 @@ SUITE(InternalModelTest)
     TEST_FIXTURE(InternalModelTestFixture, attr_01)
     {
         //@01. constructor
-        AttrObj a(0, 2);
-        AttrObj b(1, std::string("string"));
-        AttrObj c(2, 2.7);
-        AttrObj d(3, 2.5f);
-        AttrObj e(4, true);
-        AttrObj f(5, Color(80,70,55));
+        AttrInt a(0, 2);
+        AttrString b(1, std::string("string"));
+        AttrDouble c(2, 2.7);
+        AttrFloat d(3, 2.5f);
+        AttrBool e(4, true);
+        AttrColor f(5, Color(80,70,55));
 
         CHECK( a.get_int_value() == 2 );
         CHECK( b.get_string_value() == "string" );
@@ -1808,7 +1808,7 @@ SUITE(InternalModelTest)
     TEST_FIXTURE(InternalModelTestFixture, attr_02)
     {
         //@02. set and get value
-        AttrObj a(0);
+        AttrVariant a(0);
         a.set_string_value(std::string("string"));
         CHECK( a.get_string_value() == "string" );
 
@@ -1863,7 +1863,7 @@ SUITE(InternalModelTest)
         //@03. attributes are chained
 
         Document doc(m_libraryScope);
-        ImoObj* pImo = static_cast<ImoObj*>(ImFactory::inject(k_imo_barline, &doc));
+        ImoBarline* pImo = static_cast<ImoBarline*>(ImFactory::inject(k_imo_barline, &doc));
 
         pImo->set_int_attribute(5000, 2);
         CHECK( pImo->get_num_attributes() == 1 );

--- a/src/tests/lomse_test_ldp_analyser.cpp
+++ b/src/tests/lomse_test_ldp_analyser.cpp
@@ -3270,8 +3270,8 @@ SUITE(LdpAnalyserTest)
         ImoInstrument* pInstr = static_cast<ImoInstrument*>( pRoot );
         CHECK( pInstr != nullptr );
         CHECK( pInstr->get_num_staves() == 1 );
-        CHECK( pInstr->get_name().get_text() == "Guitar" );
-        CHECK( pInstr->get_abbrev().get_text() == "" );
+        CHECK( pInstr->get_name().text == "Guitar" );
+        CHECK( pInstr->get_abbrev().text == "" );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -3297,8 +3297,8 @@ SUITE(LdpAnalyserTest)
         ImoInstrument* pInstr = static_cast<ImoInstrument*>( pRoot );
         CHECK( pInstr != nullptr );
         CHECK( pInstr->get_num_staves() == 1 );
-        CHECK( pInstr->get_name().get_text() == "" );
-        CHECK( pInstr->get_abbrev().get_text() == "G." );
+        CHECK( pInstr->get_name().text == "" );
+        CHECK( pInstr->get_abbrev().text == "G." );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -3324,8 +3324,8 @@ SUITE(LdpAnalyserTest)
         ImoInstrument* pInstr = static_cast<ImoInstrument*>( pRoot );
         CHECK( pInstr != nullptr );
         CHECK( pInstr->get_num_staves() == 1 );
-        CHECK( pInstr->get_name().get_text() == "Guitar" );
-        CHECK( pInstr->get_abbrev().get_text() == "G." );
+        CHECK( pInstr->get_name().text == "Guitar" );
+        CHECK( pInstr->get_abbrev().text == "G." );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -3481,8 +3481,8 @@ SUITE(LdpAnalyserTest)
         ImoInstrument* pInstr = static_cast<ImoInstrument*>( pRoot );
         CHECK( pInstr != nullptr );
         CHECK( pInstr->get_num_staves() == 1 );
-        CHECK( pInstr->get_name().get_text() == "" );
-        CHECK( pInstr->get_abbrev().get_text() == "" );
+        CHECK( pInstr->get_name().text == "" );
+        CHECK( pInstr->get_abbrev().text == "" );
         CHECK( pInstr->get_num_sounds() == 1 );
         ImoSoundInfo* pInfo = pInstr->get_sound_info(0);
         CHECK( pInfo != nullptr );

--- a/src/tests/lomse_test_mnx_analyser.cpp
+++ b/src/tests/lomse_test_mnx_analyser.cpp
@@ -1468,7 +1468,7 @@ SUITE(MnxAnalyserTest)
                 CHECK( (*it) && (*it)->is_sound_change() );
                 ImoSoundChange* pSC = static_cast<ImoSoundChange*>( *it );
                 CHECK( pSC != nullptr );
-                CHECK( pSC && pSC->get_attribute_node(k_attr_segno) != nullptr  );
+                CHECK( pSC && pSC->get_attribute(k_attr_segno) != nullptr  );
 
                 ++it;
                 CHECK( (*it) && (*it)->is_barline() );

--- a/src/tests/lomse_test_mxl_analyser.cpp
+++ b/src/tests/lomse_test_mxl_analyser.cpp
@@ -584,10 +584,10 @@ SUITE(MxlAnalyserTest)
         ImoInstrument* pInstr = dynamic_cast<ImoInstrument*>( pRoot );
         CHECK( pInstr != nullptr );
         CHECK( pInstr->get_num_staves() == 1 );
-        CHECK( pInstr->get_name().get_text() == "Guitar" );
-//        cout << "Name: '" << pInstr->get_name().get_text()
-//             << "', Abbrev: '" << pInstr->get_abbrev().get_text() << "'" << endl;
-        CHECK( pInstr->get_abbrev().get_text() == "" );
+        CHECK( pInstr->get_name().text == "Guitar" );
+//        cout << "Name: '" << pInstr->get_name().text
+//             << "', Abbrev: '" << pInstr->get_abbrev().text << "'" << endl;
+        CHECK( pInstr->get_abbrev().text == "" );
         ImoMusicData* pMD = pInstr->get_musicdata();
         CHECK( pMD != nullptr );
         CHECK( pMD->get_num_items() == 0 );
@@ -4092,8 +4092,8 @@ SUITE(MxlAnalyserTest)
         CHECK( pScore && pScore->get_num_instruments() == 1 );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         CHECK( pInstr != nullptr );
-        CHECK( pInstr->get_name().get_text() == "Flute 1" );
-        CHECK( pInstr->get_abbrev().get_text() == "Fl. 1" );
+        CHECK( pInstr->get_name().text == "Flute 1" );
+        CHECK( pInstr->get_abbrev().text == "Fl. 1" );
         CHECK( pInstr->get_num_sounds() == 1 );
         ImoSoundInfo* pInfo = pInstr->get_sound_info(0);
         CHECK( pInfo != nullptr );
@@ -4115,8 +4115,8 @@ SUITE(MxlAnalyserTest)
         CHECK( pMidi && pMidi->get_midi_pan() == -70.0 );
         CHECK( pMidi && pMidi->get_midi_elevation() == 0.0 );
 //        cout << test_name() << endl;
-//        cout << "instr.name= " << pInstr->get_name().get_text() << endl
-//             << "instr.abbrev= " << pInstr->get_abbrev().get_text() << endl
+//        cout << "instr.name= " << pInstr->get_name().text << endl
+//             << "instr.abbrev= " << pInstr->get_abbrev().text << endl
 //             << "id= " << pInfo->get_score_instr_id() << endl
 //             << "name= " << pInfo->get_score_instr_name() << endl
 //             << "abbrev= " << pInfo->get_score_instr_abbrev() << endl
@@ -6445,7 +6445,7 @@ SUITE(MxlAnalyserTest)
         ImoSoundChange* pSC = dynamic_cast<ImoSoundChange*>(
                                         pSO->get_child_of_type(k_imo_sound_change) );
         CHECK( pSC != nullptr );
-        CHECK( pSC && pSC->get_attribute_node(k_attr_tocoda) != nullptr  );
+        CHECK( pSC && pSC->get_attribute(k_attr_tocoda) != nullptr  );
 
         a.do_not_delete_instruments_in_destructor();
         delete pRoot;
@@ -6495,7 +6495,7 @@ SUITE(MxlAnalyserTest)
 
                 ImoSoundChange* pSC = dynamic_cast<ImoSoundChange*>( *it );
                 CHECK( pSC != nullptr );
-                CHECK( pSC && pSC->get_attribute_node(k_attr_tempo) != nullptr  );
+                CHECK( pSC && pSC->get_attribute(k_attr_tempo) != nullptr  );
 
                 ++it;
                 ImoNote* pNote = dynamic_cast<ImoNote*>( *it );

--- a/src/tests/lomse_test_staffobjs_table.cpp
+++ b/src/tests/lomse_test_staffobjs_table.cpp
@@ -529,9 +529,9 @@ SUITE(ColStaffObjsBuilderTest)
         CHECK_ENTRY0(it, 1,    0,      0,   0,     1, "(n d4 e v1 p1 (stem up))" );
         CHECK_ENTRY0(it, 0,    0,      0,  32,     0, "(barline simple)" );
         CHECK_ENTRY0(it, 1,    0,      0,  32,     1, "(barline simple)" );
-        CHECK_ENTRY0(it, 0,    0,      1,  32,     0, "(grace b4 s v1 p1 (stem up)(beam 58 ++))" );
-        CHECK_ENTRY0(it, 0,    0,      1,  32,     0, "(grace +c5 s v1 p1 (stem up)(beam 58 ==))" );
-        CHECK_ENTRY0(it, 0,    0,      1,  32,     0, "(grace +d5 s v1 p1 (stem up)(beam 58 --))" );
+        CHECK_ENTRY0(it, 0,    0,      1,  32,     0, "(grace b4 s v1 p1 (stem up)(beam 57 ++))" );
+        CHECK_ENTRY0(it, 0,    0,      1,  32,     0, "(grace +c5 s v1 p1 (stem up)(beam 57 ==))" );
+        CHECK_ENTRY0(it, 0,    0,      1,  32,     0, "(grace +d5 s v1 p1 (stem up)(beam 57 --))" );
         CHECK_ENTRY0(it, 0,    0,      1,  32,     0, "(n e5 q v1 p1 (stem down))" );
         CHECK_ENTRY0(it, 1,    0,      1,  32,     1, "(n c4 q v1 p1 (stem up))" );
         CHECK_ENTRY0(it, 0,    0,      1,  96,     0, "(barline simple)" );

--- a/src/tests/lomse_test_text_engraver.cpp
+++ b/src/tests/lomse_test_text_engraver.cpp
@@ -84,10 +84,10 @@ SUITE(TextEngraverTest)
             "(instrument (name ''Violin'')(musicData (n c4 q))))))");
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
         ImoInstrument* pInstr = pScore->get_instrument(0);
-        ImoScoreText& text = pInstr->get_name();
+        TypeTextInfo& text = pInstr->get_name();
         ImoStyle* pStyle = pScore->get_default_style();
         ScoreMeter meter(pScore, 1, 1, LOMSE_STAFF_LINE_SPACING);
-        TextEngraver engraver(m_libraryScope, &meter, text.get_text(), "", pStyle);
+        TextEngraver engraver(m_libraryScope, &meter, text.text, "", pStyle);
 
         LUnits width = engraver.measure_width();
         CHECK( width > 0.0f );


### PR DESCRIPTION
This PR reviews the internal model, in preparation for comming changes to support MNX. This PR mainly, modifies the implementation of AttObj objects to avoid using variant types, and do some refactoring.

**Changes**

- Implementation of AttrObj changed to avoid using variant types and to minimize memory usage.
- Created class AttrList for managing a simple list of AttrObj objects.
- Some refactoring in internal model objects:
   - Removed ImoTextInfo objects that were used as member variables in other ImoObj objects, and replaced by TypeTextInfo struct.
   - Default copy and move constructors forced to be deleted for most ImoObj objects. Not possible to remove yet from all ImoObj objects due to Dto and Info objects that need to be reviewed.


**Other changes**

- Memory leaks checked with Valgrind and fixed (I do this from time to time).
- Added class `AnalysisResult` to MNX analyser, to better manage results and avoid memory leaks.
