### PR TITLE
Fix critical bug that could cause crashes when the score has lyrics

### DIFF
--- a/include/lomse_lyric_engraver.h
+++ b/include/lomse_lyric_engraver.h
@@ -86,6 +86,9 @@ public:
     int get_num_shapes() override { return m_numShapes; }
     ShapeBoxInfo* get_shape_box_info(int i) override { return m_shapesInfo[i]; }
 
+    //specific methods for this engraver
+    void prepare_for_next_system();
+
 
 protected:
 

--- a/src/graphic_model/engravers/lomse_lyric_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_lyric_engraver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2019. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2022. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -152,12 +152,19 @@ int LyricEngraver::create_shapes(const RelObjEngravingContext& ctx)
     int ret = int(m_lyrics.size());
     m_numShapes += ret;
 
-    //prepare for next system
-    m_lyrics.clear();
-    m_shapesInfo.clear();
-
     return ret;
 };
+
+//---------------------------------------------------------------------------------------
+void LyricEngraver::prepare_for_next_system()
+{
+    //AWARE: m_shapesInfo cannot be cleared at end of LyricEngraver::create_shapes()
+    //       as it has to be used in SystemLayouter::add_lyrics_shapes_to_model(). Thus
+    //       it will be cleared here and this method will be invoked by
+    //       SystemLayouter::add_lyrics_shapes_to_model() when appropriate.
+    m_lyrics.clear();
+    m_shapesInfo.clear();
+}
 
 //---------------------------------------------------------------------------------------
 void LyricEngraver::create_shape(int iNote, GmoShapeNote* pNoteShape, ImoLyric* pLyric,

--- a/src/graphic_model/layouters/lomse_system_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_system_layouter.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2022. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -52,6 +52,7 @@
 #include "lomse_beam_engraver.h"
 #include "lomse_chord_engraver.h"
 #include "lomse_aux_shapes_aligner.h"
+#include "lomse_lyric_engraver.h"
 
 #include <sstream>
 #include <algorithm>
@@ -1255,8 +1256,13 @@ void SystemLayouter::delete_rel_obj_engraver(ImoRelObj* pRO)
 void SystemLayouter::add_lyrics_shapes_to_model(const string& tag, int layer, bool fLast,
                                                 int iInstr, int iStaff)
 {
-    AuxRelObjEngraver* pEngrv
-        = static_cast<AuxRelObjEngraver*>(m_engravers.get_engraver(tag));
+    LyricEngraver* pEngrv
+        = dynamic_cast<LyricEngraver*>(m_engravers.get_engraver(tag));
+    if (pEngrv == nullptr)
+    {
+        LOMSE_LOG_ERROR("Fatal: Engraver is not LyricEngraver!");
+        return;
+    }
 
     //create the shapes
     InstrumentEngraver* pInstrEngrv = m_pPartsEngraver->get_engraver_for(iInstr);
@@ -1283,6 +1289,8 @@ void SystemLayouter::add_lyrics_shapes_to_model(const string& tag, int layer, bo
         m_engravers.remove_engraver(tag);
         delete pEngrv;
     }
+    else
+        pEngrv->prepare_for_next_system();
 }
 
 


### PR DESCRIPTION
An `std::vector` was cleared and later was accesed. This has been fixed.