### PR TITLE
Render scores in SVG format

### DIFF
--- a/add-sources.cmake
+++ b/add-sources.cmake
@@ -206,6 +206,7 @@ set(RENDER_FILES
     ${LOMSE_SRC_DIR}/render/lomse_font_freetype.cpp
     ${LOMSE_SRC_DIR}/render/lomse_font_storage.cpp
     ${LOMSE_SRC_DIR}/render/lomse_renderer.cpp
+    ${LOMSE_SRC_DIR}/render/lomse_svg_drawer.cpp
 )
 
 set(SCORE_FILES

--- a/examples/svg/svg-minimal.cpp
+++ b/examples/svg/svg-minimal.cpp
@@ -1,0 +1,79 @@
+// svg-minimal.cpp
+//
+// Sample code to generate SVG with Lomse
+// Feel free to use this example code in any way you see fit (Public Domain)
+//
+// Usage:
+// - modify the paths for the score to display and the file to generate
+//   (lines 36 & 51) and save.
+// - build:
+//      g++ -std=c++11 svg-minimal.cpp -o svg-minimal \
+//        `pkg-config --cflags liblomse` `pkg-config --libs liblomse` -lstdc++
+// - run:
+//      ./svg-minimal
+// - and open the generated HTML page in a browser.
+
+#include <iostream>
+using namespace std;
+
+#include <lomse_doorway.h>
+#include <lomse_graphic_view.h>     //for k_view_vertical_book
+#include <lomse_presenter.h>        //Presenter
+#include <lomse_interactor.h>       //Interactor
+using namespace lomse;
+
+int main()
+{
+    //initialize lomse library. As we are only going to generate SVG, any 
+    //values for the pixel format and resolution parameters will be acceptable
+    //as they are not going to be used
+    lomse::LomseDoorway lomse;
+    lomse.init_library(k_pix_format_rgba32, 96);
+
+    //open a score
+    lomse::Presenter* pPresenter = 
+        lomse.open_document(k_view_vertical_book,
+                            "<path>/<to>/<the>/MusicXMLscore.mxl");
+
+    if (SpInteractor spInteractor = pPresenter->get_interactor(0).lock())
+    {
+        //generate the SVG rendition for the first page
+        std::stringstream svg;
+        int page = 0;
+        spInteractor->svg_add_newlines(true);     //for human legibility
+        spInteractor->render_as_svg(svg, page);
+
+        //do whatever you like with the svg code. For instance, display it in the
+        //console or export it to an html document
+
+        //cout << svg.str() << endl;
+
+        std::ofstream file1("svg-test.html", ios::out);
+        if (file1.good())
+        {
+            char htmlStart[] = "<!DOCTYPE html><html><head><meta charset='UTF-8'>"
+                "<title>Lomse SVG</title></head><body><h1>Test of Lomse SVG</h1>"
+                "<div style='width: 800px;border: 1px solid #000;'>";
+            file1.write(htmlStart, strlen(htmlStart));
+
+            string str = svg.str();
+            file1.write(str.c_str(), str.size());
+
+            char htmlEnd[] = "</div></body></html>";
+            file1.write(htmlEnd, strlen(htmlEnd));
+
+            file1.close();
+        }
+        else
+        {
+            cout << "Error creating file!" << endl;
+        }
+    }
+    else
+    {
+        cout << "Could not open document!" << endl;
+    }
+    
+    delete pPresenter;
+    return 0;
+}

--- a/include/lomse_checkbox_ctrl.h
+++ b/include/lomse_checkbox_ctrl.h
@@ -89,7 +89,7 @@ public:
 
     //VertexSource mandatory methods
     unsigned vertex(double* px, double* py) override;
-    void rewind(int UNUSED(pathId) = 0) override { m_nCurVertex = 0; }
+    void rewind(unsigned UNUSED(pathId) = 0) override { m_nCurVertex = 0; }
 
 protected:
     void select_font();

--- a/include/lomse_graphic_view.h
+++ b/include/lomse_graphic_view.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2022. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -51,6 +51,7 @@ namespace lomse
 
 //forward declarations
 class BitmapDrawer;
+class SvgDrawer;
 class Drawer;
 class Interactor;
 class GraphicModel;
@@ -217,6 +218,7 @@ public:
     void set_viewport_at_page_center(Pixels screenWidth);
     virtual void set_viewport_for_page_fit_full(Pixels screenWidth) = 0;
     LUnits get_viewport_width();
+    virtual USize get_page_size(int page);
     void use_cursor(DocCursor* pCursor);
     void use_selection_set(SelectionSet* pSelectionSet);
     void add_visual_effect(VisualEffect* pEffect);
@@ -450,6 +452,16 @@ public:
     void set_print_ppi(double ppi) { m_print_ppi = ppi; }
 
     ///@}    //Support for printing
+
+
+    /// @name Support for svg rendering
+    ///@{
+
+    void render_as_svg(SvgDrawer& drawer, int page);
+
+    void set_svg_canvas_width(Pixels x);
+
+    ///@}    //Support for svg rendering
 
 
     //info

--- a/include/lomse_interactor.h
+++ b/include/lomse_interactor.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2022. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -37,6 +37,8 @@
 #include "lomse_events.h"
 #include "lomse_document_cursor.h"
 #include "lomse_pitch.h"
+#include "lomse_drawer.h"       //for declaration of struct SvgOptions
+
 
 #include <iostream>
 #include <chrono>
@@ -184,6 +186,7 @@ protected:
     GmoRef          m_grefLastMouseOver;
     int             m_operatingMode;
     bool            m_fEditionEnabled;
+    SvgOptions      m_svgOptions;
 
     //for controlling repaints
     bool        m_fViewParamsChanged;       //viewport, scale, ... have been modified
@@ -722,6 +725,16 @@ public:
     */
     virtual void get_viewport(Pixels* x, Pixels* y);
 
+    /** Returns the size (logical units) of a page of the rendered document.
+
+        @param page The page (0..num_pages - 1) whose size is requested. This parameter
+        is only meaningful for View types that can generate several pages
+        (<i>k_view_vertical_book</i> and <i>k_view_horizontal_book</i>). For all
+        others there is only one page (page == 0) and the value of this parameter
+        is ignored.
+    */
+    USize get_page_size(int page=0);
+
     /** Returns the total size (pixels) of the whole rendered document (the whole visual
         space, all pages).
         @param xWidth
@@ -731,6 +744,7 @@ public:
 
         @see new_viewport(), set_viewport_at_page_center(), get_viewport()
     */
+
     virtual void get_view_size(Pixels* xWidth, Pixels* yHeight);
 
     /** This method invokes Lomse auto-scrolling algorithm to determine if scroll is
@@ -1174,6 +1188,67 @@ public:
     virtual int get_num_pages();
 
     //@}    //interface to GraphicView. Printing
+
+
+
+    //interface to GraphicView. SVG drawing
+    /// @name Interface to GraphicView. SVG drawing
+    //@{
+
+    /** Request Lomse to render a document as SVG stream.
+
+        @param svg The std::ostream in which SVG code will be written.
+        @param page The page to render (0..num_pages - 1). This parameter is only
+        meaningful for View types that can generate several pages
+        (<i>k_view_vertical_book</i> and <i>k_view_horizontal_book</i>). For all
+        others there is only one page (page == 0) and the value of this parameter
+        is ignored.
+
+        See @subpage svg-drawing
+    */
+    void render_as_svg(std::ostream& svg, int page=0);
+
+    /** Lomse normally layouts the score to fit in the page width specified in
+        the document. But when
+        View type <i>k_view_free_flow</i> is selected, it is necessary specify the
+        desired width for the rendered score, and this is the purpose of this method.
+
+        The width must be set before invoking render_as_svg() but this is only needed
+        when using the <i>k_view_free_flow</i> View type. For all other view types any
+        value set using this method will be overriden by the document page width so it
+        is useless to invoke it but does not harm.
+
+        @param the desired width for the score in pixels. For most applications, this
+        value should be the width of the HTML element in which the generated SVG code
+        will be inserted.
+
+        See @subpage svg-drawing
+    */
+    void set_svg_canvas_width(Pixels x);
+
+    //svg options
+//    /** Set the number of spaces for indenting SVG elements.
+//
+//        @param value The number of spaces for an indentation. Note that a value of
+//        zero supress indentation.
+//
+//        By default, Lomse generates the SVG code to be as compact as possible and,
+//        thus, it does not include indentation spaces. So default value is 0.
+//    */
+//    inline void svg_indent(int value) { m_svgOptions.indent = value; }
+//    inline void svg_add_id(bool value) { m_svgOptions.add_id = value; }
+//    inline void svg_add_class(bool value) { m_svgOptions.add_class = value; }
+    /** Enable or disable the generation of a line break after each SVG element.
+
+        @param value @TRUE for enabling the generation of line breaks. @FALSE for
+        disabling it.
+
+        By default, Lomse generates the SVG code to be as compact as possible and,
+        thus, it does not include line breaks.
+    */
+    inline void svg_add_newlines(bool value) { m_svgOptions.add_newlines = value; }
+
+    //@}    //interface to GraphicView. SVG drawing
 
 
 

--- a/include/lomse_shape_brace_bracket.h
+++ b/include/lomse_shape_brace_bracket.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2020. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2022. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -60,7 +60,7 @@ public:
     void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 
     //VertexSource
-    void rewind(int UNUSED(pathId) = 0) override { m_nCurVertex = 0; m_nContour = 0; }
+    void rewind(unsigned UNUSED(pathId) = 0) override { m_nCurVertex = 0; m_nContour = 0; }
 
 
 protected:

--- a/include/lomse_shape_tie.h
+++ b/include/lomse_shape_tie.h
@@ -67,7 +67,7 @@ public:
     void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
 
     //VertexSource
-    void rewind(int UNUSED(pathId) = 0) override { m_nCurVertex = 0; }
+    void rewind(unsigned UNUSED(pathId) = 0) override { m_nCurVertex = 0; }
     unsigned vertex(double* px, double* py) override;
 
     //support for handlers

--- a/include/lomse_shapes.h
+++ b/include/lomse_shapes.h
@@ -152,7 +152,7 @@ public:
 
     //VertexSource
     unsigned vertex(double* px, double* py) override;
-    void rewind(int UNUSED(pathId) = 0) override;
+    void rewind(unsigned UNUSED(pathId) = 0) override;
 
 };
 

--- a/include/lomse_svg_drawer.h
+++ b/include/lomse_svg_drawer.h
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2022. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -27,58 +27,38 @@
 // the project at cecilios@users.sourceforge.net
 //---------------------------------------------------------------------------------------
 
-//  This file is based on Anti-Grain Geometry version 2.4 examples' code and on
-//  Agg2D version 1.0 code.
-//
-//  Anti-Grain Geometry (AGG) is copyright (C) 2002-2005 Maxim Shemanarev
-//  (http://www.antigrain.com). AGG 2.4 is distributed as follows:
-//    "Permission to copy, use, modify, sell and distribute this software
-//    is granted provided this copyright notice appears in all copies.
-//    This software is provided "as is" without express or implied
-//    warranty, and with no claim as to its suitability for any purpose."
-//
-//---------------------------------------------------------------------------------------
-
-#ifndef __LOMSE_SCREEN_DRAWER_H__        //to avoid nested includes
-#define __LOMSE_SCREEN_DRAWER_H__
+#ifndef __LOMSE_SVG_DRAWER_H__        //to avoid nested includes
+#define __LOMSE_SVG_DRAWER_H__
 
 #include "lomse_drawer.h"
-#include "lomse_pixel_formats.h"
-#include "lomse_agg_types.h"
-#include "lomse_path_attributes.h"
-#include "lomse_font_storage.h"
-#include "lomse_calligrapher.h"
 
-using namespace agg;
+//std
+#include <sstream>
 
 namespace lomse
 {
 
-//forward declarations
-class Renderer;
-
-
 //---------------------------------------------------------------------------------------
-/** %BitmapDrawer: a Drawer that renders on a bitmap using agg
+/** %SvgDrawer: a Drawer that renders as svg stream
 */
-class LOMSE_EXPORT BitmapDrawer : public Drawer
+class LOMSE_EXPORT SvgDrawer : public Drawer
 {
 private:
-    AttrStorage     m_attr_storage;
-    PathStorage     m_path;
-    Renderer*       m_pRenderer;
-//    TextMeter*      m_pTextMeter;
-    Calligrapher*   m_pCalligrapher;
-    int             m_numPaths;
-    RenderingBuffer m_rbuf;
-    unsigned char*  m_pBuf;         //the memory for the bitmap. Owned by user app.
-    unsigned        m_bufWidth;
-    unsigned        m_bufHeight;
+    std::ostream&       m_svg;
+    bool                m_fStartStream = true;
+    std::stringstream   m_attribs;
+    std::stringstream   m_path;
+    bool                m_fPathEmpty = true;
+    TransAffine         m_transform;
+    const SvgOptions&   m_options;
+    double              m_fontSize = 10;
+    std::string         m_fontStyle = "normal";
+    std::string         m_fontWeight = "normal";
+    std::string         m_fontFamily = "Bravura";
 
 public:
-    BitmapDrawer(LibraryScope& libraryScope);
-    virtual ~BitmapDrawer();
-
+    SvgDrawer(LibraryScope& libraryScope, std::ostream& svgstream, const SvgOptions& opt);
+    virtual ~SvgDrawer();
 
     //===================================================================
     // Implementation of pure virtual methods in Drawer base class
@@ -251,30 +231,15 @@ public:
     // Specific methods not in Drawer base class
     //===================================================================
 
-    //Inform about the RenderingBuffer to use and clear it with the desired color.
-    void set_rendering_buffer(unsigned char* buf, unsigned width, unsigned height,
-                              Color bgcolor=Color(255,255,255));
-
-    //The view area is the region to which drawing is restricted. View area must be
-    //given in device coordinates (e.g. Pixel).
-    void set_view_area(unsigned width, unsigned height, unsigned xShift, unsigned yShift);
-
-    unsigned char* get_rendering_buffer() { return m_pBuf; };
-    unsigned get_rendering_buffer_width() const { return m_bufWidth; };
-    unsigned get_rendering_buffer_height() const { return m_bufHeight; };
-
 
 protected:
-    void push_attr();
-    void pop_attr();
-    PathAttributes& cur_attr();
-    void render_existing_paths();
-    void delete_paths();
+    std::string to_svg(Color color);
+    void add_newline();
 
 };
 
 
 }   //namespace lomse
 
-#endif    // __LOMSE_SCREEN_DRAWER_H__
+#endif    // __LOMSE_SVG_DRAWER_H__
 

--- a/include/lomse_vertex_source.h
+++ b/include/lomse_vertex_source.h
@@ -49,7 +49,7 @@ public:
     VertexSource() {}
 	virtual ~VertexSource() {}
 
-    virtual void rewind(int pathId = 0) = 0;
+    virtual void rewind(unsigned pathId = 0) = 0;
     virtual unsigned vertex(double* px, double* py) = 0;
 };
 

--- a/src/graphic_model/lomse_fragment_mark.cpp
+++ b/src/graphic_model/lomse_fragment_mark.cpp
@@ -113,7 +113,7 @@ protected:
 
     //VertexSource
     unsigned vertex(double* px, double* py) override;
-    void rewind(int UNUSED(pathId) = 0) override { m_nCurVertex = 0; m_nContour = 0; }
+    void rewind(unsigned UNUSED(pathId) = 0) override { m_nCurVertex = 0; m_nContour = 0; }
 };
 
 //=======================================================================================
@@ -160,7 +160,7 @@ protected:
 
     //VertexSource
     unsigned vertex(double* px, double* py) override;
-    void rewind(int UNUSED(pathId) = 0) override { m_nCurVertex = 0; m_nContour = 0; }
+    void rewind(unsigned UNUSED(pathId) = 0) override { m_nCurVertex = 0; m_nContour = 0; }
 };
 
 

--- a/src/graphic_model/lomse_graphical_model.cpp
+++ b/src/graphic_model/lomse_graphical_model.cpp
@@ -95,9 +95,19 @@ void GraphicModel::draw_page(int iPage, UPoint& origin, Drawer* pDrawer,
                              RenderOptions& opt)
 {
     pDrawer->set_shift(-origin.x, -origin.y);
-    get_page(iPage)->on_draw(pDrawer, opt);
-    pDrawer->render();
-    pDrawer->remove_shift();
+    GmoBoxDocPage* pPage = get_page(iPage);
+    if (pPage)
+    {
+        pPage->on_draw(pDrawer, opt);
+        pDrawer->render();
+        pDrawer->remove_shift();
+    }
+    else
+    {
+        stringstream msg;
+        msg << "Page " << iPage << " does not exists!";
+        LOMSE_LOG_ERROR(msg.str());
+    }
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/lomse_shape_text.cpp
+++ b/src/graphic_model/lomse_shape_text.cpp
@@ -81,16 +81,19 @@ Color GmoShapeText::get_normal_color()
 void GmoShapeText::on_draw(Drawer* pDrawer, RenderOptions& opt)
 {
     //select_font();
-    TextMeter meter(m_libraryScope);
     if (!m_pStyle)
-        meter.select_font(m_language, "", "Liberation serif", 12.0);
+        pDrawer->select_font(m_language, "", "Liberation serif", 12.0);
     else
-        meter.select_font(m_language,
+        pDrawer->select_font(m_language,
                           m_pStyle->font_file(),
                           m_pStyle->font_name(),
                           m_pStyle->font_size(),
                           m_pStyle->is_bold(),
                           m_pStyle->is_italic() );
+
+    //AWARE: the selected font is stored in library scope. Thus the next TextMeter
+    //       will use the font selected in the drawer
+    TextMeter meter(m_libraryScope);
 
     pDrawer->set_text_color( determine_color_to_use(opt) );
     LUnits x = m_origin.x;
@@ -146,8 +149,8 @@ GmoShapeWord::GmoShapeWord(ImoObj* pCreatorImo, ShapeId idx, const wstring& text
     , m_halfLeading(halfLeading)
 {
     //bounds
-    TextMeter meter(m_libraryScope);
     select_font();
+    TextMeter meter(m_libraryScope);
     m_size.width = meter.measure_width(text);
     m_size.height = halfLeading + meter.get_font_height() + halfLeading;
 
@@ -172,7 +175,20 @@ void GmoShapeWord::on_draw(Drawer* pDrawer, RenderOptions& opt)
     if (!static_cast<ImoContentObj*>(m_pCreatorImo)->is_visible())
         return;
 
-    select_font();
+    //select_font
+    if (!m_pStyle)
+        pDrawer->select_font(m_language, "", "Liberation serif", 12.0);
+    else
+        pDrawer->select_font(m_language,
+                          m_pStyle->font_file(),
+                          m_pStyle->font_name(),
+                          m_pStyle->font_size(),
+                          m_pStyle->is_bold(),
+                          m_pStyle->is_italic() );
+
+    //AWARE: the selected font is stored in library scope. Thus any TextMeter
+    //       created after this point will use the font selected in the drawer
+
     Color color = determine_color_to_use(opt);
     pDrawer->set_text_color(color);
     //AWARE: FreeType reference is at baseline

--- a/src/graphic_model/lomse_shape_tie.cpp
+++ b/src/graphic_model/lomse_shape_tie.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2018. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2022. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/src/graphic_model/lomse_shapes.cpp
+++ b/src/graphic_model/lomse_shapes.cpp
@@ -62,7 +62,6 @@ void GmoShapeGlyph::on_draw(Drawer* pDrawer, RenderOptions& opt)
                          m_libraryScope.get_music_font_name(),
                          m_fontHeight);
     pDrawer->set_text_color( determine_color_to_use(opt) );
-    pDrawer->move_to(m_origin.x, m_origin.y);       //this line fixes issue #73 !!!
     LUnits x = m_shiftToDraw.width + m_origin.x;
     LUnits y = m_shiftToDraw.height + m_origin.y;
     pDrawer->draw_glyph(x, y, m_glyph);
@@ -443,7 +442,7 @@ void GmoShapeDebug::on_draw(Drawer* pDrawer, RenderOptions& opt)
 }
 
 //---------------------------------------------------------------------------------------
-void GmoShapeDebug::rewind(int UNUSED(pathId))
+void GmoShapeDebug::rewind(unsigned UNUSED(pathId))
 {
     m_it=m_vertices.begin();
     m_nContour = 0;

--- a/src/mvc/lomse_graphic_view.cpp
+++ b/src/mvc/lomse_graphic_view.cpp
@@ -1,6 +1,6 @@
 //---------------------------------------------------------------------------------------
 // This file is part of the Lomse library.
-// Lomse is copyrighted work (c) 2010-2021. All rights reserved.
+// Lomse is copyrighted work (c) 2010-2022. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -49,6 +49,7 @@
 #include "lomse_timegrid_table.h"
 #include "lomse_half_page_view.h"
 #include "lomse_renderer.h"
+#include "lomse_svg_drawer.h"
 
 using namespace std;
 
@@ -788,6 +789,26 @@ VisualEffect* GraphicView::get_tracking_effect(int effect)
 }
 
 //---------------------------------------------------------------------------------------
+void GraphicView::render_as_svg(SvgDrawer& drawer, int page)
+{
+    if (!drawer.is_ready())
+        return;
+
+    drawer.reset(Color(255, 255, 255));
+
+    UPoint origin(0.0f, 0.0f);
+    GraphicModel* pGModel = get_graphic_model();
+    pGModel->draw_page(page, origin, &drawer, m_options);
+    drawer.render();
+}
+
+//---------------------------------------------------------------------------------------
+void GraphicView::set_svg_canvas_width(Pixels x)
+{
+    m_viewportSize.width = x;
+}
+
+//---------------------------------------------------------------------------------------
 void GraphicView::print_page(int page, VPoint viewport)
 {
     if (!m_pPrintDrawer->is_ready())
@@ -1192,6 +1213,20 @@ LUnits GraphicView::get_viewport_width()
         return m_pDrawer->device_units_to_model( double(m_viewportSize.width) );
     else
         return 0.0f;
+}
+
+//---------------------------------------------------------------------------------------
+USize GraphicView::get_page_size(int page)
+{
+    GraphicModel* pGModel = get_graphic_model();
+    if (pGModel)
+    {
+        GmoBoxDocPage* pPage = pGModel->get_page(page);
+        URect rect = pPage->get_bounds();
+        return USize(rect.width, rect.height);
+    }
+    else
+        return USize(0.0, 0.0);
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/render/lomse_svg_drawer.cpp
+++ b/src/render/lomse_svg_drawer.cpp
@@ -1,0 +1,678 @@
+//---------------------------------------------------------------------------------------
+// This file is part of the Lomse library.
+// Lomse is copyrighted work (c) 2010-2022. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright notice, this
+//      list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright notice, this
+//      list of conditions and the following disclaimer in the documentation and/or
+//      other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+// SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// For any comment, suggestion or feature request, please contact the manager of
+// the project at cecilios@users.sourceforge.net
+//---------------------------------------------------------------------------------------
+
+#include "lomse_svg_drawer.h"
+
+#include "lomse_logger.h"
+#include "lomse_font_storage.h"
+#include "agg_basics.h"
+
+//std
+#include <locale>
+#include <codecvt>
+using namespace std;
+
+
+namespace lomse
+{
+
+//=======================================================================================
+// SvgDrawer implementation
+//=======================================================================================
+SvgDrawer::SvgDrawer(LibraryScope& libraryScope, ostream& svgstream,
+                     const SvgOptions& opt)
+    : Drawer(libraryScope)
+    , m_svg(svgstream)
+    , m_options(opt)
+{
+}
+
+//---------------------------------------------------------------------------------------
+SvgDrawer::~SvgDrawer()
+{
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::reset(Color UNUSED(bgcolor))
+{
+    m_path.str("");
+    m_path.clear();
+    m_attribs.str("");
+    m_attribs.clear();
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::add_newline()
+{
+    if (m_options.add_newlines)
+        m_svg << endl;
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::begin_path()
+{
+    if (m_path.tellp() != std::streampos(0))
+    {
+        LOMSE_LOG_ERROR("Path already open: [" + m_path.str() + "]");
+        m_path.str("");
+        m_path.clear();
+    }
+    m_path << "<path d='";
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::end_path()
+{
+    if (m_path.tellp() == std::streampos(0))
+    {
+        LOMSE_LOG_ERROR("The path was not begun!");
+    }
+    else
+    {
+        if (m_path.str() != "<path d='")
+        {
+            m_svg << m_path.str() << "'" << m_attribs.str() << "/>";
+            add_newline();
+        }
+    }
+
+    m_path.str("");
+    m_path.clear();
+    m_attribs.str("");
+    m_attribs.clear();
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::move_to(double x, double y)
+{
+    m_path << " M " << x << " " << y;
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::move_to_rel(double x, double y)
+{
+    m_path << " m " << x << " " << y;
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::line_to(double x,  double y)
+{
+    m_path << " L " << x << " " << y;
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::line_to_rel(double x,  double y)
+{
+    m_path << " l " << x << " " << y;
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::hline_to(double x)
+{
+    m_path << " H " << x;
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::hline_to_rel(double x)
+{
+    m_path << " h " << x;
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::vline_to(double y)
+{
+    m_path << " V " << y;
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::vline_to_rel(double y)
+{
+    m_path << " v " << y;
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::quadratic_bezier(double x1, double y1, double x,  double y)
+{
+    m_path << " Q " << x1 << " " << y1 << " " << x << " " << y;
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::quadratic_bezier_rel(double x1, double y1, double x,  double y)
+{
+    m_path << " q " << x1 << " " << y1 << " " << x << " " << y;
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::quadratic_bezier(double x, double y)
+{
+    m_path << " T " << x << " " << y;
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::quadratic_bezier_rel(double x, double y)
+{
+    m_path << " t " << x << " " << y;
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::cubic_bezier(double x1, double y1, double x2, double y2,
+                                 double x,  double y)
+{
+    m_path << " C " << x1 << " " << y1 << " " << x2 << " " << y2 << " " << x << " " << y;
+}
+//---------------------------------------------------------------------------------------
+void SvgDrawer::cubic_bezier_rel(double x1, double y1, double x2, double y2,
+                                     double x,  double y)
+{
+    m_path << " c " << x1 << " " << y1 << " " << x2 << " " << y2 << " " << x << " " << y;
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::cubic_bezier(double x2, double y2, double x,  double y)
+{
+    m_path << " S " << x2 << " " << y2 << " " << x << " " << y;
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::cubic_bezier_rel(double x2, double y2, double x,  double y)
+{
+    m_path << " s " << x2 << " " << y2 << " " << x << " " << y;
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::close_path()
+{
+    m_attribs << " Z";
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::fill(Color color)
+{
+    m_attribs << " fill='" << to_svg(color) << "'";
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::stroke(Color color)
+{
+    m_attribs << " stroke='" << to_svg(color) << "'";
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::stroke_width(double w)
+{
+    m_attribs << " stroke-width='" << w << "'";
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::fill_none()
+{
+    m_attribs << " fill='none'" ;
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::stroke_none()
+{
+    m_attribs << " stroke='none'";
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::add_path(VertexSource& vs,  unsigned path_id,
+                            bool UNUSED(solid_path))
+{
+    double x, y;
+    unsigned cmd;
+    unsigned cmdPrev;
+    vs.rewind(path_id);
+    while(!is_stop(cmd = vs.vertex(&x, &y)))
+    {
+        switch (cmd)
+        {
+            case agg::path_cmd_move_to:
+                m_path << " M " << x << " " << y;
+                break;
+
+            case agg::path_cmd_line_to:
+                m_path << " L " << x << " " << y;
+                break;
+
+            case agg::path_cmd_curve3:
+                m_path << " S " << x << " " << y;
+                cmd = vs.vertex(&x, &y);
+                if (cmd != agg::path_cmd_curve3)
+                {
+                    LOMSE_LOG_ERROR("curve3 has only one point");
+                    return;
+                }
+                m_path << " " << x << " " << y;
+                break;
+
+            case agg::path_cmd_curve4:
+            {
+                m_path << " C " << x << " " << y;
+                for (int i=0; i < 4; ++i)
+                {
+                    cmd = vs.vertex(&x, &y);
+                    if (cmd != agg::path_cmd_curve4)
+                    {
+                        LOMSE_LOG_ERROR("curve4 has less than five points");
+                        return;
+                    }
+                    m_path << " " << x << " " << y;
+                }
+                break;
+            }
+
+            default:
+                if (cmd & agg::path_cmd_end_poly)
+                {
+                    if (cmdPrev == agg::path_cmd_curve4)    // || cmdPrev == agg::path_cmd_curve3)
+                        m_path << " " << x << " " << y << " Z";
+                    else
+                        m_path << " Z";
+                }
+        }
+        cmdPrev = cmd;
+    }
+}
+
+//---------------------------------------------------------------------------------------
+bool SvgDrawer::select_font(const std::string& language,
+                            const std::string& fontFile,
+                            const std::string& fontName, double height,
+                            bool fBold, bool fItalic)
+{
+    m_fontSize = height;
+    m_fontStyle = fItalic ? "italic" : "normal";
+    m_fontWeight = fBold ? "bold" : "normal";
+    m_fontFamily = fontName;
+
+    //AWARE: this is needed so that shapes can do measurements at drawing time
+    m_pFonts->select_font(language, fontFile, fontName, height, fBold, fItalic);
+
+    return true;
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::draw_glyph(double x, double y, unsigned int ch)
+{
+    const double factor = 35.2778;   //to convert font-size (pt) to LUnits  (25.4*100/72)
+    m_svg << "<text x='" << x << "' y='" << y << "' fill='" << to_svg(m_textColor)
+         << "' font-family='" << m_fontFamily << "' font-size='" << m_fontSize * factor;
+
+    if (m_fontWeight != "normal")
+        m_svg << "' font-weight='" << m_fontWeight;
+
+    if (m_fontStyle != "normal")
+        m_svg << "' font-style='" << m_fontStyle;
+
+    m_svg << "'>&#" << ch << ";</text>";
+    add_newline();
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::draw_glyph_rotated(double x, double y, unsigned int ch, double rotation)
+{
+    const double factor = 35.2778;   //to convert font-size (pt) to LUnits  (25.4*100/72)
+    const double degrees = 180.0 / 3.141592654;   //to convert radians to degrees
+    m_svg << "<text x='" << x << "' y='" << y << "' fill='" << to_svg(m_textColor)
+         << "' transform='rotate(" << rotation * degrees << "," << x << "," << y << ")"
+         << "' font-family='" << m_fontFamily << "' font-size='" << m_fontSize * factor;
+
+    if (m_fontWeight != "normal")
+        m_svg << "' font-weight='" << m_fontWeight;
+
+    if (m_fontStyle != "normal")
+        m_svg << "' font-style='" << m_fontStyle;
+
+    m_svg << "'>&#" << ch << ";</text>";
+    add_newline();
+ }
+
+//---------------------------------------------------------------------------------------
+int SvgDrawer::draw_text(double x, double y, const std::string& str)
+{
+    //returns the number of chars drawn
+
+    const double factor = 35.2778;   //to convert font-size (pt) to LUnits  (25.4*100/72)
+    m_svg << "<text x='" << x << "' y='" << y << "' fill='" << to_svg(m_textColor)
+         << "' font-family='" << m_fontFamily << "' font-size='" << m_fontSize * factor;
+
+    if (m_fontWeight != "normal")
+        m_svg << "' font-weight='" << m_fontWeight;
+
+    if (m_fontStyle != "normal")
+        m_svg << "' font-style='" << m_fontStyle;
+
+    m_svg << "'>" << str << "</text>";
+    add_newline();
+
+    return str.size();
+}
+
+//---------------------------------------------------------------------------------------
+int SvgDrawer::draw_text(double x, double y, const wstring& str)
+{
+    //returns the number of chars drawn
+
+    //setup converter wstring -> string
+    using convert_type = std::codecvt_utf8<wchar_t>;
+    std::wstring_convert<convert_type, wchar_t> converter;
+
+    //use converter (.to_bytes: wstr->str, .from_bytes: str->wstr)
+    string text = converter.to_bytes(str);
+
+    return draw_text(x, y, text);
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::device_point_to_model(double* x, double* y) const
+{
+    //e.g. Pixels to LUnits
+
+    m_transform.inverse_transform(x, y);
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::model_point_to_device(double* x, double* y) const
+{
+    //e.g. LUnits to Pixels
+
+    m_transform.transform(x, y);
+}
+
+//---------------------------------------------------------------------------------------
+LUnits SvgDrawer::device_units_to_model(double value) const
+{
+    //e.g. Pixels to LUnits
+
+    return value / m_transform.scale();
+}
+
+//---------------------------------------------------------------------------------------
+double SvgDrawer::model_to_device_units(LUnits value) const
+{
+    //e.g. LUnits to Pixels
+
+    return value * m_transform.scale();
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::new_viewport_origin(double x, double y)
+{
+    //coordinates in device units (e.g. Pixel)
+    Drawer::new_viewport_origin(x, y);
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::new_viewport_size(double x, double y)
+{
+    //in device units (e.g. Pixel)
+    Drawer::new_viewport_size(x, y);
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::set_affine_transformation(TransAffine& transform)
+{
+    m_transform = transform;
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::render()
+{
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::set_shift(LUnits UNUSED(x), LUnits UNUSED(y))
+{
+    //TODO
+    //This method needs re-think. It is mainly used for visual overlays, to shift the
+    //position of the shape being drawn. It added this shit to the renderer affine
+    //transformation that was applied when the render() method is invoked.
+    //But in SvgDrawer the paths are rendered as they are created and, thus, this shift
+    //cannot be applied.
+
+    //m_pRenderer->set_shift(x, y);
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::remove_shift()
+{
+    //TODO: see comment in set_shift()
+
+    //m_pRenderer->remove_shift();
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::circle(LUnits xCenter, LUnits yCenter, LUnits radius)
+{
+    m_svg << "<circle cx='" << xCenter << "' cy='" << yCenter
+          << "' r='" << radius << "'" << m_attribs.str() << "/>";
+    add_newline();
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::line(LUnits x1, LUnits y1, LUnits x2, LUnits y2,
+                        LUnits width, ELineEdge nEdge)
+{
+    double alpha = atan((y2 - y1) / (x2 - x1));
+
+    switch(nEdge)
+    {
+        case k_edge_normal:
+            // edge line is perpendicular to line
+            {
+            LUnits uIncrX = (LUnits)( (width * sin(alpha)) / 2.0 );
+            LUnits uIncrY = (LUnits)( (width * cos(alpha)) / 2.0 );
+            UPoint uPoints[] = {
+                UPoint(x1+uIncrX, y1-uIncrY),
+                UPoint(x1-uIncrX, y1+uIncrY),
+                UPoint(x2-uIncrX, y2+uIncrY),
+                UPoint(x2+uIncrX, y2-uIncrY)
+            };
+            polygon(4, uPoints);
+            break;
+            }
+
+        case k_edge_vertical:
+            // edge is always a vertical line
+            {
+            LUnits uIncrY = (LUnits)( (width / cos(alpha)) / 2.0 );
+            UPoint uPoints[] = {
+                UPoint(x1, y1-uIncrY),
+                UPoint(x1, y1+uIncrY),
+                UPoint(x2, y2+uIncrY),
+                UPoint(x2, y2-uIncrY)
+            };
+            polygon(4, uPoints);
+            break;
+            }
+
+        case k_edge_horizontal:
+            // edge is always a horizontal line
+            {
+            LUnits uIncrX = (LUnits)( (width / sin(alpha)) / 2.0 );
+            UPoint uPoints[] = {
+                UPoint(x1+uIncrX, y1),
+                UPoint(x1-uIncrX, y1),
+                UPoint(x2-uIncrX, y2),
+                UPoint(x2+uIncrX, y2)
+            };
+            polygon(4, uPoints);
+            break;
+            }
+    }
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::polygon(int n, UPoint points[])
+{
+    move_to(points[0].x, points[0].y);
+    int i;
+    for (i=1; i < n; i++)
+    {
+        line_to(points[i].x, points[i].y);
+    }
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::rect(UPoint pos, USize size, LUnits radius)
+{
+    m_svg << "<rect x='" << pos.x << "' y='" << pos.y
+          << "' width='" << size.width << "' height='" << size.height;
+    if (radius > 0.0)
+        m_svg << "' rx='" << radius << "' ry='" << radius;
+
+    m_svg << "'/>";
+    add_newline();
+ }
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::draw_bitmap(RenderingBuffer& UNUSED(bmap), bool UNUSED(hasAlpha),
+                               Pixels UNUSED(srcX1), Pixels UNUSED(srcY1),
+                               Pixels UNUSED(srcX2), Pixels UNUSED(srcY2),
+                               LUnits UNUSED(dstX1), LUnits UNUSED(dstY1),
+                               LUnits UNUSED(dstX2), LUnits UNUSED(dstY2),
+                               EResamplingQuality UNUSED(resamplingMode),
+                               double UNUSED(alpha))
+{
+//    double x1 = double(dstX1);
+//    double y1 = double(dstY1);
+//    double x2 = double(dstX2);
+//    double y2 = double(dstY2);
+//    model_point_to_device(&x1, &y1);
+//    model_point_to_device(&x2, &y2);
+//
+//    m_pRenderer->render_bitmap(bmap, hasAlpha, double(srcX1), double(srcY1),
+//                               double(srcX2), double(srcY2), x1, y1, x2, y2,
+//                               resamplingMode, alpha);
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::fill_linear_gradient(LUnits UNUSED(x1), LUnits UNUSED(y1),
+                                     LUnits UNUSED(x2), LUnits UNUSED(y2))
+{
+    //TODO
+//    PathAttributes& attr = cur_attr();
+//    if (!attr.fill_gradient)
+//        attr.fill_gradient = LOMSE_NEW GradientAttributes();
+//
+//    double angle = atan2(double(y2-y1), double(x2-x1));
+//    attr.fill_gradient->transform.reset();
+//    attr.fill_gradient->transform *= agg::trans_affine_rotation(angle);
+//    attr.fill_gradient->transform *= agg::trans_affine_translation(x1, y1);
+//
+//    attr.fill_gradient->d1 = 0.0;
+//    attr.fill_gradient->d2 =
+//        sqrt(double(x2-x1) * double(x2-x1) + double(y2-y1) * double(y2-y1));
+//    attr.fill_mode = k_fill_gradient_linear;
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::gradient_color(Color UNUSED(c1), Color UNUSED(c2),
+                               double UNUSED(start), double UNUSED(stop))
+{
+    //TODO
+//    PathAttributes& attr = cur_attr();
+//    if (!attr.fill_gradient)
+//        attr.fill_gradient = LOMSE_NEW GradientAttributes();
+//
+//    int iStart = int(255.0 * start);
+//    int iStop   = int(255.0 * stop);
+//    if (iStop <= iStart)
+//        iStop = iStart + 1;
+//    double k = 1.0 / double(iStop - iStart);
+//
+//    GradientColors& colors = attr.fill_gradient->colors;
+//    for (int i = iStart; i < iStop; i++)
+//    {
+//        colors[i] = c1.gradient(c2, double(i - iStart) * k);
+//    }
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::gradient_color(Color UNUSED(c1),
+                               double UNUSED(start), double UNUSED(stop))
+{
+    //TODO
+//    PathAttributes& attr = cur_attr();
+//    if (!attr.fill_gradient)
+//        attr.fill_gradient = LOMSE_NEW GradientAttributes();
+//
+//    int iStart = int(255.0 * start);
+//    int iStop   = int(255.0 * stop);
+//    if (iStop <= iStart)
+//        iStop = iStart + 1;
+//
+//    GradientColors& colors = attr.fill_gradient->colors;
+//    for (int i = iStart; i < iStop; i++)
+//    {
+//        colors[i] = c1;
+//    }
+}
+
+//---------------------------------------------------------------------------------------
+void SvgDrawer::line_with_markers(UPoint start, UPoint end, LUnits width,
+                                     ELineCap startCap, ELineCap endCap)
+{
+    LineVertexSource line(double(start.x), double(start.y),
+                          double(end.x), double(end.y) );
+
+    //Converters are VertexSource objects
+    LineCapsConverter<LineVertexSource> converter(line, double(width), startCap, endCap);
+
+    add_path(converter, 0);
+}
+
+//---------------------------------------------------------------------------------------
+bool SvgDrawer::is_ready() const
+{
+    return true;
+}
+
+//---------------------------------------------------------------------------------------
+string SvgDrawer::to_svg(Color color)
+{
+    if (is_equal(color, Color(0,0,0)) )
+        return "#000";
+
+    stringstream ss;
+    ss << "#";
+    int r = color.r;
+    int g = color.g;
+    int b = color.b;
+    int a = color.a;
+    ss << std::hex << setfill('0') << setw(2) << r;
+    ss << std::hex << setfill('0') << setw(2) << g;
+    ss << std::hex << setfill('0') << setw(2) << b;
+    ss << std::hex << setfill('0') << setw(2) << a;
+    return ss.str();
+}
+
+
+}  //namespace lomse


### PR DESCRIPTION
This PR starts adding support for rendering documents as a stream of SVG commands (as text, in HTML format). The new SVG rendering facilities are independent of the existing bitmap related methods and both can be used simultaneously.


**Limitations**
- For now there are neither IDs nor classes in SVG elements. Therefore, the SVG code for notes, rests and other music notation elements can not be identified, styled and manipulated by the user application. I expect to add all these in coming PRs.
- For now the only formatting option for SVG output is to add a line break after each SVG element. Default value is `false` (do not add new lines) for maximum compactness of generated code.
- The SVG rendition does not include any Lomse visual effects (tempo line, cursor, markers, etc.) as all them should be treated differently in SVG oriented applications.


**Usage example**
See file /examples/svg/svg-minimal.cpp

Modify lines 36 & 50 as desired and build with:
```
g++ -std=c++11 svg-minimal.cpp -o svg-minimal `pkg-config --cflags liblomse` \
     `pkg-config --libs liblomse` -lstdc++
```
I will soon update the API documentation to add information about generating SVG with Lomse.



**Changes**
- Added SVG usage example in folder `/examples/svg/`.
- Added class `SvgDrawer` and struct `SvgOptions`.
- Added new methods in `Interactor` and `GraphicView` related to SVG.
- Moved helper classes `LineVertexSource`, `MarkerVertexSource` and `LineCapsConverter` from `lomse_bitmap_drawer.cpp` to `lomse_drawer.h`, so that they can be used from any `Drawer` derived class.
- Fixed `GmoShapeWord` and `GmoShapeText` `on_paint()` methods: set font has to be done by the `Drawer` class not by the `TextMeter` class.
- Now all objects providing vertices derive from `VertexSource`. Signature of method `rewind(int)` changed to `rewind(unsigned)` where required.


**Other non-related changes**
- Removed unused member variable `m_pTextMeter` in `BitmapDrawer`
- Fix in GmoShapeGlyph removing incorrect unnecessary code.

