### PR TITLE
Add more options for customizing Lomse builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,12 +248,13 @@ set( OUTDIR ${CMAKE_CURRENT_BINARY_DIR})
 set( EXECUTABLE_OUTPUT_PATH ${OUTDIR})
 set( LIBRARY_OUTPUT_PATH ${OUTDIR})
 message(STATUS "Using cmake version ${CMAKE_VERSION}")
-message(STATUS "** LOMSE_ROOT_DIR: ${LOMSE_ROOT_DIR}")
-message(STATUS "** CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
-message(STATUS "** LOMSE_SRC_DIR: ${LOMSE_SRC_DIR}")
-message(STATUS "** EXECUTABLE_OUTPUT_PATH: ${EXECUTABLE_OUTPUT_PATH}")
-message(STATUS "** LIBRARY_OUTPUT_PATH: ${LIBRARY_OUTPUT_PATH}")
-message(STATUS "** OUTDIR: ${OUTDIR}")
+message(STATUS "    LOMSE_ROOT_DIR: ${LOMSE_ROOT_DIR}")
+message(STATUS "    CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
+message(STATUS "    LOMSE_SRC_DIR: ${LOMSE_SRC_DIR}")
+message(STATUS "    EXECUTABLE_OUTPUT_PATH: ${EXECUTABLE_OUTPUT_PATH}")
+message(STATUS "    LIBRARY_OUTPUT_PATH: ${LIBRARY_OUTPUT_PATH}")
+message(STATUS "    OUTDIR: ${OUTDIR}")
+message(STATUS "")
 
 # define directories to search for CMake modules
 set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${LOMSE_ROOT_DIR}/cmake-modules")
@@ -389,6 +390,7 @@ message(STATUS "    Enable fontconfig = ${LOMSE_ENABLE_FONTCONFIG}")
 message(STATUS "    Enable freetype = ${LOMSE_ENABLE_FREETYPE}")
 message(STATUS "    Enable pthreads = ${LOMSE_ENABLE_THREADS}")
 message(STATUS "    Compatibility for LDP v1.5 = ${LOMSE_COMPATIBILITY_LDP_1_5}")
+message(STATUS "")
 
 
 
@@ -791,7 +793,7 @@ if(LOMSE_BUILD_STATIC_LIB)
 
     #When targeting emscriptem use its libraries instead of system libraries
     if (LOMSE_USING_EMSCRIPTEN)
-        add_compile_options(-sUSE_ZLIB=1 -sUSE_LIBPNG=1 -sUSE_FREETYPE=1 -sUSE_PTHREADS=1 -pthread)
+        add_compile_options(-sUSE_ZLIB=1 -sUSE_LIBPNG=1 -sUSE_FREETYPE=1)
     endif()
 
     add_library(${LOMSE_STATIC} STATIC ${ALL_LOMSE_SOURCES})
@@ -814,7 +816,7 @@ if(LOMSE_BUILD_STATIC_LIB)
         )
     #endif()
     if (LOMSE_USING_EMSCRIPTEN)
-        set_target_properties(${LOMSE_STATIC} PROPERTIES LINK_FLAGS "--bind -pthread")
+        set_target_properties(${LOMSE_STATIC} PROPERTIES LINK_FLAGS "--bind")
     endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,14 @@
 # LOMSE_BUILD_EXAMPLE (Default: OFF)
 #   Build the tutorial_1 program that uses the library, to test it.
 #
+# LOMSE_USING_EMSCRIPTEN (Default: OFF)
+#   This option is used to inform this script that it is being run with
+#   Emscripten tools, for creating JavaScript bindings. When setting this, 
+#   all other settings, such as LOMSE_BUILD_SHARED_LIB, LOMSE_BUILD_TESTS,
+#   LOMSE_ENABLE_COMPRESSION, etc. are ignored and this script will use
+#   instead pre-defined settings, as required for JavaScript bindings.
+#   	cmake -DLOMSE_USING_EMSCRIPTEN=ON [...]
+#
 #
 # Debug options (ON / OFF values):
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -167,7 +175,7 @@
 #   has no effect because libpng depends on zlib. Therefore, when png is
 #   enabled (LOMSE_ENABLE_PNG=ON) then compression is automatically enabled.
 #
-# LOMSE_ENABLE_SYSTEM_FONTS   (Default value: ON)
+# LOMSE_ENABLE_FONTCONFIG   (Default value: ON)
 #   ** Only meaningfull in Linux systems **
 #	In Linux systems, build with support to look for fonts in system installed
 #   fonts. This requires the ‘fontconfig’ library.
@@ -175,6 +183,14 @@
 #   Lomse will use only the fonts available in the path provided by the user
 #   application at Lomse initialization. Example for disabling:
 #		cmake -G "Unix Makefiles" -DLOMSE_ENABLE_SYSTEM_FONTS=OFF [...]
+#
+# LOMSE_ENABLE_THREADS   (Default value: ON)
+#	Build with support for threads. This requires the 'threads' library.
+#   Lomse uses threads for the ScorePlayer class, also used by ScorePlayerCtrl
+#   class. If your application will not use ScorePlayer, you can reduce 
+#   lomse size and avoid the pthreads dependency by disabling the use
+#   of threads. Example for disabling:
+#		cmake -G "Unix Makefiles" -DLOMSE_ENABLE_THREADS=OFF [...]
 #
 #
 #
@@ -185,7 +201,7 @@
 #
 #-------------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 2.8.10 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.4 FATAL_ERROR)
 
 #Travis complains when building with clang. What is this for?
 cmake_policy(SET CMP0042 NEW)   #MACOSX_RPATH is enabled by default
@@ -220,6 +236,9 @@ cmake_policy(SET CMP0054 NEW)   # quoted arguments will not be further dereferen
 
 # project name
 project(lomse)
+
+# uncomment for debugging
+#set(CMAKE_VERBOSE_MAKEFILE on)
 
 # main directories 
 set( LOMSE_ROOT_DIR  ${CMAKE_CURRENT_SOURCE_DIR} )
@@ -264,6 +283,9 @@ option(LOMSE_RUN_TESTS
 option(LOMSE_BUILD_EXAMPLE
     "Build the tutorial_1 program"
     OFF)
+option(LOMSE_USING_EMSCRIPTEN
+    "This is a build using Emscripten tools, for JavaScript bindings."
+    OFF)
 
 # Debug options (ON / OFF values):
 option(LOMSE_DEBUG
@@ -288,9 +310,13 @@ option(LOMSE_ENABLE_PNG
 option(LOMSE_ENABLE_COMPRESSION
     "Enable compressed formats (requires zlib)"
     ON)
-option(LOMSE_ENABLE_SYSTEM_FONTS
+option(LOMSE_ENABLE_FONTCONFIG
     "Enable search in system fonts (requires fontconfig)"
     ON)
+option(LOMSE_ENABLE_THREADS
+    "Enable to use threads (requires pthreads)"
+    ON)
+
 
 # Other options
 option(LOMSE_COMPATIBILITY_LDP_1_5
@@ -306,7 +332,26 @@ if (LOMSE_ENABLE_PNG)
         message(STATUS "**WARNING**: Enabling PNG requires enabling compression. LOMSE_ENABLE_COMPRESSION set to ON" )
     	set(LOMSE_ENABLE_COMPRESSION ON)
 	endif()
-endif()      
+endif()
+
+# when targeting Emscripten do not use external dependencies
+set(LOMSE_ENABLE_FREETYPE ON)
+if (LOMSE_USING_EMSCRIPTEN)
+    set(LOMSE_ENABLE_PNG OFF)
+    set(LOMSE_ENABLE_COMPRESSION OFF)
+    set(LOMSE_ENABLE_FONTCONFIG OFF)
+    set(LOMSE_BUILD_TESTS OFF)
+    set(LOMSE_RUN_TESTS OFF)
+    set(LOMSE_DOWNLOAD_BRAVURA_FONT OFF)
+    set(LOMSE_INSTALL_BRAVURA_FONT OFF)
+    set(LOMSE_ENABLE_FREETYPE OFF)
+    set(LOMSE_ENABLE_THREADS OFF)
+
+    #emscripten does not support dynamic linking
+    set(LOMSE_BUILD_STATIC_LIB ON)
+    set(LOMSE_BUILD_SHARED_LIB OFF)
+endif()
+     
 
 #libraries to build
 #if (WIN32)
@@ -326,20 +371,24 @@ endif()
 #endif()
 
 # display options values for building
-message(STATUS "Build monolithic library = ${LOMSE_BUILD_MONOLITHIC}")
-message(STATUS "Build the static library = ${LOMSE_BUILD_STATIC_LIB}")
-message(STATUS "Build the shared library = ${LOMSE_BUILD_SHARED_LIB}")
-message(STATUS "Build testlib program = ${LOMSE_BUILD_TESTS}")
-message(STATUS "Run tests after building = ${LOMSE_RUN_TESTS}")
-message(STATUS "Build tutorial_1 program = ${LOMSE_BUILD_EXAMPLE}")
-message(STATUS "Create Debug build = ${LOMSE_DEBUG}")
-message(STATUS "Enable debug logs = ${LOMSE_ENABLE_DEBUG_LOGS}")
-message(STATUS "Download Bravura font = ${LOMSE_DOWNLOAD_BRAVURA_FONT}")
-message(STATUS "Install Bravura font = ${LOMSE_INSTALL_BRAVURA_FONT}")
-message(STATUS "Enable png format = ${LOMSE_ENABLE_PNG}")
-message(STATUS "Enable compressed formats = ${LOMSE_ENABLE_COMPRESSION}")
-message(STATUS "Enable search in system fonts = ${LOMSE_ENABLE_SYSTEM_FONTS}")
-message(STATUS "Compatibility for LDP v1.5 = ${LOMSE_COMPATIBILITY_LDP_1_5}")
+message(STATUS "Build options:")
+message(STATUS "    Building with emscripten = ${LOMSE_USING_EMSCRIPTEN}")
+message(STATUS "    Build monolithic library = ${LOMSE_BUILD_MONOLITHIC}")
+message(STATUS "    Build the static library = ${LOMSE_BUILD_STATIC_LIB}")
+message(STATUS "    Build the shared library = ${LOMSE_BUILD_SHARED_LIB}")
+message(STATUS "    Build testlib program = ${LOMSE_BUILD_TESTS}")
+message(STATUS "    Run tests after building = ${LOMSE_RUN_TESTS}")
+message(STATUS "    Build tutorial_1 program = ${LOMSE_BUILD_EXAMPLE}")
+message(STATUS "    Create Debug build = ${LOMSE_DEBUG}")
+message(STATUS "    Enable debug logs = ${LOMSE_ENABLE_DEBUG_LOGS}")
+message(STATUS "    Download Bravura font = ${LOMSE_DOWNLOAD_BRAVURA_FONT}")
+message(STATUS "    Install Bravura font = ${LOMSE_INSTALL_BRAVURA_FONT}")
+message(STATUS "    Enable libpng = ${LOMSE_ENABLE_PNG}")
+message(STATUS "    Enable zlib = ${LOMSE_ENABLE_COMPRESSION}")
+message(STATUS "    Enable fontconfig = ${LOMSE_ENABLE_FONTCONFIG}")
+message(STATUS "    Enable freetype = ${LOMSE_ENABLE_FREETYPE}")
+message(STATUS "    Enable pthreads = ${LOMSE_ENABLE_THREADS}")
+message(STATUS "    Compatibility for LDP v1.5 = ${LOMSE_COMPATIBILITY_LDP_1_5}")
 
 
 
@@ -615,13 +664,15 @@ if( LOMSE_ENABLE_COMPRESSION )
 endif(LOMSE_ENABLE_COMPRESSION)
 
 # Check for FreeType
-find_package(Freetype REQUIRED)                 
-include_directories( ${FREETYPE_INCLUDE_DIRS} )
-message(STATUS "Found Freetype: ${FREETYPE_LIBRARY}" )
-message("      include= ${FREETYPE_INCLUDE_DIRS}" )
-set(LOMSE_REQUIRES "${LOMSE_REQUIRES}, freetype2")
-set(LOMSE_DEBIAN_DEPS "${LOMSE_DEBIAN_DEPS}, libfreetype6")
-set(LOMSE_BUILD_DEPS ${LOMSE_BUILD_DEPS} ${FREETYPE_LIBRARY})
+if( LOMSE_ENABLE_FREETYPE )
+    find_package(Freetype REQUIRED)                 
+    include_directories( ${FREETYPE_INCLUDE_DIRS} )
+    message(STATUS "Found Freetype: ${FREETYPE_LIBRARY}" )
+    message("      include= ${FREETYPE_INCLUDE_DIRS}" )
+    set(LOMSE_REQUIRES "${LOMSE_REQUIRES}, freetype2")
+    set(LOMSE_DEBIAN_DEPS "${LOMSE_DEBIAN_DEPS}, libfreetype6")
+    set(LOMSE_BUILD_DEPS ${LOMSE_BUILD_DEPS} ${FREETYPE_LIBRARY})
+endif()
 
 # Check for libpng
 if( LOMSE_ENABLE_PNG )
@@ -636,7 +687,7 @@ if( LOMSE_ENABLE_PNG )
 endif(LOMSE_ENABLE_PNG)
 
 # Check for fontconfig
-if (UNIX AND LOMSE_ENABLE_SYSTEM_FONTS)  #UNIX = Linux, macOS & Android
+if (UNIX AND LOMSE_ENABLE_FONTCONFIG)  #UNIX = Linux, macOS & Android
     find_path(FONTCONFIG_INCLUDE_DIR fontconfig/fontconfig.h)
     find_library(FONTCONFIG_LIBRARIES NAMES fontconfig)
     if (("${FONTCONFIG_INCLUDE_DIR}" STREQUAL "FONTCONFIG_INCLUDE_DIR-NOTFOUND")
@@ -667,26 +718,32 @@ endif()
 # libc standard library (called "bionic") already includes the relevant functions
 # in threads.h and pthread.h
 # See: https://stackoverflow.com/questions/5990661/cmake-find-packagethreads-for-android-cross-compilation
-
-set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
-set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-if (NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
-    find_package(Threads REQUIRED)
-    if( Threads_FOUND )
-        message(STATUS "Found pthreads:" )
-        message(STATUS "    CMAKE_THREAD_LIBS_INIT=${CMAKE_THREAD_LIBS_INIT}")
-        message(STATUS "    CMAKE_USE_PTHREADS_INIT=${CMAKE_USE_PTHREADS_INIT}")
-        message(STATUS "    CMAKE_USE_WIN32_THREADS_INIT=${CMAKE_USE_WIN32_THREADS_INIT}")
-        message(STATUS "    CMAKE_HP_PTHREADS_INIT=${CMAKE_HP_PTHREADS_INIT}")
-    else()
-        message(FATAL_ERROR "pthreads dependency not found.")
+#
+if( LOMSE_ENABLE_THREADS )
+    set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+    set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+    if (NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
+        find_package(Threads REQUIRED)
+        if( Threads_FOUND )
+            message(STATUS "Found pthreads:" )
+            message(STATUS "    CMAKE_THREAD_LIBS_INIT=${CMAKE_THREAD_LIBS_INIT}")
+            message(STATUS "    CMAKE_USE_PTHREADS_INIT=${CMAKE_USE_PTHREADS_INIT}")
+            message(STATUS "    CMAKE_USE_WIN32_THREADS_INIT=${CMAKE_USE_WIN32_THREADS_INIT}")
+            message(STATUS "    CMAKE_HP_PTHREADS_INIT=${CMAKE_HP_PTHREADS_INIT}")
+        else()
+            message(FATAL_ERROR "pthreads dependency not found.")
+        endif()
     endif()
 endif()
 
 
 # strip leading commas from LOMSE_REQUIRES and LOMSE_DEBIAN_DEPS
-string( REGEX REPLACE "^, " "" LOMSE_REQUIRES ${LOMSE_REQUIRES})
-string( REGEX REPLACE "^, " "" LOMSE_DEBIAN_DEPS ${LOMSE_DEBIAN_DEPS})
+if (LOMSE_REQUIRES)
+    string( REGEX REPLACE "^, " "" LOMSE_REQUIRES ${LOMSE_REQUIRES})
+endif()
+if (LOMSE_DEBIAN_DEPS)
+    string( REGEX REPLACE "^, " "" LOMSE_DEBIAN_DEPS ${LOMSE_DEBIAN_DEPS})
+endif()
 
 if(UNIX)
     # macros for "Print all warnings", GCC & __UNIX__
@@ -731,6 +788,12 @@ configure_file(
 if(LOMSE_BUILD_STATIC_LIB)
 
     set(LOMSE_STATIC lomse)
+
+    #When targeting emscriptem use its libraries instead of system libraries
+    if (LOMSE_USING_EMSCRIPTEN)
+        add_compile_options(-sUSE_ZLIB=1 -sUSE_LIBPNG=1 -sUSE_FREETYPE=1 -sUSE_PTHREADS=1 -pthread)
+    endif()
+
     add_library(${LOMSE_STATIC} STATIC ${ALL_LOMSE_SOURCES})
     add_dependencies(${LOMSE_STATIC} build-version)
 
@@ -750,6 +813,10 @@ if(LOMSE_BUILD_STATIC_LIB)
                 RUNTIME_OUTPUT_DIRECTORY ${LIBRARY_OUTPUT_PATH}
         )
     #endif()
+    if (LOMSE_USING_EMSCRIPTEN)
+        set_target_properties(${LOMSE_STATIC} PROPERTIES LINK_FLAGS "--bind -pthread")
+    endif()
+
 
     # Force not to link with standard MSVC libraries: /NODEFAULTLIB
     if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
@@ -889,7 +956,7 @@ if (LOMSE_BUILD_EXAMPLE)
     # libraries to link
     if (LOMSE_BUILD_SHARED_LIB)
         target_link_libraries ( ${EXAMPLE1} ${LOMSE_SHARED} 
-                ${UNITTEST++_LIBRARY} ${LOMSE_BUILD_DEPS}
+                ${UNITTEST++_LIBRARY} ${LOMSE_BUILD_DEPS}  #${CMAKE_THREAD_LIBS_INIT}
         )
         add_dependencies(${EXAMPLE1} ${LOMSE_SHARED})
     else()      
@@ -964,8 +1031,10 @@ install(DIRECTORY "${INCLUDES_UTFCPP}/utf8"
         DESTINATION "${LOMSE_INCLUDEDIR}/utf8"
         FILES_MATCHING PATTERN "*.h" )
 
-# copy also lomse_config.h
-install(FILES  ${CMAKE_CURRENT_BINARY_DIR}/lomse_config.h 
+# copy also lomse_config.h and lomse_version.h
+install(FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/lomse_config.h
+            ${CMAKE_CURRENT_BINARY_DIR}/lomse_version.h
         DESTINATION "${LOMSE_INCLUDEDIR}" )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,8 @@
 #   By default the unit tests runner program 'testlib' is also built.
 #   You can disable building the tests with this option:
 #       cmake -DLOMSE_BUILD_TESTS:BOOL=OFF [...]
+#   When the tests are not build, the dependency from 'UnitTest++' is
+#   automatically removed.
 #
 # LOMSE_RUN_TESTS (Default: ON)
 #   When unit test runner program 'testlib' is built (enabled by default and
@@ -144,29 +146,36 @@
 # Options to reduce dependencies from other libraries (ON / OFF values):
 # --------------------------------------------------------------------------
 #
-# If your application will not deal with compressed files or with scores
-# containing png images, it is possible to reduce dependencies from third
-# party librraries by removing the code that deals with compressed files
-# or with PNG images.
-#
 # LOMSE_ENABLE_PNG   (Default value: ON)
-#	Build with support for PNG images. This requires libpng library.
-#	By setting this to OFF Lomse will ignore any png image embedded in the
-#	documents. But Lomse will not fail in those cases, just will log error
-#	messages. For instance:
+#	Build with support for PNG images. This requires the 'libpng' library.
+#	By setting this to OFF the dependency from 'libpng' is removed and
+#   Lomse will ignore any png image embedded in the documents, but will not
+#   fail if the document contains PNG images, it will just log an error
+#   message. Example for disabling:
 #		cmake -G "Unix Makefiles" -DLOMSE_ENABLE_PNG=OFF [...]
 #
 # LOMSE_ENABLE_COMPRESSION   (Default value: ON)
-#	Build with support for compressed files. This requires zlib library.
-#	By setting this to OFF Lomse will not be able to deal with compressed files,
-#	such as MusicXML files in compressed format, or with png images embedded in
-#	the documents. But Lomse will not fail in those cases, just will log error
-#	messages. For instance:
+#	Build with support for compressed files. This requires the 'zlib' library.
+#	By setting this to OFF the dependency from 'zlib' is removed but Lomse will
+#   not be able to deal with compressed files, such as MusicXML files in
+#   compressed format, or with png images embedded in the documents. 
+#   But Lomse will not fail in those cases, just will log error
+#	messages. Example for disabling:
 #		cmake -G "Unix Makefiles" -DLOMSE_ENABLE_COMPRESSION=OFF [...]
 #
 #	**Important**: trying to disable compression without also disabling png
 #   has no effect because libpng depends on zlib. Therefore, when png is
-#   active (LOMSE_ENABLE_PNG=ON) then compression is automatically enabled.
+#   enabled (LOMSE_ENABLE_PNG=ON) then compression is automatically enabled.
+#
+# LOMSE_ENABLE_SYSTEM_FONTS   (Default value: ON)
+#   ** Only meaningfull in Linux systems **
+#	In Linux systems, build with support to look for fonts in system installed
+#   fonts. This requires the ‘fontconfig’ library.
+#	By setting this to OFF the dependency from 'fontconfig' is removed and
+#   Lomse will use only the fonts available in the path provided by the user
+#   application at Lomse initialization. Example for disabling:
+#		cmake -G "Unix Makefiles" -DLOMSE_ENABLE_SYSTEM_FONTS=OFF [...]
+#
 #
 #
 # Other options (ON / OFF values):
@@ -279,6 +288,9 @@ option(LOMSE_ENABLE_PNG
 option(LOMSE_ENABLE_COMPRESSION
     "Enable compressed formats (requires zlib)"
     ON)
+option(LOMSE_ENABLE_SYSTEM_FONTS
+    "Enable search in system fonts (requires fontconfig)"
+    ON)
 
 # Other options
 option(LOMSE_COMPATIBILITY_LDP_1_5
@@ -326,6 +338,7 @@ message(STATUS "Download Bravura font = ${LOMSE_DOWNLOAD_BRAVURA_FONT}")
 message(STATUS "Install Bravura font = ${LOMSE_INSTALL_BRAVURA_FONT}")
 message(STATUS "Enable png format = ${LOMSE_ENABLE_PNG}")
 message(STATUS "Enable compressed formats = ${LOMSE_ENABLE_COMPRESSION}")
+message(STATUS "Enable search in system fonts = ${LOMSE_ENABLE_SYSTEM_FONTS}")
 message(STATUS "Compatibility for LDP v1.5 = ${LOMSE_COMPATIBILITY_LDP_1_5}")
 
 
@@ -589,8 +602,8 @@ if (LOMSE_BUILD_TESTS)
 	endif()
 endif(LOMSE_BUILD_TESTS)
 
+# Check for zlib
 if( LOMSE_ENABLE_COMPRESSION )
-    # Check for zlib
     # libpng and freetype require zlib. So deal with zlib first.
     find_package(ZLIB REQUIRED)
     include_directories( ${ZLIB_INCLUDE_DIR} )
@@ -623,7 +636,7 @@ if( LOMSE_ENABLE_PNG )
 endif(LOMSE_ENABLE_PNG)
 
 # Check for fontconfig
-if (UNIX)  #Linux, macOS & Android
+if (UNIX AND LOMSE_ENABLE_SYSTEM_FONTS)  #UNIX = Linux, macOS & Android
     find_path(FONTCONFIG_INCLUDE_DIR fontconfig/fontconfig.h)
     find_library(FONTCONFIG_LIBRARIES NAMES fontconfig)
     if (("${FONTCONFIG_INCLUDE_DIR}" STREQUAL "FONTCONFIG_INCLUDE_DIR-NOTFOUND")
@@ -645,6 +658,31 @@ if (UNIX)  #Linux, macOS & Android
         message(FATAL_ERROR "fontconfig package not found.")
     endif()
 endif()
+
+
+# Check for pthreads
+# It is required for fontconfig and for Lomse
+#
+# Under Android, there is no need for FIND_PACKAGE(Threads) because the Android
+# libc standard library (called "bionic") already includes the relevant functions
+# in threads.h and pthread.h
+# See: https://stackoverflow.com/questions/5990661/cmake-find-packagethreads-for-android-cross-compilation
+
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+if (NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
+    find_package(Threads REQUIRED)
+    if( Threads_FOUND )
+        message(STATUS "Found pthreads:" )
+        message(STATUS "    CMAKE_THREAD_LIBS_INIT=${CMAKE_THREAD_LIBS_INIT}")
+        message(STATUS "    CMAKE_USE_PTHREADS_INIT=${CMAKE_USE_PTHREADS_INIT}")
+        message(STATUS "    CMAKE_USE_WIN32_THREADS_INIT=${CMAKE_USE_WIN32_THREADS_INIT}")
+        message(STATUS "    CMAKE_HP_PTHREADS_INIT=${CMAKE_HP_PTHREADS_INIT}")
+    else()
+        message(FATAL_ERROR "pthreads dependency not found.")
+    endif()
+endif()
+
 
 # strip leading commas from LOMSE_REQUIRES and LOMSE_DEBIAN_DEPS
 string( REGEX REPLACE "^, " "" LOMSE_REQUIRES ${LOMSE_REQUIRES})
@@ -766,22 +804,27 @@ if(LOMSE_BUILD_TESTS)
     file(GLOB TESTLIB_SRC "${LOMSE_SRC_DIR}/tests/lomse_*.cpp" )
     add_executable(${TESTLIB} ${TESTLIB_SRC})
     
-    # libraries to link
+    # lomse library name
     if (LOMSE_BUILD_SHARED_LIB)
-        target_link_libraries (${TESTLIB} ${LOMSE_SHARED}
+        set(LOMSE_LIBRARY ${LOMSE_SHARED})
+    else()
+        set(LOMSE_LIBRARY ${LOMSE_STATIC})
+    endif()
+
+    # libraries to link
+    if( Threads_FOUND )
+        target_link_libraries (${TESTLIB} ${LOMSE_LIBRARY}
                 ${UNITTEST++_LIBRARY} ${LOMSE_BUILD_DEPS} 
         )
-        add_dependencies(${TESTLIB} ${LOMSE_SHARED})
+        target_link_libraries (${TESTLIB} "${CMAKE_THREAD_LIBS_INIT}")
     else()
-        # Check for pthreads
-        find_package (Threads)
-
-        target_link_libraries (${TESTLIB} ${LOMSE_STATIC}
-                ${UNITTEST++_LIBRARY} ${LOMSE_BUILD_DEPS} ${CMAKE_THREAD_LIBS_INIT}
-        ) 
-        add_dependencies(${TESTLIB} ${LOMSE_STATIC})
+        target_link_libraries (${TESTLIB} ${LOMSE_LIBRARY}
+                ${UNITTEST++_LIBRARY} ${LOMSE_BUILD_DEPS} 
+        )
     endif()
-    
+    add_dependencies(${TESTLIB} ${LOMSE_LIBRARY})
+
+    # Windows properties    
     if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         set_target_properties(${TESTLIB} PROPERTIES  LINK_FLAGS "/NODEFAULTLIB:LIBCMT")
     endif()
@@ -846,7 +889,7 @@ if (LOMSE_BUILD_EXAMPLE)
     # libraries to link
     if (LOMSE_BUILD_SHARED_LIB)
         target_link_libraries ( ${EXAMPLE1} ${LOMSE_SHARED} 
-                ${UNITTEST++_LIBRARY} ${LOMSE_BUILD_DEPS}  #${CMAKE_THREAD_LIBS_INIT}
+                ${UNITTEST++_LIBRARY} ${LOMSE_BUILD_DEPS}
         )
         add_dependencies(${EXAMPLE1} ${LOMSE_SHARED})
     else()      

--- a/add-sources.cmake
+++ b/add-sources.cmake
@@ -132,7 +132,6 @@ set(GUI_CONTROLS_FILES
     ${LOMSE_SRC_DIR}/gui_controls/lomse_button_ctrl.cpp
     ${LOMSE_SRC_DIR}/gui_controls/lomse_checkbox_ctrl.cpp
     ${LOMSE_SRC_DIR}/gui_controls/lomse_hyperlink_ctrl.cpp
-    ${LOMSE_SRC_DIR}/gui_controls/lomse_score_player_ctrl.cpp
     ${LOMSE_SRC_DIR}/gui_controls/lomse_static_text_ctrl.cpp
     ${LOMSE_SRC_DIR}/gui_controls/lomse_progress_bar_ctrl.cpp
 )
@@ -215,12 +214,23 @@ set(SCORE_FILES
 
 set(SOUND_FILES
     ${LOMSE_SRC_DIR}/sound/lomse_midi_table.cpp
-    ${LOMSE_SRC_DIR}/sound/lomse_score_player.cpp
 )
 
 set(LOMSE_PACKAGES_FILES
     ${LOMSE_PKG_DIR}/pugixml/pugixml.cpp
 )
+
+# add sources that depend on build options
+if( LOMSE_ENABLE_PTHREADS )
+    set(SOUND_FILES
+        ${SOUND_FILES} 
+        ${LOMSE_SRC_DIR}/sound/lomse_score_player.cpp
+    )
+    set(GUI_CONTROLS_FILES
+        ${GUI_CONTROLS_FILES}
+        ${LOMSE_SRC_DIR}/gui_controls/lomse_score_player_ctrl.cpp
+    )
+endif()
 
 if( LOMSE_ENABLE_COMPRESSION )
     set(LOMSE_PACKAGES_FILES

--- a/add-sources.cmake
+++ b/add-sources.cmake
@@ -221,7 +221,7 @@ set(LOMSE_PACKAGES_FILES
 )
 
 # add sources that depend on build options
-if( LOMSE_ENABLE_PTHREADS )
+if( LOMSE_ENABLE_THREADS )
     set(SOUND_FILES
         ${SOUND_FILES} 
         ${LOMSE_SRC_DIR}/sound/lomse_score_player.cpp
@@ -241,7 +241,7 @@ if( LOMSE_ENABLE_COMPRESSION )
 endif()
 
 # platform dependent implementation files
-if(UNIX AND LOMSE_ENABLE_SYSTEM_FONTS)
+if(UNIX AND LOMSE_ENABLE_FONTCONFIG)
     set(PLATFORM_FILES
         ${LOMSE_SRC_DIR}/platform/lomse_linux.cpp
     )

--- a/add-sources.cmake
+++ b/add-sources.cmake
@@ -231,7 +231,7 @@ if( LOMSE_ENABLE_COMPRESSION )
 endif()
 
 # platform dependent implementation files
-if(UNIX)
+if(UNIX AND LOMSE_ENABLE_SYSTEM_FONTS)
     set(PLATFORM_FILES
         ${LOMSE_SRC_DIR}/platform/lomse_linux.cpp
     )

--- a/include/lomse_doorway.h
+++ b/include/lomse_doorway.h
@@ -410,6 +410,7 @@ public:
 	*/
     void set_global_metronome_and_replace_local(Metronome* pMtr);
 
+#if (LOMSE_ENABLE_THREADS == 1)
 	/** Method create_score_player() informs Lomse about the MIDI server that will be
         used for scores play back.
 
@@ -420,7 +421,7 @@ public:
         @see @subpage page-sound-generation
 	*/
     ScorePlayer* create_score_player(MidiServerBase* pSoundServer);
-
+#endif
     //@}    //Playback related methods
 
 

--- a/include/lomse_injectors.h
+++ b/include/lomse_injectors.h
@@ -18,7 +18,6 @@
 
 
 #include <iostream>
-using namespace std;
 
 namespace lomse
 {
@@ -87,10 +86,10 @@ protected:
     FontSelector* m_pFontSelector;
     Metronome* m_pGlobalMetronome;
     EventsDispatcher* m_pDispatcher;
-    string m_sMusicFontFile;
-    string m_sMusicFontName;
-    string m_sMusicFontPath;
-    string m_sFontsPath;
+    std::string m_sMusicFontFile;
+    std::string m_sMusicFontName;
+    std::string m_sMusicFontPath;
+    std::string m_sFontsPath;
     MusicGlyphs* m_pMusicGlyphs;
 
     //options
@@ -118,43 +117,43 @@ protected:
     int m_renderSpacingOpts;        //options for spacing and lines breaker algorithm
 
 public:
-    LibraryScope(ostream& reporter=cout, LomseDoorway* pDoorway=nullptr);
+    LibraryScope(ostream& reporter=std::cout, LomseDoorway* pDoorway=nullptr);
     ~LibraryScope();
 
     inline ostream& default_reporter() { return m_reporter; }
     inline LomseDoorway* platform_interface() { return m_pDoorway; }
     LdpFactory* ldp_factory();
     FontStorage* font_storage();
-    inline string& fonts_path() { return m_sFontsPath; }
+    inline std::string& fonts_path() { return m_sFontsPath; }
     EventsDispatcher* get_events_dispatcher();
     FontSelector* get_font_selector();
 
     //callbacks
     void post_event(SpEventInfo pEvent);
     void post_request(Request* pRequest);
-    std::string get_font(const string& name, bool fBold, bool fItalic);
+    std::string get_font(const std::string& name, bool fBold, bool fItalic);
 
     double get_screen_ppi() const;
     int get_pixel_format() const;
 
     //library info
-    static string get_version_string();
-    static string get_version_long_string();
+    static std::string get_version_string();
+    static std::string get_version_long_string();
     static int get_version_major();
     static int get_version_minor();
     static int get_version_patch();
-    static string get_build_date();
+    static std::string get_build_date();
 
     //fonts
     MusicGlyphs* get_glyphs_table();
-    inline void set_default_fonts_path(const string& fontsPath) {
+    inline void set_default_fonts_path(const std::string& fontsPath) {
         m_sFontsPath = fontsPath;
     }
-    void set_music_font(const string& fontFile, const string& fontName,
-                        const string& path="");
-    inline const string& get_music_font_name() { return m_sMusicFontName; }
-    inline const string& get_music_font_file() { return m_sMusicFontFile; }
-    const string& get_music_font_path();
+    void set_music_font(const std::string& fontFile, const std::string& fontName,
+                        const std::string& path="");
+    inline const std::string& get_music_font_name() { return m_sMusicFontName; }
+    inline const std::string& get_music_font_file() { return m_sMusicFontFile; }
+    const std::string& get_music_font_path();
     bool is_music_font_smufl_compliant();
 
     //global options
@@ -228,7 +227,7 @@ protected:
     IdAssigner* m_idAssigner;
 
 public:
-    DocumentScope(ostream& reporter=cout);
+    DocumentScope(ostream& reporter=std::cout);
     ~DocumentScope();
 
     ostream& default_reporter() { return m_reporter; }
@@ -269,7 +268,7 @@ public:
 
     static ModelBuilder* inject_ModelBuilder(DocumentScope& documentScope);
     static Document* inject_Document(LibraryScope& libraryScope,
-                                     ostream& reporter = cout);
+                                     ostream& reporter = std::cout);
     static BitmapDrawer* inject_BitmapDrawer(LibraryScope& libraryScope);
 
     static View* inject_View(LibraryScope& libraryScope, int viewType);
@@ -287,8 +286,10 @@ public:
                                        Drawer* screenDrawer, Drawer* printDrawer);
 
     static Task* inject_Task(int taskType, Interactor* pIntor);
+#if (LOMSE_ENABLE_THREADS == 1)
     static ScorePlayer* inject_ScorePlayer(LibraryScope& libraryScope,
                                            MidiServerBase* pSoundServer);
+#endif
     static DocCursor* inject_DocCursor(Document* pDoc);
     static SelectionSet* inject_SelectionSet(Document* pDoc);
     static DocCommandExecuter* inject_DocCommandExecuter(Document* pDoc);

--- a/include/lomse_instrument_engraver.h
+++ b/include/lomse_instrument_engraver.h
@@ -190,6 +190,7 @@ public:
     LUnits get_barline_bottom();
 
     //helper
+    LUnits tenths_to_logical(Tenths value, int iStaff=0);
     inline ImoInstrument* get_instrument() { return m_pInstr; }
     int get_num_staves();
 

--- a/include/lomse_instrument_engraver.h
+++ b/include/lomse_instrument_engraver.h
@@ -190,7 +190,6 @@ public:
     LUnits get_barline_bottom();
 
     //helper
-    LUnits tenths_to_logical(Tenths value, int iStaff=0);
     inline ImoInstrument* get_instrument() { return m_pInstr; }
     int get_num_staves();
 

--- a/include/lomse_ldp_elements.h
+++ b/include/lomse_ldp_elements.h
@@ -341,7 +341,7 @@ class LdpObject : public LdpElement
 	public:
         //! static constructor to be used by Factory
 		static LdpElement* new_ldp_object()
-			{ LdpObject<type>* o = LOMSE_NEW LdpObject<type>; assert(o!=0); return o; }
+			{ LdpObject<type>* o = LOMSE_NEW LdpObject<type>; assert(o!=nullptr); return o; }
 
         //! implementation of Visitable interface
         void accept_visitor(BaseVisitor& v) override {

--- a/include/lomse_score_player.h
+++ b/include/lomse_score_player.h
@@ -10,6 +10,8 @@
 #ifndef __LOMSE_SCORE_PLAYER_H__        //to avoid nested includes
 #define __LOMSE_SCORE_PLAYER_H__
 
+#if (LOMSE_ENABLE_THREADS == 1)
+
 #include "lomse_basic.h"
 #include "lomse_internal_model.h"
 
@@ -366,5 +368,7 @@ protected:
 
 
 }   //namespace lomse
+
+#enif   //LOMSE_ENABLE_THREADS == 1
 
 #endif  // __LOMSE_SCORE_PLAYER_H__

--- a/include/lomse_score_player.h
+++ b/include/lomse_score_player.h
@@ -369,6 +369,6 @@ protected:
 
 }   //namespace lomse
 
-#enif   //LOMSE_ENABLE_THREADS == 1
+#endif   //LOMSE_ENABLE_THREADS == 1
 
 #endif  // __LOMSE_SCORE_PLAYER_H__

--- a/include/lomse_score_player_ctrl.h
+++ b/include/lomse_score_player_ctrl.h
@@ -10,6 +10,7 @@
 #ifndef _LOMSE_SCORE_PLAYER_CTRL_H__
 #define _LOMSE_SCORE_PLAYER_CTRL_H__
 
+#include "lomse_config.h"
 #if (LOMSE_ENABLE_THREADS == 1)
 
 #include "lomse_control.h"

--- a/include/lomse_score_player_ctrl.h
+++ b/include/lomse_score_player_ctrl.h
@@ -10,6 +10,8 @@
 #ifndef _LOMSE_SCORE_PLAYER_CTRL_H__
 #define _LOMSE_SCORE_PLAYER_CTRL_H__
 
+#if (LOMSE_ENABLE_THREADS == 1)
+
 #include "lomse_control.h"
 #include "lomse_player_gui.h"
 
@@ -80,5 +82,7 @@ protected:
 
 
 } //namespace lomse
+
+#endif //LOMSE_ENABLE_THREADS == 1
 
 #endif    //_LOMSE_SCORE_PLAYER_CTRL_H__

--- a/include/lomse_svg_drawer.h
+++ b/include/lomse_svg_drawer.h
@@ -26,8 +26,10 @@ class LOMSE_EXPORT SvgDrawer : public Drawer
 {
 private:
     std::ostream&       m_svg;
+    bool                m_fStartStream = true;
     std::stringstream   m_attribs;
     std::stringstream   m_path;
+    bool                m_fPathEmpty = true;
     TransAffine         m_transform;
     const SvgOptions&   m_options;
     double              m_fontSize = 10;

--- a/include/lomse_svg_drawer.h
+++ b/include/lomse_svg_drawer.h
@@ -26,10 +26,8 @@ class LOMSE_EXPORT SvgDrawer : public Drawer
 {
 private:
     std::ostream&       m_svg;
-    bool                m_fStartStream = true;
     std::stringstream   m_attribs;
     std::stringstream   m_path;
-    bool                m_fPathEmpty = true;
     TransAffine         m_transform;
     const SvgOptions&   m_options;
     double              m_fontSize = 10;

--- a/include/private/lomse_internal_model_p.h
+++ b/include/private/lomse_internal_model_p.h
@@ -5980,6 +5980,7 @@ public:
 };
 
 
+#if (LOMSE_ENABLE_THREADS == 1)
 //---------------------------------------------------------------------------------------
 // ImoScorePlayer: A control for managing score playback
 class ImoScorePlayer : public ImoControl
@@ -6015,6 +6016,7 @@ public:
     inline const std::string& get_stop_label() { return m_stopLabel; }
 
 };
+#endif  //LOMSE_ENABLE_THREADS == 1
 
 //---------------------------------------------------------------------------------------
 class ImoSizeDto : public ImoSimpleObj

--- a/lomse_config.h.cmake
+++ b/lomse_config.h.cmake
@@ -79,6 +79,9 @@
 // Enable png format (requires pnglib and zlib)
 #define LOMSE_ENABLE_PNG    @LOMSE_ENABLE_PNG@
 
+// Enable threads (requires pthreads). If not enabled, ScorePlayer will not be included
+#define LOMSE_ENABLE_THREADS    @LOMSE_ENABLE_THREADS@
+
 
 #endif  // __LOMSE_CONFIG_H__
 

--- a/scripts/build-lomse.sh
+++ b/scripts/build-lomse.sh
@@ -93,7 +93,7 @@ function DisplayHelp()
     echo "    -r --remove      Remove dependency. Lomse will not be linked with"
     echo "                     the specified library and the related functionality"
     echo "                     will not be included in Lomse. Valid values are:"
-    echo "                     {zlib | libpng | fontconfig }"
+    echo "                     {zlib | libpng | fontconfig | threads }"
     echo "    -t --only-tests  Do not build. Only run unit tests if enabled."
     echo "    -w --web         Generate test results in local website folder."
     echo "                     If option -w is not specified, the results are"
@@ -114,6 +114,8 @@ function mark_for_removing()
         OPTIONS="${OPTIONS} -DLOMSE_BUILD_TESTS:BOOL=OFF"
     elif [ "$1" == "zlib" ]; then
         OPTIONS="${OPTIONS} -DLOMSE_ENABLE_COMPRESSION:BOOL=OFF"
+    elif [ "$1" == "threads" ]; then
+        OPTIONS="${OPTIONS} -DLOMSE_ENABLE_THREADS:BOOL=OFF"
     else
         display_error "Invalid package name '$1'. Valid values:"
         abort "    { fontconfig | libpng | unittest++ | zlib }"

--- a/scripts/build-lomse.sh
+++ b/scripts/build-lomse.sh
@@ -87,6 +87,7 @@ function DisplayHelp()
     echo "Usage: ./bulid-lomse.sh [option]*"
     echo ""
     echo "Options:"
+    echo "    -c --clang       Compile with CLang. Default: use GCC."
     echo "    -h --help        Print this help text."
     echo "    -n --no-tests    Do not buid unit tests."
     echo "    -r --remove      Remove dependency. Lomse will not be linked with"
@@ -144,6 +145,7 @@ website_pages="${website_root}/content/lenmus/lomse/html/lomse_en"
 fGenerateForWeb=0
 fRunTests=1
 fBuild=1
+fUseClang=0     #use CLang or GCC
 OPTIONS=        #Options for building
 
 
@@ -155,6 +157,9 @@ do
     key="$1"
 
     case $key in
+        -c|--clang)
+        fUseClang=1
+        ;;
         -h|--help)
         DisplayHelp
         exit 1
@@ -216,8 +221,11 @@ if [ ${fBuild} -eq 1 ]; then
     cd "${build_path}"
     echo -e "${GREEN}Creating makefile${NC}"
 #    echo "options='${OPTIONS}'"
-    cmake -G "Unix Makefiles" ${OPTIONS} ${sources} || exit 1
-    #cmake -G "Unix Makefiles" -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER=clang++ ${sources} || exit 1
+    if [ ${fUseClang} -eq 0 ]; then
+        cmake -G "Unix Makefiles" ${OPTIONS} ${sources} || exit 1
+    else
+        cmake -G "Unix Makefiles" -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER=clang++ ${OPTIONS} ${sources} || exit 1
+    fi
 
     # build lomse
     echo -e "${GREEN}Building liblomse. Will use ${num_jobs} jobs.${NC}"

--- a/src/graphic_model/engravers/lomse_engrouters.cpp
+++ b/src/graphic_model/engravers/lomse_engrouters.cpp
@@ -648,8 +648,7 @@ void InlineWrapperEngrouter::add_engrouter_shape(GmoObj* pGmo, GmoBox* pBox)
     }
     else if (pGmo->is_box())
     {
-        GmoBox* pBox = static_cast<GmoBox*>(pGmo);
-        pBox->add_child_box(pBox);
+        pBox->add_child_box( static_cast<GmoBox*>(pGmo) );
     }
 }
 

--- a/src/graphic_model/engravers/lomse_instrument_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_instrument_engraver.cpp
@@ -609,12 +609,6 @@ int InstrumentEngraver::get_num_staves()
 }
 
 //---------------------------------------------------------------------------------------
-LUnits InstrumentEngraver::tenths_to_logical(Tenths value, int iStaff)
-{
-    return (value * m_pInstr->get_staff(iStaff)->get_line_spacing()) / 10.0f;
-}
-
-//---------------------------------------------------------------------------------------
 void InstrumentEngraver::measure_name_and_bracket()
 {
     measure_name_abbrev();

--- a/src/graphic_model/engravers/lomse_instrument_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_instrument_engraver.cpp
@@ -609,6 +609,12 @@ int InstrumentEngraver::get_num_staves()
 }
 
 //---------------------------------------------------------------------------------------
+LUnits InstrumentEngraver::tenths_to_logical(Tenths value, int iStaff)
+{
+    return (value * m_pInstr->get_staff(iStaff)->get_line_spacing()) / 10.0f;
+}
+
+//---------------------------------------------------------------------------------------
 void InstrumentEngraver::measure_name_and_bracket()
 {
     measure_name_abbrev();

--- a/src/graphic_model/layouters/lomse_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_layouter.cpp
@@ -241,7 +241,7 @@ bool LayouterFactory::compute_value_for_add_shapes_flag(ImoContentObj* pItem,
         return false;
 
     //otherwise inherit from parent
-        return fInheritedValue;
+    return fInheritedValue;
 }
 
 

--- a/src/graphic_model/layouters/lomse_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_layouter.cpp
@@ -241,7 +241,7 @@ bool LayouterFactory::compute_value_for_add_shapes_flag(ImoContentObj* pItem,
         return false;
 
     //otherwise inherit from parent
-    return fInheritedValue;
+        return fInheritedValue;
 }
 
 

--- a/src/gui_controls/lomse_score_player_ctrl.cpp
+++ b/src/gui_controls/lomse_score_player_ctrl.cpp
@@ -7,6 +7,8 @@
 // See LICENSE and NOTICE.md files in the root directory of this source tree.
 //---------------------------------------------------------------------------------------
 
+#if (LOMSE_ENABLE_THREADS == 1)
+
 #include "lomse_score_player_ctrl.h"
 
 #include "lomse_score_player.h"
@@ -338,3 +340,5 @@ Metronome* ScorePlayerCtrl::get_metronome()
 
 
 }   //namespace lomse
+
+#endif  //LOMSE_ENABLE_THREADS == 1

--- a/src/gui_controls/lomse_score_player_ctrl.cpp
+++ b/src/gui_controls/lomse_score_player_ctrl.cpp
@@ -7,6 +7,7 @@
 // See LICENSE and NOTICE.md files in the root directory of this source tree.
 //---------------------------------------------------------------------------------------
 
+#include "lomse_config.h"
 #if (LOMSE_ENABLE_THREADS == 1)
 
 #include "lomse_score_player_ctrl.h"

--- a/src/internal_model/lomse_im_factory.cpp
+++ b/src/internal_model/lomse_im_factory.cpp
@@ -98,7 +98,9 @@ ImoObj* ImFactory::inject(int type, Document* pDoc, ImoId id)
         case k_imo_rest:                pObj = LOMSE_NEW ImoRest();               break;
         case k_imo_score:               pObj = LOMSE_NEW ImoScore(pDoc);          break;
         case k_imo_score_line:          pObj = LOMSE_NEW ImoScoreLine();          break;
+#if (LOMSE_ENABLE_THREADS == 1)
         case k_imo_score_player:        pObj = LOMSE_NEW ImoScorePlayer();        break;
+#endif
         case k_imo_score_text:          pObj = LOMSE_NEW ImoScoreText();          break;
         case k_imo_score_title:         pObj = LOMSE_NEW ImoScoreTitle();         break;
         case k_imo_slur:                pObj = LOMSE_NEW ImoSlur();               break;

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -5223,10 +5223,12 @@ void ImoStyles::accept_visitor(BaseVisitor& v)
 
     vObj = dynamic_cast<Visitor<ImoObj>*>(&v);
     if (vObj)
+    {
         vObj->start_visit(this);
+    }
 
     //visit_children
-	map<std::string, ImoStyle*>::iterator it;
+    map<std::string, ImoStyle*>::iterator it;
     for(it = m_nameToStyle.begin(); it != m_nameToStyle.end(); ++it)
         (it->second)->accept_visitor(v);
 

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -5222,10 +5222,12 @@ void ImoStyles::accept_visitor(BaseVisitor& v)
 
     vObj = dynamic_cast<Visitor<ImoObj>*>(&v);
     if (vObj)
+    {
         vObj->start_visit(this);
+    }
 
     //visit_children
-	map<std::string, ImoStyle*>::iterator it;
+    map<std::string, ImoStyle*>::iterator it;
     for(it = m_nameToStyle.begin(); it != m_nameToStyle.end(); ++it)
         (it->second)->accept_visitor(v);
 

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -4269,7 +4269,7 @@ void ImoScore::end_of_changes()
 //}
 
 
-
+#if (LOMSE_ENABLE_THREADS == 1)
 //=======================================================================================
 // ImoScorePlayer implementation
 //=======================================================================================
@@ -4317,6 +4317,7 @@ int ImoScorePlayer::get_metronome_mm()
     else
         return 60;
 }
+#endif  //LOMSE_ENABLE_THREADS == 1
 
 
 //=======================================================================================
@@ -5222,12 +5223,10 @@ void ImoStyles::accept_visitor(BaseVisitor& v)
 
     vObj = dynamic_cast<Visitor<ImoObj>*>(&v);
     if (vObj)
-    {
         vObj->start_visit(this);
-    }
 
     //visit_children
-    map<std::string, ImoStyle*>::iterator it;
+	map<std::string, ImoStyle*>::iterator it;
     for(it = m_nameToStyle.begin(); it != m_nameToStyle.end(); ++it)
         (it->second)->accept_visitor(v);
 

--- a/src/module/lomse_doorway.cpp
+++ b/src/module/lomse_doorway.cpp
@@ -130,7 +130,6 @@ void LomseDoorway::init_library(int pixel_format, int ppi, bool reverse_y_axis,
 
     delete m_pLibraryScope;
     m_pLibraryScope = LOMSE_NEW LibraryScope(reporter, this);
-//    m_pLibraryScope->get_threads_poll();        //force to create the threads
 }
 
 //---------------------------------------------------------------------------------------
@@ -141,7 +140,6 @@ void LomseDoorway::init_library(int pixel_format, int ppi, ostream& reporter)
 
     delete m_pLibraryScope;
     m_pLibraryScope = LOMSE_NEW LibraryScope(reporter, this);
-//    m_pLibraryScope->get_threads_poll();        //force to create the threads
 }
 
 //---------------------------------------------------------------------------------------
@@ -216,11 +214,13 @@ string LomseDoorway::get_build_date()
     return m_pLibraryScope->get_build_date();
 }
 
+#if (LOMSE_ENABLE_THREADS == 1)
 //---------------------------------------------------------------------------------------
 ScorePlayer* LomseDoorway::create_score_player(MidiServerBase* pSoundServer)
 {
     return Injector::inject_ScorePlayer(*m_pLibraryScope, pSoundServer);
 }
+#endif
 
 //---------------------------------------------------------------------------------------
 void LomseDoorway::set_global_metronome_and_replace_local(Metronome* pMtr)

--- a/src/module/lomse_injectors.cpp
+++ b/src/module/lomse_injectors.cpp
@@ -33,7 +33,6 @@
 #include "lomse_bitmap_drawer.h"
 #include "lomse_tasks.h"
 #include "lomse_events.h"
-#include "lomse_score_player.h"
 #include "lomse_metronome.h"
 #include "lomse_id_assigner.h"
 #include "lomse_document_cursor.h"
@@ -41,6 +40,10 @@
 #include "lomse_caret_positioner.h"
 #include "lomse_glyphs.h"
 #include "lomse_engraving_options.h"
+
+#if (LOMSE_ENABLE_THREADS == 1)
+    #include "lomse_score_player.h"
+#endif
 
 #include <sstream>
 using namespace std;
@@ -422,11 +425,13 @@ Task* Injector::inject_Task(int taskType, Interactor* pIntor)
 }
 
 //---------------------------------------------------------------------------------------
+#if (LOMSE_ENABLE_THREADS == 1)
 ScorePlayer* Injector::inject_ScorePlayer(LibraryScope& libraryScope,
                                           MidiServerBase* pSoundServer)
 {
     return LOMSE_NEW ScorePlayer(libraryScope, pSoundServer);
 }
+#endif
 
 //---------------------------------------------------------------------------------------
 DocCursor* Injector::inject_DocCursor(Document* pDoc)

--- a/src/parser/ldp/lomse_ldp_analyser.cpp
+++ b/src/parser/ldp/lomse_ldp_analyser.cpp
@@ -4822,6 +4822,7 @@ public:
 
     void do_analysis() override
     {
+#if (LOMSE_ENABLE_THREADS == 1)
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoScorePlayer* pSP = static_cast<ImoScorePlayer*>(
                     ImFactory::inject(k_imo_score_player, pDoc, get_node_id()) );
@@ -4858,6 +4859,8 @@ public:
         }
 
         add_to_model(pSP);
+
+#endif  //LOMSE_ENABLE_THREADS == 1
     }
 };
 

--- a/src/parser/lmd/lomse_lmd_analyser.cpp
+++ b/src/parser/lmd/lomse_lmd_analyser.cpp
@@ -4232,6 +4232,7 @@ public:
 
     ImoObj* do_analysis() override
     {
+#if (LOMSE_ENABLE_THREADS == 1)
         Document* pDoc = m_pAnalyser->get_document_being_analysed();
         ImoScorePlayer* pSP = static_cast<ImoScorePlayer*>(
                         ImFactory::inject(k_imo_score_player, pDoc, get_node_id()) );
@@ -4259,6 +4260,9 @@ public:
 
         add_to_model(pSP);
         return pSP;
+#else
+        return nullptr;
+#endif
     }
 };
 

--- a/src/render/lomse_font_freetype.cpp
+++ b/src/render/lomse_font_freetype.cpp
@@ -117,10 +117,9 @@ static unsigned calc_crc32(const unsigned char* buf, unsigned size)
 {
     unsigned crc = (unsigned)~0;
     const unsigned char* p;
-    unsigned len = 0;
     unsigned nr = size;
 
-    for (len += nr, p = buf; nr--; ++p)
+    for (p = buf; nr--; ++p)
     {
         crc = (crc >> 8) ^ crc32tab[(crc ^ *p) & 0xff];
     }

--- a/src/render/lomse_font_freetype.cpp
+++ b/src/render/lomse_font_freetype.cpp
@@ -117,9 +117,10 @@ static unsigned calc_crc32(const unsigned char* buf, unsigned size)
 {
     unsigned crc = (unsigned)~0;
     const unsigned char* p;
+    unsigned len = 0;
     unsigned nr = size;
 
-    for (p = buf; nr--; ++p)
+    for (len += nr, p = buf; nr--; ++p)
     {
         crc = (crc >> 8) ^ crc32tab[(crc ^ *p) & 0xff];
     }

--- a/src/sound/lomse_score_player.cpp
+++ b/src/sound/lomse_score_player.cpp
@@ -7,6 +7,7 @@
 // See LICENSE and NOTICE.md files in the root directory of this source tree.
 //---------------------------------------------------------------------------------------
 
+#include "lomse_config.h"
 #if (LOMSE_ENABLE_THREADS == 1)
 
 #define LOMSE_INTERNAL_API

--- a/src/sound/lomse_score_player.cpp
+++ b/src/sound/lomse_score_player.cpp
@@ -7,6 +7,8 @@
 // See LICENSE and NOTICE.md files in the root directory of this source tree.
 //---------------------------------------------------------------------------------------
 
+#if (LOMSE_ENABLE_THREADS == 1)
+
 #define LOMSE_INTERNAL_API
 #include "lomse_score_player.h"
 
@@ -993,3 +995,4 @@ void ScorePlayer::set_new_beat_information(SoundEvent* pEvent)
 
 }   //namespace lomse
 
+#endif   //LOMSE_ENABLE_THREADS == 1

--- a/src/tests/lomse_test_ldp_analyser.cpp
+++ b/src/tests/lomse_test_ldp_analyser.cpp
@@ -10887,6 +10887,7 @@ SUITE(LdpAnalyserTest)
 #endif
 
     // scorePlayer ----------------------------------------------------------------------
+#if (LOMSE_ENABLE_THREADS == 1)
 
     TEST_FIXTURE(LdpAnalyserTestFixture, scorePlayer_Creation)
     {
@@ -10983,6 +10984,7 @@ SUITE(LdpAnalyserTest)
             //cout << "metronome mm = " << pSP->get_metronome_mm() << endl;
         }
     }
+#endif  //LOMSE_ENABLE_THREADS == 1
 
     // tableCell ------------------------------------------------------------------------
 

--- a/src/tests/lomse_test_lmd_analyser.cpp
+++ b/src/tests/lomse_test_lmd_analyser.cpp
@@ -1768,6 +1768,7 @@ SUITE(LmdAnalyserTest)
 //    // graphic line  --------------------------------------------------------------------
 
     //@ scorePlayer ---------------------------------------------------------------------
+#if (LOMSE_ENABLE_THREADS == 1)
 
     TEST_FIXTURE(LmdAnalyserTestFixture, scorePlayer_Creation)
     {
@@ -1881,6 +1882,7 @@ SUITE(LmdAnalyserTest)
 
         if (pRoot && !pRoot->is_document()) delete pRoot;
     }
+#endif  //LOMSE_ENABLE_THREADS == 1
 
     //@ tableCell -----------------------------------------------------------------------
 

--- a/src/tests/lomse_test_score_player.cpp
+++ b/src/tests/lomse_test_score_player.cpp
@@ -7,6 +7,8 @@
 // See LICENSE and NOTICE.md files in the root directory of this source tree.
 //---------------------------------------------------------------------------------------
 
+#if (LOMSE_ENABLE_THREADS == 1)
+
 #define LOMSE_INTERNAL_API
 #include <UnitTest++.h>
 #include <sstream>
@@ -474,3 +476,5 @@ SUITE(ScorePlayerTest)
     }
 
 }
+
+#endif  //LOMSE_ENABLE_THREADS == 1

--- a/src/tests/lomse_test_score_player.cpp
+++ b/src/tests/lomse_test_score_player.cpp
@@ -7,6 +7,7 @@
 // See LICENSE and NOTICE.md files in the root directory of this source tree.
 //---------------------------------------------------------------------------------------
 
+#include "lomse_config.h"
 #if (LOMSE_ENABLE_THREADS == 1)
 
 #define LOMSE_INTERNAL_API


### PR DESCRIPTION
This PR adds additional options for building:

- Option `LOMSE_USING_EMSCRIPTEN` (Default: `OFF`) is oriented to build JavaScript bindings using the `Emscripten SDK`. This new option is used to inform cmake script that it is being run with Emscripten tools. When setting this, all other settings, such as `LOMSE_BUILD_SHARED_LIB`, `LOMSE_BUILD_TESTS`, `LOMSE_ENABLE_COMPRESSION`, etc. are ignored and the cmake script will instead use the pre-defined settings required for JavaScript bindings.

- Option `LOMSE_ENABLE_FONTCONFIG` (Default value: `ON`) is only meaningful for Linux systems and is used to control the dependency from the ‘fontconfig’ library. By setting this to `OFF` the dependency from 'fontconfig' is removed and Lomse will use only the fonts available in the path provided by the user application at Lomse initialization, instead of using system installed fonts.

- Option `LOMSE_ENABLE_THREADS` (Default value: `ON`) allows to control whether Lomse will use threads or not, and can be used to remove the dependency from the 'threads' library. Lomse uses threads for the `ScorePlayer` class, also used by `ScorePlayerCtrl` class. If your application will not use `ScorePlayer`, you can reduce lomse size and avoid the `pthreads` dependency by disabling the use of threads.
