### PR TITLE
Interactor: API method to get info about mouse click point

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -775,7 +775,7 @@ set( TESTLIB_FONTS_PATH      "\"${LOMSE_ROOT_DIR}/fonts/\"" )
 
 # path to fonts (will be hardcoded in lomse library, so *MUST* be the
 # path in which Lomse standard fonts will be installed)
-set( LOMSE_FONTS_PATH   "\"${BRAVURA_FONT_PATH}\"" )
+set( LOMSE_FONTS_PATH   "\"${BRAVURA_FONT_PATH}/\"" )
 
 
 #define a header file to pass CMake settings to source code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,16 +449,6 @@ else()
 endif()
 
 
-# other variables needed by lomse_config.h
-
-# paths for tests
-set( TESTLIB_SCORES_PATH     "\"${LOMSE_ROOT_DIR}/test-scores/\"" )
-set( TESTLIB_FONTS_PATH      "\"${LOMSE_ROOT_DIR}/fonts/\"" )
-
-# path to fonts (will be hardcoded in lomse library, so *MUST* be the
-# path in which Lomse standard fonts will be installed)
-set( LOMSE_FONTS_PATH   "\"${FONTS_PATH}/\"" )
-
 
 
 # Build environtment checks and settings
@@ -776,6 +766,16 @@ if (LOMSE_BUILD_MONOLITHIC)
     set(LOMSE_DEBIAN_DEPS "")
 endif()
 
+
+# set other variables needed by lomse_config.h
+
+# paths for tests
+set( TESTLIB_SCORES_PATH     "\"${LOMSE_ROOT_DIR}/test-scores/\"" )
+set( TESTLIB_FONTS_PATH      "\"${LOMSE_ROOT_DIR}/fonts/\"" )
+
+# path to fonts (will be hardcoded in lomse library, so *MUST* be the
+# path in which Lomse standard fonts will be installed)
+set( LOMSE_FONTS_PATH   "\"${BRAVURA_FONT_PATH}\"" )
 
 
 #define a header file to pass CMake settings to source code

--- a/add-group-folders.cmake
+++ b/add-group-folders.cmake
@@ -19,7 +19,6 @@ source_group( "${LOMSE_GROUP_FOLDER}mvc"             FILES ${MVC_FILES} )
 source_group( "${LOMSE_GROUP_FOLDER}parser"          FILES ${PARSER_FILES} )
 source_group( "${LOMSE_GROUP_FOLDER}parser/lmd"      FILES ${LMD_FILES} )
 source_group( "${LOMSE_GROUP_FOLDER}render"          FILES ${RENDER_FILES} )
-source_group( "${LOMSE_GROUP_FOLDER}score"           FILES ${SCORE_FILES} )
 source_group( "${LOMSE_GROUP_FOLDER}sound"           FILES ${SOUND_FILES} )
 source_group( "${LOMSE_GROUP_FOLDER}packages"        FILES ${LOMSE_PACKAGES_FILES} )
 

--- a/include/lomse_basic.h
+++ b/include/lomse_basic.h
@@ -327,7 +327,7 @@ typedef double TimeUnits;           //time units (TU). Relative, depends on metr
     to which the measure number refers.
 
     The first measure (anacruxis or not) is always measure 0.
-    The firts instrument is always instrument 0.
+    The first instrument is always instrument 0.
 */
 struct MeasureLocator
 {
@@ -335,8 +335,10 @@ struct MeasureLocator
     int iMeasure;           ///measure number (0..m), for the instrument
     TimeUnits location;     ///TimeUnits from start of measure
 
-    MeasureLocator() : iInstr(0), iMeasure(0), location(0.0) {}
+    MeasureLocator() : iInstr(-1), iMeasure(-1), location(0.0) {}
     MeasureLocator(int i, int m, TimeUnits l) : iInstr(i), iMeasure(m), location(l) {}
+
+    bool is_valid() const { return iInstr >=0 && iMeasure >= 0; }
 
 };
 
@@ -347,19 +349,23 @@ class ImoObj;
 /** Struct that describes the content of a point on current bitmap rendition
     (e.g. a mouse click)
 
-    The struct provides a ptr. to the clicked object, and if the clicked point is on
-    a score, it also provides:
+    The struct provides a ptr. to the clicked object. In addition, if the clicked point
+    is on a score, it also provides:
     - A MeasureLocator struct with information about measure, instrument, and time
       position.
     - The staff index, relative to instrument staves.
+
+    Otherwise, if clicked point is not on a score, the MeasureLocator is invalid
+    and the staff index is -1.
+
 */
 struct ClickPointData
 {
     ImoObj* pImo;           //clicked object or nullptr if out of document
-    MeasureLocator ml;      //locator when clicked point is on a score; otherwise locator to 0
-    int iStaff;             //staff index, relative to instrument, or 0 when clicked point is not on a score
+    MeasureLocator ml;      //locator when clicked point is on a score; otherwise invalid locator
+    int iStaff;             //staff index, relative to instrument, or -1 when clicked point is not on a score
 
-    ClickPointData() : pImo(nullptr), ml(), iStaff(0) {}
+    ClickPointData() : pImo(nullptr), ml(-1, -1, 0.0), iStaff(-1) {}
 
 };
 

--- a/include/lomse_basic.h
+++ b/include/lomse_basic.h
@@ -16,7 +16,6 @@
 #include <vector>
 #include <memory>
 #include <algorithm>   //min
-using namespace std;
 
 
 
@@ -53,6 +52,7 @@ using namespace std;
 #endif
 
 
+///@cond INTERNALS
 namespace lomse
 {
 
@@ -214,10 +214,10 @@ struct Rectangle
         }
         else if ( rect.width && rect.height )
         {
-            T x1 = min(x, rect.x);
-            T y1 = min(y, rect.y);
-            T y2 = max(y + height, rect.height + rect.y);
-            T x2 = max(x + width, rect.width + rect.x);
+            T x1 = std::min(x, rect.x);
+            T y1 = std::min(y, rect.y);
+            T y2 = std::max(y + height, rect.height + rect.y);
+            T x2 = std::max(x + width, rect.width + rect.x);
 
             x = x1;
             y = y1;
@@ -305,24 +305,66 @@ typedef int_least32_t ImoId;        //identifier for ImoObj objects
 const ImoId k_no_imoid = -1;        //value for undefined imo id (MUST BE -1. See Cursor)
 
 typedef std::pair<ImoId, ImoId> GmoRef;        //identifier for GmoObj objects
-const GmoRef k_no_gmo_ref = make_pair(-1, -1);
+const GmoRef k_no_gmo_ref = std::make_pair(-1, -1);
 
 typedef double TimeUnits;           //time units (TU). Relative, depends on metronome speed
 
+///@endcond
 
-//---------------------------------------------------------------------------------------
-// For describing the measure location of a musical event or other.
+//=======================================================================================
+/** Struct describing the measure location of a musical event or other.
+
+    There are a variety of situations in which the position of an object needs to be
+    described not by its absolute timepos but referencing the measure number.
+
+    But although for most common scores just providing the measure number does the job,
+    it is necessary to take into account that for polymetric music (music in which not
+    all instruments have the same time signature), the measure number is not an absolute
+    value, common to all score instruments (score parts), but it is relative to
+    each instrument.
+
+    Due to this, the measure location struct also needs a reference to the instrument
+    to which the measure number refers.
+
+    The first measure (anacruxis or not) is always measure 0.
+    The firts instrument is always instrument 0.
+*/
 struct MeasureLocator
 {
-    int iInstr;             //instrument number (0..n)
-    int iMeasure;           //measure number (0..m), for the instrument
-    TimeUnits location;     //TimeUnits from start of measure
+    int iInstr;             ///instrument number (0..n)
+    int iMeasure;           ///measure number (0..m), for the instrument
+    TimeUnits location;     ///TimeUnits from start of measure
 
     MeasureLocator() : iInstr(0), iMeasure(0), location(0.0) {}
     MeasureLocator(int i, int m, TimeUnits l) : iInstr(i), iMeasure(m), location(l) {}
 
 };
 
+//forward declarations
+class ImoObj;
+
+//=======================================================================================
+/** Struct that describes the content of a point on current bitmap rendition
+    (e.g. a mouse click)
+
+    The struct provides a ptr. to the clicked object, and if the clicked point is on
+    a score, it also provides:
+    - A MeasureLocator struct with information about measure, instrument, and time
+      position.
+    - The staff index, relative to instrument staves.
+*/
+struct ClickPointData
+{
+    ImoObj* pImo;           //clicked object or nullptr if out of document
+    MeasureLocator ml;      //locator when clicked point is on a score; otherwise locator to 0
+    int iStaff;             //staff index, relative to instrument, or 0 when clicked point is not on a score
+
+    ClickPointData() : pImo(nullptr), ml(), iStaff(0) {}
+
+};
+
+
+///@cond INTERNALS
 
 //---------------------------------------------------------------------------------------
 // Logical Units comparison (LUnits, Tenths)
@@ -443,6 +485,7 @@ inline bool is_different(Color c1, Color c2) {
 
 
 
+///@endcond
 
 
 }   //namespace lomse

--- a/include/lomse_box_slice.h
+++ b/include/lomse_box_slice.h
@@ -36,6 +36,7 @@ public:
     ~GmoBoxSlice();
 
     GmoBoxSliceInstr* add_box_for_instrument(ImoInstrument* pInstr, int idxStaff);
+    GmoBoxSliceInstr* find_instr_slice_at(LUnits x, LUnits y);
     GmoBoxSystem* get_system_box();
     GmoBoxSliceInstr* get_instr_slice(int iInstr);
 

--- a/include/lomse_box_slice_instr.h
+++ b/include/lomse_box_slice_instr.h
@@ -37,6 +37,7 @@ public:
     GmoBoxSystem* get_system_box();
 
     void add_shape(GmoShape* pShape, int layer, int iStaff);
+    GmoShape* find_staffobj_shape_before(LUnits x);
 
     //helpers for layout
     /**  Move boxes and shapes to theirs final 'y' positions. */
@@ -65,6 +66,8 @@ private:
 public:
     GmoBoxSliceStaff(ImoInstrument* pInstr, int idxStaff);
     ~GmoBoxSliceStaff();
+
+    GmoShape* find_staffobj_shape_before(LUnits x);
 
     //helpers for layout
     /**  Move shapes to theirs final 'y' positions and increment barlines height. */

--- a/include/lomse_box_slice_instr.h
+++ b/include/lomse_box_slice_instr.h
@@ -38,6 +38,7 @@ public:
 
     void add_shape(GmoShape* pShape, int layer, int iStaff);
     GmoShape* find_staffobj_shape_before(LUnits x);
+    GmoShape* find_staffobj_shape_after(LUnits x);
 
     //helpers for layout
     /**  Move boxes and shapes to theirs final 'y' positions. */
@@ -68,6 +69,7 @@ public:
     ~GmoBoxSliceStaff();
 
     GmoShape* find_staffobj_shape_before(LUnits x);
+    GmoShape* find_staffobj_shape_after(LUnits x);
 
     //helpers for layout
     /**  Move shapes to theirs final 'y' positions and increment barlines height. */

--- a/include/lomse_box_system.h
+++ b/include/lomse_box_system.h
@@ -69,6 +69,7 @@ public:
 	inline int get_num_slices() const { return (int)m_childBoxes.size(); }
     inline GmoBoxSlice* get_slice(int i) const { return (GmoBoxSlice*)m_childBoxes[i]; }
     GmoBoxSliceInstr* get_first_instr_slice(int iInstr);
+    GmoBoxSliceInstr* find_instr_slice_at(LUnits x, LUnits y);
     GmoBoxSliceStaff* get_first_slice_staff_for(int iInstr, int iStaff);
     void reposition_slices(USize shift);
     void remove_free_space_at_bottom_and_adjust_slices();
@@ -112,7 +113,7 @@ public:
     inline vector<GmoShapeStaff*>& get_staff_shapes() { return m_staffShapes; }
 
     //hit tests related
-    int nearest_staff_to_point(LUnits y);
+    int staff_at(LUnits y);
 
     //helper. User API related
     int get_num_instruments();

--- a/include/lomse_gm_measures_table.h
+++ b/include/lomse_gm_measures_table.h
@@ -29,10 +29,10 @@ class GmoBoxSystem;
 class GmMeasuresTable
 {
 protected:
-    typedef vector<GmoShapeBarline*> BarlinesVector;    //barlines for one instrument
+    typedef std::vector<GmoShapeBarline*> BarlinesVector;    //barlines for one instrument
 
-    vector<BarlinesVector*> m_instrument;       //pointers to each instrument barlines
-    vector<int> m_numBarlines;                  //num.added barlines in each instrument
+    std::vector<BarlinesVector*> m_instrument;       //pointers to each instrument barlines
+    std::vector<int> m_numBarlines;                  //num.added barlines in each instrument
 
 public:
     GmMeasuresTable(ImoScore* pScore);

--- a/include/lomse_graphical_model.h
+++ b/include/lomse_graphical_model.h
@@ -190,17 +190,21 @@ protected:
 };
 
 //---------------------------------------------------------------------------------------
-// Algorithms for finding info in the graphical model
+/** Algorithms for finding info in the graphical model
+*/
 class GModelAlgorithms
 {
 protected:
 
 public:
     GModelAlgorithms() {}
-    ~GModelAlgorithms() {}
 
     ///mouse point is over inner box pGmo. Find box system
     static GmoBoxSystem* get_box_system_for(GmoObj* pGmo, LUnits y);
+
+    ///Get info about a clicked point
+    static ClickPointData find_info_for_point(LUnits x, LUnits y, GmoObj* pGmo);
+
 
 };
 

--- a/include/lomse_interactor.h
+++ b/include/lomse_interactor.h
@@ -320,6 +320,22 @@ public:
     //@}    //operating modes
 
 
+    //information about mouse clicked point
+    /** @name Information about mouse clicked point    */
+    //@{
+
+    /** Returns a ClickedDataInfo struct with information about object at x,y position
+        on current bitmap rendition.
+        @param x  The x coorditane (pixels) of the point.
+        @param y  The y coorditane (pixels) of the point.
+    */
+    ClickPointData find_click_info_at(Pixels x, Pixels y);
+
+    //@}    //access to collaborators
+
+
+
+
     //access to collaborators
     /** @name Access to collaborators in MVC model    */
     //@{

--- a/include/lomse_interactor.h
+++ b/include/lomse_interactor.h
@@ -326,8 +326,8 @@ public:
 
     /** Returns a ClickedDataInfo struct with information about object at x,y position
         on current bitmap rendition.
-        @param x  The x coorditane (pixels) of the point.
-        @param y  The y coorditane (pixels) of the point.
+        @param x  The x coordinate (pixels) of the point.
+        @param y  The y coordinate (pixels) of the point.
     */
     ClickPointData find_click_info_at(Pixels x, Pixels y);
 

--- a/include/lomse_time.h
+++ b/include/lomse_time.h
@@ -32,7 +32,8 @@ extern bool is_greater_time(TimeUnits t1, TimeUnits t2);
 
 TimeUnits round_half_up(TimeUnits num);
 
-string to_simple_string(chrono::time_point<chrono::system_clock> time, bool microsec = false);
+std::string to_simple_string(std::chrono::time_point<std::chrono::system_clock> time,
+                             bool microsec = false);
 
 }   //namespace lomse
 

--- a/include/lomse_timegrid_table.h
+++ b/include/lomse_timegrid_table.h
@@ -54,15 +54,13 @@ TimeGridTableEntry;
 class TimeGridTable
 {
 protected:
-    vector<TimeGridTableEntry> m_PosTimes;         //the table
+    std::vector<TimeGridTableEntry> m_PosTimes;         //the table
 
 public:
     TimeGridTable();
-    ///Destructor
-    ~TimeGridTable();
 
     //creation
-    void add_entries(vector<TimeGridTableEntry>& entries);
+    void add_entries(std::vector<TimeGridTableEntry>& entries);
     void add_entry(TimeGridTableEntry& entry);
 
     //info
@@ -75,7 +73,7 @@ public:
     inline TimeUnits get_duration(int iItem) { return m_PosTimes[iItem].rDuration; }
     inline LUnits get_x_pos(int iItem) { return m_PosTimes[iItem].uxPos; }
     inline TimeGridTableEntry& get_entry(int iItem) { return m_PosTimes[iItem]; }
-    inline vector<TimeGridTableEntry>& get_entries() { return m_PosTimes; }
+    inline std::vector<TimeGridTableEntry>& get_entries() { return m_PosTimes; }
 
     //access by position
     TimeUnits get_time_for_position(LUnits uxPos);
@@ -102,7 +100,7 @@ public:
     LUnits get_x_for_barline_at_time(TimeUnits timepos);
 
     //debug
-    string dump();
+    std::string dump();
 
 protected:
 

--- a/include/lomse_vertical_profile.h
+++ b/include/lomse_vertical_profile.h
@@ -42,7 +42,7 @@ public:
 };
 
 //to simplify writing code
-typedef list<VProfilePoint>::iterator  PointsIterator;
+typedef std::list<VProfilePoint>::iterator  PointsIterator;
 
 //---------------------------------------------------------------------------------------
 /**	VerticalProfile is responsible for maintaining and managing the information about
@@ -108,7 +108,7 @@ public:
     std::string dump_min(int idxStaff);
 
 protected:
-    void update_profile(list<VProfilePoint>* pPoints, LUnits yPos, bool fMax,
+    void update_profile(std::list<VProfilePoint>* pPoints, LUnits yPos, bool fMax,
                         LUnits xLeft, LUnits xRight, GmoShape* pShape);
     PointsIterator locate_insertion_point(std::list<VProfilePoint>* pPoints, LUnits xLeft);
     void update_point(std::list<VProfilePoint>* pPointsMin, LUnits xPos,
@@ -119,7 +119,7 @@ protected:
 
     //debug
     GmoShape* dbg_generate_shape(bool fMax, int idxStaff);
-    std::string dump(list<VProfilePoint>* pPoints);
+    std::string dump(std::list<VProfilePoint>* pPoints);
 
 };
 

--- a/include/private/lomse_internal_model_p.h
+++ b/include/private/lomse_internal_model_p.h
@@ -2987,6 +2987,7 @@ public:
     ImoAuxObj(ImoAuxObj&&) = delete;
     ImoAuxObj& operator= (ImoAuxObj&&) = delete;
 
+    ImoStaffObj* get_parent_staffobj();
 };
 
 //---------------------------------------------------------------------------------------

--- a/src/file_system/lomse_image_reader.cpp
+++ b/src/file_system/lomse_image_reader.cpp
@@ -167,12 +167,12 @@ SpImage PngImageDecoder::decode_file(InputStream* file)
     if (!pInfoStruct)
     {
         pImage->set_error_msg("[PngImageDecoder::decode_file] out of memory creating info struct");
-        png_destroy_read_struct(&pReadStruct, 0, 0);
+        png_destroy_read_struct(&pReadStruct, nullptr, nullptr);
         return SpImage(pImage );
     }
 
 
-    png_set_error_fn(pReadStruct, 0, error_callback, warning_callback);
+    png_set_error_fn(pReadStruct, nullptr, error_callback, warning_callback);
 
 
     png_uint_32 width, height;
@@ -263,7 +263,7 @@ SpImage PngImageDecoder::decode_file(InputStream* file)
     pImage = LOMSE_NEW Image(imgbuf, bmpSize, format, imgSize);
 
     //delete helper structs
-    png_destroy_read_struct(&pReadStruct, &pInfoStruct, 0);
+    png_destroy_read_struct(&pReadStruct, &pInfoStruct, nullptr);
 
     //done!
     return SpImage(pImage);

--- a/src/graphic_model/engravers/lomse_beam_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_beam_engraver.cpp
@@ -1769,41 +1769,41 @@ void BeamEngraver::position_segments(std::vector<SegmentData>* pSegs)
     //create secondary beam segments
     for (size_t i = 1; i < pSegs->size(); ++i)
     {
-        SegmentData& sg = pSegs->at(i);
+        SegmentData& sgd = pSegs->at(i);
 
-        LUnits yShift = sg.iLevel * uBeamSpacing;
-        if (sg.position == k_beam_above)
+        LUnits yShift = sgd.iLevel * uBeamSpacing;
+        if (sgd.position == k_beam_above)
             yShift = - yShift;
 
-        LUnits yStart = sg.yStart + yShift;
-        LUnits yEnd = sg.yEnd + yShift;
-        add_segment(sg.xStart, yStart, sg.xEnd, yEnd);
+        LUnits yStart = sgd.yStart + yShift;
+        LUnits yEnd = sgd.yEnd + yShift;
+        add_segment(sgd.xStart, yStart, sgd.xEnd, yEnd);
 
         //increment stem lenght of start note
-        if (sg.pStartNote)
+        if (sgd.pStartNote)
         {
-            if  (sg.position == k_beam_above)
+            if  (sgd.position == k_beam_above)
             {
-                if (sg.pStartNote->is_up())
-                    sg.pStartNote->increment_stem_length(-yShift);
+                if (sgd.pStartNote->is_up())
+                    sgd.pStartNote->increment_stem_length(-yShift);
             }
             else
             {
-                if (!sg.pStartNote->is_up())
-                    sg.pStartNote->increment_stem_length(yShift);
+                if (!sgd.pStartNote->is_up())
+                    sgd.pStartNote->increment_stem_length(yShift);
             }
         }
 
         //increment stem lenght of end note
-        if  (sg.position == k_beam_above)
+        if  (sgd.position == k_beam_above)
         {
-            if (sg.pEndNote->is_up())
-                sg.pEndNote->increment_stem_length(-yShift);
+            if (sgd.pEndNote->is_up())
+                sgd.pEndNote->increment_stem_length(-yShift);
         }
         else
         {
-            if (!sg.pEndNote->is_up())
-                sg.pEndNote->increment_stem_length(yShift);
+            if (!sgd.pEndNote->is_up())
+                sgd.pEndNote->increment_stem_length(yShift);
         }
     }
 

--- a/src/graphic_model/engravers/lomse_chord_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_chord_engraver.cpp
@@ -473,8 +473,8 @@ void ChordEngraver::layout_accidentals()
                 if (itCur != m_notes.rbegin())
                 {
                     --itCur;
-                    GmoShapeNotehead* pHead = (*itCur)->pNoteShape->get_notehead_shape();
-                    shift_acc_if_confict_with_shape(pCurAcc, pHead);
+                    GmoShapeNotehead* head = (*itCur)->pNoteShape->get_notehead_shape();
+                    shift_acc_if_confict_with_shape(pCurAcc, head);
                 }
             }
 

--- a/src/graphic_model/lomse_box_slice.cpp
+++ b/src/graphic_model/lomse_box_slice.cpp
@@ -84,6 +84,20 @@ GmoBoxSliceInstr* GmoBoxSlice::get_instr_slice(int iInstr)
 }
 
 //---------------------------------------------------------------------------------------
+GmoBoxSliceInstr* GmoBoxSlice::find_instr_slice_at(LUnits x, LUnits y)
+{
+    vector<GmoBox*>::iterator it;
+    for (it=m_childBoxes.begin(); it != m_childBoxes.end(); ++it)
+    {
+        GmoBoxSliceInstr* pISlice = static_cast<GmoBoxSliceInstr*>(*it);
+        URect bbox = pISlice->get_bounds();
+        if (bbox.contains(x, y))
+            return pISlice;
+    }
+    return nullptr;
+}
+
+//---------------------------------------------------------------------------------------
 GmoBoxSliceStaff* GmoBoxSlice::get_slice_staff_for(int iInstr, int iStaff)
 {
     GmoBoxSliceInstr* pSlice = static_cast<GmoBoxSliceInstr*>(m_childBoxes[iInstr]);

--- a/src/graphic_model/lomse_box_slice_instr.cpp
+++ b/src/graphic_model/lomse_box_slice_instr.cpp
@@ -56,6 +56,26 @@ void GmoBoxSliceInstr::add_shape(GmoShape* pShape, int layer, int iStaff)
 }
 
 //---------------------------------------------------------------------------------------
+GmoShape* GmoBoxSliceInstr::find_staffobj_shape_before(LUnits x)
+{
+    vector<GmoBox*>::iterator it;
+    GmoShape* pShape = nullptr;
+    for (it=m_childBoxes.begin(); it != m_childBoxes.end(); ++it)
+    {
+        GmoBoxSliceStaff* pSlice = static_cast<GmoBoxSliceStaff*>(*it);
+        GmoShape* pS = pSlice->find_staffobj_shape_before(x);
+        if (pS)
+        {
+            if (!pShape)
+                pShape = pS;
+            else if (pShape->get_right() < pS->get_right())
+                pShape = pS;
+        }
+    }
+    return pShape;
+}
+
+//---------------------------------------------------------------------------------------
 void GmoBoxSliceInstr::reposition_slices_and_shapes(const vector<LUnits>& yOrgShifts,
                                                     const vector<LUnits>& heights,
                                                     LUnits barlinesHeight,
@@ -193,6 +213,22 @@ void GmoBoxSliceStaff::reposition_shapes(const vector<LUnits>& yShifts,
             }
         }
     }
+}
+
+//---------------------------------------------------------------------------------------
+GmoShape* GmoBoxSliceStaff::find_staffobj_shape_before(LUnits x)
+{
+    list<GmoShape*>::reverse_iterator it;
+    for (it=m_shapes.rbegin(); it != m_shapes.rend(); ++it)
+    {
+        ImoObj* pImo = (*it)->get_creator_imo();
+        if (pImo && pImo->is_staffobj())
+        {
+            if ((*it)->get_right() <= x)
+                return *it;
+        }
+    }
+    return nullptr;
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/lomse_box_slice_instr.cpp
+++ b/src/graphic_model/lomse_box_slice_instr.cpp
@@ -76,6 +76,26 @@ GmoShape* GmoBoxSliceInstr::find_staffobj_shape_before(LUnits x)
 }
 
 //---------------------------------------------------------------------------------------
+GmoShape* GmoBoxSliceInstr::find_staffobj_shape_after(LUnits x)
+{
+    vector<GmoBox*>::iterator it;
+    GmoShape* pShape = nullptr;
+    for (it=m_childBoxes.begin(); it != m_childBoxes.end(); ++it)
+    {
+        GmoBoxSliceStaff* pSlice = static_cast<GmoBoxSliceStaff*>(*it);
+        GmoShape* pS = pSlice->find_staffobj_shape_after(x);
+        if (pS)
+        {
+            if (!pShape)
+                pShape = pS;
+            else if (pShape->get_left() > pS->get_left())
+                pShape = pS;
+        }
+    }
+    return pShape;
+}
+
+//---------------------------------------------------------------------------------------
 void GmoBoxSliceInstr::reposition_slices_and_shapes(const vector<LUnits>& yOrgShifts,
                                                     const vector<LUnits>& heights,
                                                     LUnits barlinesHeight,
@@ -225,6 +245,22 @@ GmoShape* GmoBoxSliceStaff::find_staffobj_shape_before(LUnits x)
         if (pImo && pImo->is_staffobj())
         {
             if ((*it)->get_right() <= x)
+                return *it;
+        }
+    }
+    return nullptr;
+}
+
+//---------------------------------------------------------------------------------------
+GmoShape* GmoBoxSliceStaff::find_staffobj_shape_after(LUnits x)
+{
+    list<GmoShape*>::iterator it;
+    for (it=m_shapes.begin(); it != m_shapes.end(); ++it)
+    {
+        ImoObj* pImo = (*it)->get_creator_imo();
+        if (pImo && pImo->is_staffobj())
+        {
+            if ((*it)->get_left() >= x)
                 return *it;
         }
     }

--- a/src/graphic_model/lomse_box_system.cpp
+++ b/src/graphic_model/lomse_box_system.cpp
@@ -139,6 +139,20 @@ GmoBoxSliceInstr* GmoBoxSystem::get_first_instr_slice(int iInstr)
 }
 
 //---------------------------------------------------------------------------------------
+GmoBoxSliceInstr* GmoBoxSystem::find_instr_slice_at(LUnits x, LUnits y)
+{
+    vector<GmoBox*>::iterator it;
+    for (it=m_childBoxes.begin(); it != m_childBoxes.end(); ++it)
+    {
+        GmoBoxSlice* pSlice = static_cast<GmoBoxSlice*>(*it);
+        URect bbox = pSlice->get_bounds();
+        if (bbox.contains(x, y))
+            return pSlice->find_instr_slice_at(x, y);
+    }
+    return nullptr;
+}
+
+//---------------------------------------------------------------------------------------
 GmoBoxSliceStaff* GmoBoxSystem::get_first_slice_staff_for(int iInstr, int iStaff)
 {
     GmoBoxSlice* pSlice = static_cast<GmoBoxSlice*>(m_childBoxes[0]);
@@ -183,7 +197,7 @@ int GmoBoxSystem::staff_number_for(int absStaff, int UNUSED(iInstr))
 }
 
 //---------------------------------------------------------------------------------------
-int GmoBoxSystem::nearest_staff_to_point(LUnits y)
+int GmoBoxSystem::staff_at(LUnits y)
 {
     //The y coordinate should be within system box limits.
 

--- a/src/graphic_model/lomse_caret_positioner.cpp
+++ b/src/graphic_model/lomse_caret_positioner.cpp
@@ -502,7 +502,7 @@ SpElementCursorState ScoreCaretPositioner::click_point_to_cursor_state(int iPage
             time = pTimeGrid->get_time_for_position(x);
 
             //determine instrument & staff
-            int absStaff = pBSYS->nearest_staff_to_point(y);
+            int absStaff = pBSYS->staff_at(y);
             instr = pBSYS->instr_number_for_staff(absStaff);
             staff = pBSYS->staff_number_for(absStaff, instr);
             //AWARE: only instr, staff & time are relevant (id == k_no_imoid)

--- a/src/graphic_model/lomse_timegrid_table.cpp
+++ b/src/graphic_model/lomse_timegrid_table.cpp
@@ -33,11 +33,6 @@ TimeGridTable::TimeGridTable()
 }
 
 //---------------------------------------------------------------------------------------
-TimeGridTable::~TimeGridTable()
-{
-}
-
-//---------------------------------------------------------------------------------------
 void TimeGridTable::add_entries(vector<TimeGridTableEntry>& entries)
 {
     int iMax = int(entries.size());

--- a/src/internal_model/lomse_im_measures_table.cpp
+++ b/src/internal_model/lomse_im_measures_table.cpp
@@ -116,7 +116,7 @@ ImMeasuresTableEntry* ImMeasuresTable::get_measure_at(TimeUnits timepos)
 {
     //Binary search in table for measure containing the requested timepos.
     //Returns nullptr if no measures or negative timepos.
-    //If timepos > las measure time, always returns last measure.
+    //If timepos > last measure time, always returns last measure.
 
     if (m_theTable.size() == 0 || timepos < 0.0)
         return nullptr;

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -1051,6 +1051,19 @@ Color ImoObj::get_color_attribute(TIntAttribute idx)
 
 
 //=======================================================================================
+// ImoAuxObj implementation
+//=======================================================================================
+ImoStaffObj* ImoAuxObj::get_parent_staffobj()
+{
+    ImoObj* pImo = get_parent_imo();
+    while (pImo && !pImo->is_staffobj())
+        pImo = pImo->get_parent_imo();
+
+    return (pImo && pImo->is_staffobj() ? static_cast<ImoStaffObj*>(pImo) : nullptr);
+}
+
+
+//=======================================================================================
 // ImoAuxRelObj implementation
 //=======================================================================================
 ImoAuxRelObj::~ImoAuxRelObj()

--- a/src/internal_model/lomse_model_builder.cpp
+++ b/src/internal_model/lomse_model_builder.cpp
@@ -750,6 +750,15 @@ void MeasuresTableBuilder::build(ImoScore* pScore)
         //advance to next entry
         ++it;
     }
+
+//    //debug
+//    int maxInstr = pScore->get_num_instruments();
+//    for (int i=0; i < maxInstr; ++i)
+//    {
+//        ImoInstrument* pInstr = pScore->get_instrument(i);
+//        ImMeasuresTable* pTable = pInstr->get_measures_table();
+//        LOMSE_LOG_INFO(pTable->dump());
+//    }
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/internal_model/lomse_score_algorithms.cpp
+++ b/src/internal_model/lomse_score_algorithms.cpp
@@ -317,7 +317,7 @@ TimeUnits ScoreAlgorithms::get_timepos_for(ImoScore* pScore, int iMeasure, int i
 //---------------------------------------------------------------------------------------
 TimeUnits ScoreAlgorithms::get_timepos_for(ImoScore* pScore, const MeasureLocator& ml)
 {
-    if (ml.iInstr < 0 || ml.iInstr >= pScore->get_num_instruments())
+    if (!ml.is_valid() || ml.iInstr >= pScore->get_num_instruments())
         return 0.0;
 
     ImoInstrument* pInstr = pScore->get_instrument(ml.iInstr);

--- a/src/mvc/lomse_interactor.cpp
+++ b/src/mvc/lomse_interactor.cpp
@@ -730,6 +730,33 @@ GmoObj* Interactor::find_object_at(Pixels x, Pixels y)
 }
 
 //---------------------------------------------------------------------------------------
+ClickPointData Interactor::find_click_info_at(Pixels x, Pixels y)
+{
+    //get graphic view
+    GraphicView* pGView = dynamic_cast<GraphicView*>(m_pView);
+    if (pGView == nullptr)
+    {
+        LOMSE_LOG_ERROR("Invoking Interactor::find_click_info_at() but no graphic view!");
+        return ClickPointData();
+    }
+
+    //get document page
+    double xPos = double(x);
+    double yPos = double(y);
+    int iPage = page_at_screen_point(xPos, yPos);
+    if (iPage == -1)
+        return ClickPointData();
+
+    //get graphic model clicked object
+    screen_point_to_page_point(&xPos, &yPos);
+    GraphicModel* pGM = get_graphic_model();
+    GmoObj* pGmo = pGM->hit_test(iPage, LUnits(xPos), LUnits(yPos));
+
+    //get clicked point info
+    return GModelAlgorithms::find_info_for_point(xPos, yPos, pGmo);
+}
+
+//---------------------------------------------------------------------------------------
 GmoBox* Interactor::find_box_at(Pixels x, Pixels y)
 {
     double xPos = double(x);

--- a/src/tests/lomse_test_interactor.cpp
+++ b/src/tests/lomse_test_interactor.cpp
@@ -150,9 +150,11 @@ class InteractorTestFixture
 {
 public:
     LibraryScope m_libraryScope;
+    std::string m_scores_path;
 
     InteractorTestFixture()     //SetUp fixture
         : m_libraryScope(cout)
+        , m_scores_path(TESTLIB_SCORES_PATH)
     {
         m_libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
     }
@@ -489,6 +491,48 @@ SUITE(InteractorTest)
         CHECK( pIntor->select_object_invoked() == true );
         CHECK( pIntor->sel_point_is(10, 33) == true );
     }
+
+
+    // find_click_info_at()
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_01)
+    {
+        //@01 - beamed chord invokes compute_stems_directions()
+        //       chord: d4,g4 - f4,c5
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "00205-multimetric.lmd");
+        Document* pDoc = pPresenter->get_document_raw_ptr();
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+        pIntor->get_graphic_model();        //force to engrave the score
+
+        //pIntor->get_graphic_model()->dump_page(0, cout);
+
+        double x = 12600.0;
+        double y = 5200.0;
+        pIntor->model_point_to_device(&x, &y, 0);
+        cout << "x=" << x << ", y=" << y << endl;
+
+//        ClickPointData data = pIntor->find_click_info_at(Pixels(x), Pixels(y)); //588, 255);
+        ClickPointData data = pIntor->find_click_info_at(728, 335);
+
+        cout << "instr=" << data.ml.iInstr << ", staff=" << data.iStaff
+            << ", measure=" << data.ml.iMeasure << ", location=" << data.ml.location
+            << ", pImo is " << (data.pImo ? data.pImo->get_name() : "nullptr") << endl;
+        CHECK( data.ml.iInstr == 1 );
+        CHECK( data.iStaff == 0 );
+        CHECK( data.ml.iMeasure == 3 );
+        CHECK( is_equal_time(data.ml.location, 32.0) );
+        CHECK( data.pImo && data.pImo->is_instrument() );
+    }
+
+
+
+
 
     //TEST_FIXTURE(InteractorTestFixture, NotificationReceived)
     //{

--- a/src/tests/lomse_test_interactor.cpp
+++ b/src/tests/lomse_test_interactor.cpp
@@ -162,6 +162,39 @@ public:
     ~InteractorTestFixture()    //TearDown fixture
     {
     }
+
+    //-----------------------------------------------------------------------------------
+    inline const char* test_name()
+    {
+        return UnitTest::CurrentTest::Details()->testName;
+    }
+
+    //-----------------------------------------------------------------------------------
+    bool check_click_data(ClickPointData& data, int iInstr, int iStaff, int iMeasure,
+                          TimeUnits location, const string& pImoName, const char* name)
+    {
+        bool fTestOk = data.ml.iInstr == iInstr
+                       && data.iStaff == iStaff
+                       && data.ml.iMeasure == iMeasure
+                       && is_equal_time(data.ml.location, location)
+                       && (pImoName=="nullptr" ? data.pImo==nullptr
+                                               : data.pImo->get_name() == pImoName);
+
+        if (!fTestOk)
+        {
+            cout << "Error in test " << name << endl
+                 << "    Result: "
+                 << "instr=" << data.ml.iInstr << ", staff=" << data.iStaff
+                 << ", measure=" << data.ml.iMeasure << ", location=" << data.ml.location
+                 << ", pImo is " << (data.pImo==nullptr ? "nullptr"
+                                                        : data.pImo->get_name()) << endl
+                 << "  Expected: "
+                 << "instr=" << iInstr << ", staff=" << iStaff
+                 << ", measure=" << iMeasure << ", location=" << location
+                 << ", pImo is " << pImoName <<endl;
+        }
+        return fTestOk;
+    }
 };
 
 
@@ -493,12 +526,16 @@ SUITE(InteractorTest)
     }
 
 
-    // find_click_info_at()
+    //@ find_click_info_at() ------------------------------------------------------------
+    //These are indirect test. To avoid problems with Pixels to LUnits conversions
+    //instead of testing Interactor::find_click_info_at(Pixels x, Pixels y) these tests
+    //are for GModelAlgorithms::find_info_for_point(), that use LUnits. Data for the
+    //tests (clicked point in LUnits and the results) are obtained by using lomseapp
+    //and uncommented log code in that method and should be platform independent.
 
-    TEST_FIXTURE(InteractorTestFixture, click_info_01)
+    TEST_FIXTURE(InteractorTestFixture, click_info_100)
     {
-        //@01 - beamed chord invokes compute_stems_directions()
-        //       chord: d4,g4 - f4,c5
+        //@100. Click on document background
 
         LomseDoorway doorway;
         doorway.init_library(k_pix_format_rgb24, 82);
@@ -506,28 +543,610 @@ SUITE(InteractorTest)
         libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
         Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
             m_scores_path + "00205-multimetric.lmd");
-        Document* pDoc = pPresenter->get_document_raw_ptr();
         Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
-        pIntor->get_graphic_model();        //force to engrave the score
 
-        //pIntor->get_graphic_model()->dump_page(0, cout);
+        ClickPointData data = pIntor->find_click_info_at(1, 1);
 
-        double x = 12600.0;
-        double y = 5200.0;
-        pIntor->model_point_to_device(&x, &y, 0);
-        cout << "x=" << x << ", y=" << y << endl;
+        CHECK( check_click_data(data, -1, -1, -1, 0.0, "nullptr", test_name()) );
+    }
 
-//        ClickPointData data = pIntor->find_click_info_at(Pixels(x), Pixels(y)); //588, 255);
-        ClickPointData data = pIntor->find_click_info_at(728, 335);
+    TEST_FIXTURE(InteractorTestFixture, click_info_200)
+    {
+        //@200. click on staff after final barline
 
-        cout << "instr=" << data.ml.iInstr << ", staff=" << data.iStaff
-            << ", measure=" << data.ml.iMeasure << ", location=" << data.ml.location
-            << ", pImo is " << (data.pImo ? data.pImo->get_name() : "nullptr") << endl;
-        CHECK( data.ml.iInstr == 1 );
-        CHECK( data.iStaff == 0 );
-        CHECK( data.ml.iMeasure == 3 );
-        CHECK( is_equal_time(data.ml.location, 32.0) );
-        CHECK( data.pImo && data.pImo->is_instrument() );
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "07012-two-instruments-four-staves.lmd");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 13453.9;
+        LUnits y = 8551.37;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, 1, 1, 1, 256.0, "instrument", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_201)
+    {
+        //@201. click on staff, second measure, after initial barline
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "07012-two-instruments-four-staves.lmd");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 8484.21;
+        LUnits y = 5081.57;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, 0, 1, 1, 0.0, "instrument", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_202)
+    {
+        //@202. click on staff, first measure, after time signature
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "00205-multimetric.lmd");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 4253.3;
+        LUnits y = 5283.05;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, 1, 0, 0, 0, "instrument", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_203)
+    {
+        //@203. click on staff, second measure, after first note
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "00205-multimetric.lmd");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 6827.66;
+        LUnits y = 4992.03;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, 1, 0, 1, 32, "instrument", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_204)
+    {
+        //@204. click on staff, second measure, after last note
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "00205-multimetric.lmd");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 8954.31;
+        LUnits y = 5171.12;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, 1, 0, 1, 128, "instrument", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_205)
+    {
+        //@205. click on staff, fifth measure, after last note
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "00205-multimetric.lmd");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 16744.6;
+        LUnits y = 5283.05;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, 1, 0, 4, 128.0, "instrument", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_300)
+    {
+        //@300. Click point is a note
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "00205-multimetric.lmd");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 11125.7;
+        LUnits y = 4992.03;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, 1, 0, 2, 96, "note", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_301)
+    {
+        //@301. Click point is a note after last barline
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "00136-clef-follows-note-when-note-displaced.lms");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 7723.1;
+        LUnits y = 3827.97;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, 0, 0, 1, 64, "note", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_302)
+    {
+        //@302. Click point is a barline
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "00136-clef-follows-note-when-note-displaced.lms");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 6357.74;
+        LUnits y = 4979.33;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, 0, 0, 1, 0, "barline", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_303)
+    {
+        //@303. Click point is a prolog clef in third staff (gosht image)
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "50041-octave_shift.xml");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 1992.33;
+        LUnits y = 8752.84;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, 0, 0, 8, 0, "clef", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_304)
+    {
+        //@304. Intermediate clef at start of measure but displayed at end of prev.measure
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "50041-octave_shift.xml");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 15916.3;
+        LUnits y = 3223.55;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, 0, 0, 3, 0, "clef", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_305)
+    {
+        //@305. Click point is an intermediate clef between two notes
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "00136-clef-follows-note-when-note-displaced.lms");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 7275.38;
+        LUnits y = 3447.41;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, 0, 0, 1, 64, "clef", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_306)
+    {
+        //@306. Click point is courtesy key at end of system
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "50400-time-key-after-break.xml");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 19095.1;
+        LUnits y = 12894.2;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, 1, 0, 6, 0, "key-signature", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_401)
+    {
+        //@401. Click point is an AuxObj aligned with ist parent staffobj
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "02021-all-fermatas.lms");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 9402.03;
+        LUnits y = 4029.44;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, 0, 0, 3, 0, "fermata", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_501)
+    {
+        //@501. Click point is a beam
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "07012-two-instruments-four-staves.lmd");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 9200.56;
+        LUnits y = 6827.66;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, 1, 0, 1, 0, "beam", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_502)
+    {
+        //@502. Click point is a wedge starting at previous measure
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "50040-wedge.xml");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 17975.8;
+        LUnits y = 9804.97;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, 0, 0, 12, 0, "wedge", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_503)
+    {
+        //@503. Click point is a slur starting in previous system
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "50041-octave_shift.xml");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 14326.9;
+        LUnits y = 9760.2;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, 0, 0, 6, 0, "octave-shift", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_600)
+    {
+        //@600. Click point is on the document but not on a score
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "09001-paragraph-two-scores-in-vertical.lms");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 12670.4;
+        LUnits y = 2417.66;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, -1, -1, -1, 0, "paragraph", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_601)
+    {
+        //@601. Click point on empty space, second measure, between two notes,
+        //      inmediatelly above first staff. //TODO: should provide valid locator?
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "00205-multimetric.lmd");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 7835.02;
+        LUnits y = 4745.79;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, -1, -1, -1, 0, "instrument", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_602)
+    {
+        //@602. Click point on, second measure, space between two staves of the same
+        //      instrument. //TODO: should provide valid locator?
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "07012-two-instruments-four-staves.lmd");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 10364.6;
+        LUnits y = 4298.07;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, -1, -1, -1, 0, "instrument", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_603)
+    {
+        //@603. Click point on space before system
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "07012-two-instruments-four-staves.lmd");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 1701.32;
+        LUnits y = 5954.62;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, -1, -1, -1, 0, "score", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_604)
+    {
+        //@604. Click point on instrument brace
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "07012-two-instruments-four-staves.lmd");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 1634.16;
+        LUnits y = 7208.22;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, -1, -1, -1, 0, "instrument", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_900)
+    {
+        //@900. after last barline, empty space between staves: on box-system, Imo is score
+
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "07012-two-instruments-four-staves.lmd");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 13386.7;
+        LUnits y = 7678.32;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, -1, -1, -1, 0, "score", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_901)
+    {
+        //@901. after last barline, empty space inmediately above/below the staff: on box-system, Imo is score
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "07012-two-instruments-four-staves.lmd");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 13722.5;
+        LUnits y = 9066.24;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, -1, -1, -1, 0, "score", test_name()) );
+    }
+
+    TEST_FIXTURE(InteractorTestFixture, click_info_902)
+    {
+        //@902. empty space above/below the score: on box-doc-page, Imo is lenmusdoc
+        LomseDoorway doorway;
+        doorway.init_library(k_pix_format_rgb24, 82);
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
+            m_scores_path + "07012-two-instruments-four-staves.lmd");
+        Interactor* pIntor = pPresenter->get_interactor_raw_ptr(0);
+
+        //get graphic model clicked object
+        LUnits x = 10745.2;
+        LUnits y = 11461.5;
+        GraphicModel* pGM = pIntor->get_graphic_model(); //this also forces to engrave the score
+        GmoObj* pGmo = pGM->hit_test(0, x, y);
+
+        //get clicked point info
+        ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
+
+        CHECK( check_click_data(data, -1, -1, -1, 0, "lenmusdoc", test_name()) );
     }
 
 

--- a/src/tests/lomse_test_interactor.cpp
+++ b/src/tests/lomse_test_interactor.cpp
@@ -596,6 +596,8 @@ SUITE(InteractorTest)
 
         LomseDoorway doorway;
         doorway.init_library(k_pix_format_rgb24, 82);
+        lomse::get_global_logger().deinit();
+        lomse::get_global_logger().init(&std::cout, &std::cerr);
         LibraryScope libraryScope(cout, &doorway);
         libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
         Presenter* pPresenter = doorway.open_document(k_view_vertical_book,

--- a/src/tests/lomse_test_interactor.cpp
+++ b/src/tests/lomse_test_interactor.cpp
@@ -195,6 +195,22 @@ public:
         }
         return fTestOk;
     }
+
+    //-----------------------------------------------------------------------------------
+    void dump_gmodel(Interactor* pIntor)
+    {
+        GraphicModel* pGM = pIntor->get_graphic_model();
+        int pages = pGM->get_num_pages();
+        cout << test_name() << ". Dump of graphic model:" << endl;
+        for (int i=0; i < pages; ++i)
+        {
+            cout << "Page " << i
+                 << " ==================================================================="
+                 << endl;
+            pGM->dump_page(i, cout);
+        }
+        cout << endl << endl;
+    }
 };
 
 
@@ -596,6 +612,7 @@ SUITE(InteractorTest)
         ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
 
         CHECK( check_click_data(data, 0, 1, 1, 0.0, "instrument", test_name()) );
+        dump_gmodel(pIntor);
     }
 
     TEST_FIXTURE(InteractorTestFixture, click_info_202)

--- a/src/tests/lomse_test_interactor.cpp
+++ b/src/tests/lomse_test_interactor.cpp
@@ -596,8 +596,6 @@ SUITE(InteractorTest)
 
         LomseDoorway doorway;
         doorway.init_library(k_pix_format_rgb24, 82);
-        lomse::get_global_logger().deinit();
-        lomse::get_global_logger().init(&std::cout, &std::cerr);
         LibraryScope libraryScope(cout, &doorway);
         libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
         Presenter* pPresenter = doorway.open_document(k_view_vertical_book,
@@ -614,7 +612,6 @@ SUITE(InteractorTest)
         ClickPointData data = GModelAlgorithms::find_info_for_point(x, y, pGmo);
 
         CHECK( check_click_data(data, 0, 1, 1, 0.0, "instrument", test_name()) );
-        dump_gmodel(pIntor);
     }
 
     TEST_FIXTURE(InteractorTestFixture, click_info_202)

--- a/src/tests/lomse_the_test_runner.cpp
+++ b/src/tests/lomse_the_test_runner.cpp
@@ -104,7 +104,9 @@ int main(int argc, char** argv)
          << ". Library tests runner." << endl << endl;
 
     cout << "Lomse build date: " << LibraryScope::get_build_date() << endl;
-    cout << "Path for tests scores: '" << TESTLIB_SCORES_PATH << "'" << endl << endl;
+    cout << "Path for tests scores: '" << TESTLIB_SCORES_PATH << "'" << endl;
+    cout << "Tests fonts path: '" << TESTLIB_FONTS_PATH << "'" << endl;
+    cout << "Lomse fonts path: '" << LOMSE_FONTS_PATH << "'" << endl << endl;
 
     bool verbose = argc > 1 && (!strcmp(argv[1], "--verbose") || !strcmp(argv[1], "-v"));
     int nextArg = verbose ? 2 : 1;


### PR DESCRIPTION
This PR adds a method to get info about the score object at mouse click point position. It returns a struct `ClickPointData` that describes the content of the point on current bitmap rendition.

The struct provides a ptr. to the clicked object, and if the clicked point is on a score, it also provides:

- A `MeasureLocator` struct with information about measure, instrument, and time position.
- The staff index, relative to instrument staves.

Otherwise, if clicked point is not on a score, the `MeasureLocator` is invalid and the staff index is -1.

Example:

```
//get mouse click point
Pixels x = Pixels( mouse_x );
Pixels y = Pixels( mouse_y );

//get information about that point
ClickPointData data = spInteractor->find_click_info_at(x, y);

ImoObj* pClickedObj = data.pImo;
MeasureLocator ml = data.ml;
if (ml.is_valid())
{
    //clicked point is a valid location on an score 
    int iMeasure = ml.iMeasure;
    int iInstr = ml.iInstr
    int iStaff = data.iStaff
    
    //do whatever you like with this information
    ...
}
```


### Other changes ###
- Added method `MeasureLocator::is_valid()` to check locators.
- Some fixes for warnings about a variable that shadows another local variable.
- Add prefix `std::` to declarations in some header files.


