### PR TITLE
Add mute information to notes and suppress playback for muted notes

### DIFF
--- a/include/lomse_im_note.h
+++ b/include/lomse_im_note.h
@@ -224,6 +224,10 @@ protected:
     int get_int_attribute(TIntAttribute attrib) override;
     list<TIntAttribute> get_supported_attributes() override;
 
+    //play techniques. AWARE: In future, when play techniques are implemented, these
+    //variables must be replaced by a ImoPlayInfo child
+    bool m_fMute = false;       //true: mute in playback, do not generate MIDI events
+
 public:
     virtual ~ImoNote();
     ImoNote(const ImoNote&) = delete;
@@ -242,6 +246,10 @@ public:
         k_non_standard  = 0x0020, ///< Use non-standard acc. if necessary
     };
 
+
+    /** For muting playback and determining mute state */
+    void mute(EMuteType value);
+    bool is_muted();
 
     //pitch
     inline float get_actual_accidentals() { return m_actual_acc; }

--- a/include/lomse_internal_model.h
+++ b/include/lomse_internal_model.h
@@ -124,6 +124,37 @@ enum EDocObject
 };
 
 
+//---------------------------------------------------------------------------------------
+/** @ingroup enumerations
+    This enum describes the valid values for muting playback for different instruments.
+    A mute is a device attached to a musical instrument which changes the instrument's
+    tone quality (timbre) or lowers its volume. Mutes are commonly used on string and
+    brass instruments, especially the trumpet and trombone, and are occasionally used
+    on woodwinds. Muting can also be done by hand, as in the case of palm muting a
+    guitar or grasping a triangle to dampen its sound.
+    The on value is used to totally remove playback.
+    See: https://en.wikipedia.org/wiki/Mute_(music)
+*/
+enum EMuteType
+{
+    k_mute_off = 0,     ///< Not muted
+    k_mute_on,          ///< Total mute. No playback
+    k_mute_bucket,      ///< Bucket mute, also known as the velvetone or velvet-tone.
+    k_mute_cup,         ///< Cup mute. Similar to strait but includes an extra inverted cone.
+    k_mute_echo,            ///< Mute echo not main sound.
+    k_mute_harmon_no_stem,  ///< Harmon mute, also known as the wa-wa, wow-wow, or wah-wah mute .
+    k_mute_harmon_stem,     ///< Harmon mute, with a small tube inserted into the mute.
+    k_mute_hat,             ///< Derby or hat mute is done with a bowler hat or similar object.
+    k_mute_palm,        ///< Palm mute, a playing technique for guitar and bass guitar,
+    k_mute_plunger,     ///< Muted with a plunger held in front of the bell.
+    k_mute_practice,    ///< Muted with absorbent material. Used during practice to prevent bothering others.
+    k_mute_solotone,    ///< Solotone mute (two telescoping cones and a small tube in the center).
+    k_mute_stop_hand,   ///< Stop mute using the hand.
+    k_mute_stop_mute,   ///< Stop mute using a physical stop mute.
+    k_mute_straight,    ///< Strait mute using a truncated cone.
+};
+
+
 //=======================================================================================
 // Classes defined in this module
 //=======================================================================================

--- a/include/private/lomse_internal_model_p.h
+++ b/include/private/lomse_internal_model_p.h
@@ -814,6 +814,7 @@ enum EImoObjType
     k_imo_lyrics_text_info,
     k_imo_midi_info,
     k_imo_page_info,
+//    k_imo_play_info,
     k_imo_sound_info,
     k_imo_staff_info,
     k_imo_system_info,
@@ -1657,6 +1658,7 @@ public:
     inline bool is_pedal_mark() const { return m_objtype == k_imo_pedal_mark; }
     inline bool is_pedal_line() const { return m_objtype == k_imo_pedal_line; }
     inline bool is_pedal_dto() const { return m_objtype == k_imo_pedal_line_dto; }
+//    inline bool is_play_info() const { return m_objtype == k_imo_play_info; }
     inline bool is_point_dto() { return m_objtype == k_imo_point_dto; }
     inline bool is_rest() { return m_objtype == k_imo_rest; }
     inline bool is_relations() { return m_objtype == k_imo_relations; }
@@ -7425,6 +7427,32 @@ public:
     bool is_end_of_relation() const { return m_fEnd; }
     ImoDirection* get_staffobj() const { return m_pDirection; }
 };
+
+
+//---------------------------------------------------------------------------------------
+// AWARE: ImoPlayInfo object is not required until playback techniques are implemented.
+////ImoPlayInfo specifies the playback technique to use.
+//// - when attached to ImoSoundInfo it applies to all notes after the ImoSoundInfo.
+//// - When attached to ImoNote, it applies only to that note.
+//
+//class ImoPlayInfo : public ImoSimpleObj
+//{
+//protected:
+//    EMuteType m_mute = k_mute_off;
+//
+//    friend class ImFactory;
+//    ImoPlayInfo() : ImoSimpleObj(k_imo_play_info) {}
+//
+//public:
+//    ImoPlayInfo(const ImoPlayInfo&) = delete;
+//    ImoPlayInfo& operator= (const ImoPlayInfo&) = delete;
+//    ImoPlayInfo(ImoPlayInfo&&) = delete;
+//    ImoPlayInfo& operator= (ImoPlayInfo&&) = delete;
+//
+//    //setters
+//
+//    //getters
+//};
 
 
 //---------------------------------------------------------------------------------------

--- a/src/exporters/lomse_mxl_exporter.cpp
+++ b/src/exporters/lomse_mxl_exporter.cpp
@@ -95,8 +95,6 @@ protected:
 const bool k_in_same_line = false;
 //const bool k_in_new_line = true;
 const int k_indent_step = 3;
-const bool k_add_close_tag = false;
-//const bool k_add_close_element = true;
 
 //=======================================================================================
 // generators for specific elements

--- a/src/internal_model/lomse_im_note.cpp
+++ b/src/internal_model/lomse_im_note.cpp
@@ -254,6 +254,18 @@ bool ImoNote::is_cross_staff_chord()
 }
 
 //---------------------------------------------------------------------------------------
+void ImoNote::mute(EMuteType value)
+{
+    m_fMute = (value != k_mute_off);
+}
+
+//---------------------------------------------------------------------------------------
+bool ImoNote::is_muted()
+{
+    return m_fMute != k_mute_off;
+}
+
+//---------------------------------------------------------------------------------------
 bool ImoNote::has_beam()
 {
     ImoChord* pChord = get_chord();

--- a/src/sound/lomse_midi_table.cpp
+++ b/src/sound/lomse_midi_table.cpp
@@ -297,9 +297,9 @@ void SoundEventsTable::add_jumps_if_volta_bracket(StaffObjsCursor& cursor,
 
                         //jumps for the other voltas in this set
                         int numVoltas = pVB->get_total_voltas();
-                        for (int i=2; i <= numVoltas; ++i)
+                        for (int j=2; j <= numVoltas; ++j)
                         {
-                            int times = (i == numVoltas ? 0 : 1);
+                            times = (j == numVoltas ? 0 : 1);
                             pJump = create_jump(measure, 0, times);
                             add_jump(cursor, measure, pJump);
                             m_pending.push_back(pJump);
@@ -372,21 +372,24 @@ void SoundEventsTable::add_noterest_events(StaffObjsCursor& cursor, int measure)
     TimeUnits rTime = pNR->get_playback_time();
     if (pNR->is_note())
     {
-        //It is a note. Generate Note On event
-        if (!pNote->is_tied_prev())
+        //It is a note. Generate Note On event if not muted.
+        if (!pNote->is_muted())
         {
-            //It is not tied to the previous one. Generate NoteOn event to
-            //start the sound and highlight the note
-            int volume = compute_volume(rTime, pTS, cursor.anacrusis_missing_time());
-            store_event(rTime, SoundEvent::k_note_on, channel, pitch,
-                        volume, step, pNR, measure);
-        }
-        else
-        {
-            //This note is tied to the previous one. Generate only a VisualOn event as the
-            //sound is already started by the previous note.
-            store_event(rTime, SoundEvent::k_visual_on, channel, pitch,
-                        0, step, pNR, measure);
+            if (!pNote->is_tied_prev())
+            {
+                //It is not tied to the previous one. Generate NoteOn event to
+                //start the sound and highlight the note
+                int volume = compute_volume(rTime, pTS, cursor.anacrusis_missing_time());
+                store_event(rTime, SoundEvent::k_note_on, channel, pitch,
+                            volume, step, pNR, measure);
+            }
+            else
+            {
+                //This note is tied to the previous one. Generate only a VisualOn event as the
+                //sound is already started by the previous note.
+                store_event(rTime, SoundEvent::k_visual_on, channel, pitch,
+                            0, step, pNR, measure);
+            }
         }
     }
     else
@@ -400,20 +403,23 @@ void SoundEventsTable::add_noterest_events(StaffObjsCursor& cursor, int measure)
     rTime += pNR->get_playback_duration();
     if (pNR->is_note())
     {
-        //It is a note
-        if (!pNote->is_tied_next())
+        //It is a note. Generate events if not muted.
+        if (!pNote->is_muted())
         {
-            //It is not tied to next note. Generate NoteOff event to stop the sound and
-            //un-highlight the note
-            store_event(rTime, SoundEvent::k_note_off, channel, pitch,
-                        0, step, pNR, measure);
-        }
-        else
-        {
-            //This note is tied to the next one. Generate only a VisualOff event so that
-            //the note will be un-highlighted but the sound will not be stopped.
-            store_event(rTime, SoundEvent::k_visual_off, channel, pitch,
-                        0, step, pNR, measure);
+            if (!pNote->is_tied_next())
+            {
+                //It is not tied to next note. Generate NoteOff event to stop the sound and
+                //un-highlight the note
+                store_event(rTime, SoundEvent::k_note_off, channel, pitch,
+                            0, step, pNR, measure);
+            }
+            else
+            {
+                //This note is tied to the next one. Generate only a VisualOff event so that
+                //the note will be un-highlighted but the sound will not be stopped.
+                store_event(rTime, SoundEvent::k_visual_off, channel, pitch,
+                            0, step, pNR, measure);
+            }
         }
     }
     else


### PR DESCRIPTION
Lomse internal model distinguishes between elements used for sound information and elements used for notation information.

For display, visibility of any note is controlled by methods `is_visible()` and `set_visible()`. But for playback there is not any method to mute a note as all this was waiting to implement playback techniques.

This PR adds methods `ImoNote::mute()` and `ImoNote::is_muted()` to control notes playback. In preparation for the future implementation of playback techniques, method `ImoNote::mute(EMuteType value)` receives as parameter not a boolean but a value from enum `EMuteType` that defines different mute techniques. For now, any value different from `k_mute_off` causes to suppress playback for the affected note.

MIDI events generation has been reviewed to ensure that no MIDI events are generated for muted notes.

This PR closes #360
