### PR TITLE
Improve MusicXML exporter

### DIFF
--- a/include/lomse_mxl_exporter.h
+++ b/include/lomse_mxl_exporter.h
@@ -58,8 +58,6 @@ protected:
     static const int k_max_tuplet_number = 16;
     std::array<ImoId, k_max_tuplet_number> m_tuplets;
 
-
-
 public:
     MxlExporter(LibraryScope& libScope);
     virtual ~MxlExporter();
@@ -72,7 +70,6 @@ public:
     inline void set_remove_newlines(bool value) { m_fRemoveNewlines = value; }
     inline void set_remove_separator_lines(bool value) { m_fRemoveSeparators = value; }
     inline void save_divisions(int value) { m_divisions = value; }
-
 
     //getters for settings
     inline int get_indent() const { return m_nIndent; }
@@ -134,6 +131,7 @@ public:
     }
     inline void push_tag(const std::string& tag) { m_openTags.push(tag); }
     inline void pop_tag() { m_openTags.pop(); }
+
 
 protected:
     MxlGenerator* new_generator(ImoObj* pImo);

--- a/src/internal_model/lomse_model_builder.cpp
+++ b/src/internal_model/lomse_model_builder.cpp
@@ -525,7 +525,7 @@ void MidiAssigner::assign_port_and_channel()
             {
                 if (m_assigned[i] == nullptr)
                 {
-                    pMidi->set_midi_port(i / 16);
+                    pMidi->init_midi_port(i / 16);
                     m_assigned[i] = *it;
                     break;
                 }
@@ -544,7 +544,7 @@ void MidiAssigner::assign_port_and_channel()
                 int i = p*16 + ch;
                 if (m_assigned[i] == nullptr)
                 {
-                    pMidi->set_midi_channel(i % 16);
+                    pMidi->init_midi_channel(i % 16);
                     m_assigned[i] = *it;
                     fAssigned = true;
                     break;
@@ -561,8 +561,8 @@ void MidiAssigner::assign_port_and_channel()
             {
                 if (m_assigned[idx] == nullptr)
                 {
-                    pMidi->set_midi_port(idx / 16);
-                    pMidi->set_midi_channel(idx % 16);
+                    pMidi->init_midi_port(idx / 16);
+                    pMidi->init_midi_channel(idx % 16);
                     m_assigned[idx] = *it;
                     ++idx;
                     break;

--- a/src/parser/ldp/lomse_ldp_analyser.cpp
+++ b/src/parser/ldp/lomse_ldp_analyser.cpp
@@ -3379,7 +3379,8 @@ public:
 
             while (get_optional(k_string))
             {
-                pSyl->set_elision_text(".");    //undertie U+203F
+                pSyl->set_elision_text(".");
+                //pSyl->set_elision_text("‿");    //undertie U+203F
                 //pSyl->set_elision_text("\xE2\x80\xBF");   //undertie U+203F in utf-8
                 //pSyl->set_elision_text("0x203F");         //undertie U+203F
                 //undertie is not supported in LiberationSerif font
@@ -3435,7 +3436,7 @@ public:
             // [<placement>]
             if (get_optional(k_label))
             {
-                int placement = get_placement(k_placement_below);
+                int placement = get_placement(k_placement_default);
                 m_pAnalyser->set_lyrics_placement(line, placement);
                 pImo->set_placement(placement);
                 fPlacement = true;
@@ -6615,7 +6616,7 @@ void LdpAnalyser::set_lyrics_placement(int line, int placement)
 int LdpAnalyser::get_lyrics_placement(int line)
 {
     if (m_lyricsPlacement.size() < size_t(line))
-        return k_placement_below;
+        return k_placement_default;
     else
         return m_lyricsPlacement[line-1];
 }

--- a/src/tests/lomse_test_ldp_analyser.cpp
+++ b/src/tests/lomse_test_ldp_analyser.cpp
@@ -4072,6 +4072,90 @@ SUITE(LdpAnalyserTest)
         if (pRoot && !pRoot->is_document()) delete pRoot;
     }
 
+    TEST_FIXTURE(LdpAnalyserTestFixture, LdpAnalyser_lyric_11)
+    {
+        //@ 11. lyrics. Syllable type correctly inferred
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+        stringstream expected;
+        //expected << "" << endl;
+        parser.parse_text("(score (vers 2.0)(instrument (musicData "
+            "(n c4 e (lyric \"vic\" -))"
+            "(n d4 e (lyric \"to\" -))"
+            "(n e4 e (lyric \"ri\" -))"
+            "(n e4 e (lyric \"ous\"))"
+            ")))");
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        ImoScore* pScore = static_cast<ImoScore*>( pRoot );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMusic = pInstr->get_musicdata();
+        CHECK( pMusic != nullptr );
+        ImoObj::children_iterator it = pMusic->begin();
+
+        ImoNote* pNote = dynamic_cast<ImoNote*>(*it);
+        CHECK( pNote != nullptr );
+        CHECK( pNote && pNote->get_octave() == 4 );
+        CHECK( pNote && pNote->get_step() == 0 );
+        CHECK( pNote && pNote->get_num_attachments() == 1 );
+        ImoLyric* pLyric1 = dynamic_cast<ImoLyric*>( pNote->get_attachment(0) );
+        CHECK( pLyric1 && pLyric1->get_number() == 1 );
+        ImoLyricsTextInfo* pTxt1 = pLyric1->get_text_item(0);
+        CHECK( pTxt1 && pTxt1->get_syllable_type() == ImoLyricsTextInfo::k_begin );
+
+        ++it;
+        pNote = dynamic_cast<ImoNote*>(*it);
+        CHECK( pNote != nullptr );
+        CHECK( pNote && pNote->get_octave() == 4 );
+        CHECK( pNote && pNote->get_step() == 1);
+        CHECK( pNote && pNote->get_num_attachments() == 1 );
+        ImoLyric* pLyric2 = dynamic_cast<ImoLyric*>( pNote->get_attachment(0) );
+        CHECK( pLyric2 && pLyric2->get_number() == 1 );
+        ImoLyricsTextInfo* pTxt2 = pLyric2->get_text_item(0);
+        CHECK( pTxt2 && pTxt2->get_syllable_type() == ImoLyricsTextInfo::k_middle );
+
+        ++it;
+        pNote = dynamic_cast<ImoNote*>(*it);
+        CHECK( pNote != nullptr );
+        CHECK( pNote && pNote->get_octave() == 4 );
+        CHECK( pNote && pNote->get_step() == 2);
+        CHECK( pNote && pNote->get_num_attachments() == 1 );
+        ImoLyric* pLyric3 = dynamic_cast<ImoLyric*>( pNote->get_attachment(0) );
+        CHECK( pLyric3 && pLyric3->get_number() == 1 );
+        ImoLyricsTextInfo* pTxt3 = pLyric3->get_text_item(0);
+        CHECK( pTxt3 && pTxt3->get_syllable_type() == ImoLyricsTextInfo::k_middle );
+
+        ++it;
+        pNote = dynamic_cast<ImoNote*>(*it);
+        CHECK( pNote != nullptr );
+        CHECK( pNote && pNote->get_octave() == 4 );
+        CHECK( pNote && pNote->get_step() == 2);
+        CHECK( pNote && pNote->get_num_attachments() == 1 );
+        ImoLyric* pLyric4 = dynamic_cast<ImoLyric*>( pNote->get_attachment(0) );
+        CHECK( pLyric4 && pLyric4->get_number() == 1 );
+        ImoLyricsTextInfo* pTxt4 = pLyric4->get_text_item(0);
+        CHECK( pTxt4 && pTxt4->get_syllable_type() == ImoLyricsTextInfo::k_end );
+
+        CHECK( pLyric1->get_prev_lyric() == nullptr );
+        CHECK( pLyric1->get_next_lyric() == pLyric2 );
+        CHECK( pLyric2->get_prev_lyric() == pLyric1 );
+        CHECK( pLyric2->get_next_lyric() == pLyric3 );
+        CHECK( pLyric3->get_prev_lyric() == pLyric2 );
+        CHECK( pLyric3->get_next_lyric() == pLyric4 );
+        CHECK( pLyric4->get_prev_lyric() == pLyric3 );
+        CHECK( pLyric4->get_next_lyric() == nullptr );
+
+        delete tree->get_root();
+        // coverity[check_after_deref]
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
     //@ metronome -----------------------------------------------------------------------
 
     TEST_FIXTURE(LdpAnalyserTestFixture, metronome_00)

--- a/src/tests/lomse_test_ldp_analyser.cpp
+++ b/src/tests/lomse_test_ldp_analyser.cpp
@@ -3612,7 +3612,7 @@ SUITE(LdpAnalyserTest)
         ImoLyric* pImo = static_cast<ImoLyric*>( pRoot );
         CHECK( pImo != nullptr );
         CHECK( pImo && pImo->get_number() == 1 );
-        CHECK( pImo && pImo->get_placement() == k_placement_below );
+        CHECK( pImo && pImo->get_placement() == k_placement_default );
         CHECK( pImo && pImo->is_laughing() == false );
         CHECK( pImo && pImo->is_humming() == false );
         CHECK( pImo && pImo->is_end_line() == false );
@@ -3686,7 +3686,7 @@ SUITE(LdpAnalyserTest)
         ImoLyric* pImo = static_cast<ImoLyric*>( pRoot );
         CHECK( pImo != nullptr );
         CHECK( pImo && pImo->get_number() == 1 );
-        CHECK( pImo && pImo->get_placement() == k_placement_below );
+        CHECK( pImo && pImo->get_placement() == k_placement_default );
         CHECK( pImo && pImo->is_laughing() == false );
         CHECK( pImo && pImo->is_humming() == false );
         CHECK( pImo && pImo->is_end_line() == false );
@@ -3763,7 +3763,7 @@ SUITE(LdpAnalyserTest)
         ImoLyric* pImo = static_cast<ImoLyric*>( pRoot );
         CHECK( pImo != nullptr );
         CHECK( pImo && pImo->get_number() == 1 );
-        CHECK( pImo && pImo->get_placement() == k_placement_below );
+        CHECK( pImo && pImo->get_placement() == k_placement_default );
         CHECK( pImo && pImo->is_laughing() == false );
         CHECK( pImo && pImo->is_humming() == false );
         CHECK( pImo && pImo->is_end_line() == false );
@@ -3810,7 +3810,7 @@ SUITE(LdpAnalyserTest)
         ImoLyric* pImo = static_cast<ImoLyric*>( pRoot );
         CHECK( pImo != nullptr );
         CHECK( pImo && pImo->get_number() == 1 );
-        CHECK( pImo && pImo->get_placement() == k_placement_below );
+        CHECK( pImo && pImo->get_placement() == k_placement_default );
         CHECK( pImo && pImo->is_laughing() == false );
         CHECK( pImo && pImo->is_humming() == false );
         CHECK( pImo && pImo->is_end_line() == false );
@@ -3857,7 +3857,7 @@ SUITE(LdpAnalyserTest)
         ImoLyric* pImo = static_cast<ImoLyric*>( pRoot );
         CHECK( pImo != nullptr );
         CHECK( pImo && pImo->get_number() == 1 );
-        CHECK( pImo && pImo->get_placement() == k_placement_below );
+        CHECK( pImo && pImo->get_placement() == k_placement_default );
         CHECK( pImo && pImo->is_laughing() == false );
         CHECK( pImo && pImo->is_humming() == false );
         CHECK( pImo && pImo->is_end_line() == false );
@@ -4150,6 +4150,63 @@ SUITE(LdpAnalyserTest)
         CHECK( pLyric3->get_next_lyric() == pLyric4 );
         CHECK( pLyric4->get_prev_lyric() == pLyric3 );
         CHECK( pLyric4->get_next_lyric() == nullptr );
+
+        delete tree->get_root();
+        // coverity[check_after_deref]
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, LdpAnalyser_lyric_12)
+    {
+        //@ 12. lyrics. placement
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+        stringstream expected;
+        //expected << "" << endl;
+        parser.parse_text("(score (vers 2.0)(instrument (musicData "
+            "(n c4 e (lyric \"Ah\"))"
+            "(n d4 e (lyric \"Be\" above))"
+            "(n e4 e (lyric \"Ce\" below))"
+            ")))");
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+//        cout << "[" << errormsg.str() << "]" << endl;
+//        cout << "[" << expected.str() << "]" << endl;
+        CHECK( errormsg.str() == expected.str() );
+        ImoScore* pScore = static_cast<ImoScore*>( pRoot );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMusic = pInstr->get_musicdata();
+        CHECK( pMusic != nullptr );
+        ImoObj::children_iterator it = pMusic->begin();
+
+        ImoNote* pNote = dynamic_cast<ImoNote*>(*it);
+        CHECK( pNote != nullptr );
+        CHECK( pNote && pNote->get_octave() == 4 );
+        CHECK( pNote && pNote->get_step() == 0 );
+        CHECK( pNote && pNote->get_num_attachments() == 1 );
+        ImoLyric* pLyric = dynamic_cast<ImoLyric*>( pNote->get_attachment(0) );
+        CHECK( pLyric && pLyric->get_placement() == k_placement_default );
+
+        ++it;
+        pNote = dynamic_cast<ImoNote*>(*it);
+        CHECK( pNote != nullptr );
+        CHECK( pNote && pNote->get_octave() == 4 );
+        CHECK( pNote && pNote->get_step() == 1);
+        CHECK( pNote && pNote->get_num_attachments() == 1 );
+        pLyric = dynamic_cast<ImoLyric*>( pNote->get_attachment(0) );
+        CHECK( pLyric && pLyric->get_placement() == k_placement_above );
+
+        ++it;
+        pNote = dynamic_cast<ImoNote*>(*it);
+        CHECK( pNote != nullptr );
+        CHECK( pNote && pNote->get_octave() == 4 );
+        CHECK( pNote && pNote->get_step() == 2);
+        CHECK( pNote && pNote->get_num_attachments() == 1 );
+        pLyric = dynamic_cast<ImoLyric*>( pNote->get_attachment(0) );
+        CHECK( pLyric && pLyric->get_placement() == k_placement_below );
 
         delete tree->get_root();
         // coverity[check_after_deref]

--- a/src/tests/lomse_test_ldp_exporter.cpp
+++ b/src/tests/lomse_test_ldp_exporter.cpp
@@ -59,6 +59,17 @@ public:
         return UnitTest::CurrentTest::Details()->testName;
     }
 
+    bool check_result(const string& ss, const string& expected)
+    {
+        if (ss != expected)
+        {
+            cout << "  result=[" << ss << "]" << endl;
+            cout << "expected=[" << expected << "]" << endl;
+            return false;
+        }
+        return true;
+    }
+
 };
 
 //---------------------------------------------------------------------------------------
@@ -203,7 +214,7 @@ SUITE(LdpExporterTest)
         string expected =
             "(musicData (clef G p1)(n g5 s v1 p1 (beam 106 ++))"
             "(n f5 s v1 p1 (beam 106 =-))(n g5 e v1 p1 (beam 106 -))(barline simple))";
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     TEST_FIXTURE(LdpExporterTestFixture, beam_1)
@@ -226,7 +237,7 @@ SUITE(LdpExporterTest)
         string expected = "(musicData (clef G p1)"
             "(chord (n e4 e. v1 p1 (stem up)(beam 111 +))(n g4 e. v1 p1))"
             "(chord (n d4 s v1 p1 (stem up)(beam 111 -b))(n f4 s v1 p1)))";
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     TEST_FIXTURE(LdpExporterTestFixture, beam_2)
@@ -251,7 +262,7 @@ SUITE(LdpExporterTest)
             "(n c4 q v1 p1)(n e4 q v1 p1)(goFwd 64 v2 p1)"
             "(chord (n e4 e. v2 p1 (stem up)(beam 114 +))(n g4 e. v2 p1))"
             "(chord (n d4 s v2 p1 (stem up)(beam 114 -b))(n f4 s v2 p1)))";
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     TEST_FIXTURE(LdpExporterTestFixture, beam_3)
@@ -274,7 +285,7 @@ SUITE(LdpExporterTest)
         string expected = "(musicData (clef F4 p1)"
             "(n e3 e v1 p1 (beam 106 +))(n c2 w v3 p1)(n g3 e v1 p1 (beam 106 =))"
             "(n c4 e v1 p1 (beam 106 -))(barline simple))";
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     //@ clef ----------------------------------------------------------------------------
@@ -431,7 +442,7 @@ SUITE(LdpExporterTest)
             "(n g4 q v1 p1 (dyn \"sfz\" above))"
             "(n g4 q v1 p1 (dyn \"sfz\" above (color #ff0000ff)(dx 50)(dy -70)))"
             ")))";
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
 
@@ -477,7 +488,7 @@ SUITE(LdpExporterTest)
         string expected = "(instrument P1 (staves 1)(staff 1 (staffType ossia)"
             "(staffLines 5)(staffSpacing 250)(staffDistance 2000)"
             "(lineThickness 15))(musicData))";
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     TEST_FIXTURE(LdpExporterTestFixture, instrument_2)
@@ -531,7 +542,7 @@ SUITE(LdpExporterTest)
         //cout << test_name() << endl << "\"" << source << "\"" << endl;
         string expected = "(instrument P1 (name \"Guitar\" (style \"Best1\"))"
             "(abbrev \"G.\" (style \"Best2\"))(staves 1)(musicData))";
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     //@ key -----------------------------------------------------------------------------
@@ -598,9 +609,9 @@ SUITE(LdpExporterTest)
         doc.from_string("(score (vers 2.0)"
             "(instrument (musicData (clef G)"
             "(n c4 q (lyric 1 \"This\")(lyric 2 \"A\"))"
-            "(n d4 q (lyric 1 \"is\")(lyric 2 \"se\" -))"
+            "(n d4 q (lyric 1 \"is\" \"a\")(lyric 2 \"se\" -))"
             "(n e4 q (lyric 1 \"line\")(lyric 2 \"cond\"))"
-            "(n f4 q (lyric 1 \"one.\")(lyric 2 \"line.\"))"
+            "(n f4 q (lyric 1 \"one.\" above)(lyric 2 \"line.\" below))"
             "(barline))))" );
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
 //        dump_colection(pScore);
@@ -613,10 +624,10 @@ SUITE(LdpExporterTest)
         string source = exporter.get_source(pMD);
         //cout << test_name() << endl << "\"" << source << "\"" << endl;
         CHECK( source == "(musicData (clef G p1)"
-            "(n c4 q v1 p1 (lyric 1 \"This\" below)(lyric 2 \"A\" below))"
-            "(n d4 q v1 p1 (lyric 1 \"is\" below)(lyric 2 \"se\" - below))"
-            "(n e4 q v1 p1 (lyric 1 \"line\" below)(lyric 2 \"cond\" below))"
-            "(n f4 q v1 p1 (lyric 1 \"one.\" below)(lyric 2 \"line.\" below))"
+            "(n c4 q v1 p1 (lyric 1 \"This\")(lyric 2 \"A\"))"
+            "(n d4 q v1 p1 (lyric 1 \"is\" \"a\")(lyric 2 \"se\" -))"
+            "(n e4 q v1 p1 (lyric 1 \"line\")(lyric 2 \"cond\"))"
+            "(n f4 q v1 p1 (lyric 1 \"one.\" above)(lyric 2 \"line.\" below))"
             "(barline simple))" );
     }
 
@@ -806,7 +817,7 @@ SUITE(LdpExporterTest)
             "(musicData "
             "(clef G p1)(clef F4 p2)(key C)(time 2 4)(n c4 e v1 p1)"
             "(n g2 e v3 p2)(n c3 e v3 p2)(n e3 e v3 p2)(n g3 e v3 p2)(barline simple))";
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     TEST_FIXTURE(LdpExporterTestFixture, musicData_5)
@@ -828,7 +839,7 @@ SUITE(LdpExporterTest)
         string expected = "(musicData (clef G p1)"
             "(n c5 q v1 p1)"
             "(chord (n c4 e v1 p1)(n e4 e v1 p1)(n g4 e v1 p1)))";
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     TEST_FIXTURE(LdpExporterTestFixture, musicData_6)
@@ -851,7 +862,7 @@ SUITE(LdpExporterTest)
         string expected = "(musicData (clef G p1)"
             "(goFwd 64 v1 p1)"
             "(chord (n c4 e v1 p1)(n e4 e v1 p1)(n g4 e v1 p1)))";
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     TEST_FIXTURE(LdpExporterTestFixture, musicData_7)
@@ -885,7 +896,7 @@ SUITE(LdpExporterTest)
             "(n g5 e v1 p1 (beam 115 -))(barline simple)"
             "(chord (n a4 q v1 p1)(n e5 q v1 p1))(r q v1 p1)"
             "(chord (n d4 q v1 p1)(n g4 q v1 p1)(n f5 q v1 p1))(barline simple))";
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     //@ note ----------------------------------------------------------------------------
@@ -911,7 +922,7 @@ SUITE(LdpExporterTest)
             "(n g4 e v1 p1 (tm 2 3)(t 106 -))"
             ")))";
 
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     TEST_FIXTURE(LdpExporterTestFixture, note_1)
@@ -954,7 +965,7 @@ SUITE(LdpExporterTest)
         string expected = "(score (vers 2.0)(instrument P1 (staves 1)(musicData "
             "(clef G p1)(n c4 e v1 p1)(goFwd e v1 p1)(n e4 e v1 p1))))";
 
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     // ScoreLdpGenerator ----------------------------------------------------------------
@@ -979,7 +990,7 @@ SUITE(LdpExporterTest)
         string expected = "(score (vers 2.0)(style \"Score1\")"
             "(instrument P1 (staves 1)(musicData (clef G p1))))";
 
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     TEST_FIXTURE(LdpExporterTestFixture, score_1)
@@ -1002,7 +1013,7 @@ SUITE(LdpExporterTest)
             "(font-style normal)(font-weight bold)(color #00fe0f7f))"
             "(instrument P1 (staves 1)(musicData (clef G p1))))";
 
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     TEST_FIXTURE(LdpExporterTestFixture, score_2)
@@ -1025,7 +1036,7 @@ SUITE(LdpExporterTest)
             "(opt Render.SpacingValue 40)(opt StaffLines.Truncate 0)"
             "(instrument P1 (staves 1)(musicData (clef G p1))))";
 
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     TEST_FIXTURE(LdpExporterTestFixture, score_3)
@@ -1050,7 +1061,7 @@ SUITE(LdpExporterTest)
             "(systemLayout other (systemMargins 0 0 1800 2000))"
             "(instrument P1 (staves 1)(musicData (clef G p1))))";
 
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     TEST_FIXTURE(LdpExporterTestFixture, score_4)
@@ -1077,7 +1088,7 @@ SUITE(LdpExporterTest)
             "(opt StaffLines.Truncate 0)"
             "(instrument P1 (staves 1)(musicData)))";
 
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     // ScoreLineLdpGenerator ------------------------------------------------------------
@@ -1108,7 +1119,7 @@ SUITE(LdpExporterTest)
         string expected = "(musicData (clef G p1)"
             "(dir 0 p1 (text \"Largo\" (style \"Notations\")(dx -20)(dy -45))))";
 
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 #endif
 
@@ -1136,7 +1147,7 @@ SUITE(LdpExporterTest)
 //        cout << test_name() << endl;
 //        cout << test_name() << endl << "\"" << source << "\"" << endl;
 
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     // StaffObjLdpGenerator -------------------------------------------------------------
@@ -1165,7 +1176,7 @@ SUITE(LdpExporterTest)
 
         //cout << test_name() << endl << "\"" << source << "\"" << endl;
 
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     //@ time signature ------------------------------------------------------------------
@@ -1336,7 +1347,7 @@ SUITE(LdpExporterTest)
             "(n c4 s v1 p1 (tm 3 2)(beam 112 ==))"
             "(n b3 e v1 p1 (tm 3 2)(beam 112 --)(t 107 -))"
             ")";
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     TEST_FIXTURE(LdpExporterTestFixture, tuplet_1)
@@ -1366,7 +1377,7 @@ SUITE(LdpExporterTest)
             "(n c4 s v1 p1 (tm 3 2)(beam 112 ==))"
             "(n b3 e v1 p1 (tm 3 2)(beam 112 --)(t 107 -))"
             ")";
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
     //@ Order of elements in the score --------------------------------------------------
@@ -1393,13 +1404,13 @@ SUITE(LdpExporterTest)
         string expected = "(musicData (n c4 q v1 p1 (stem down))"
             "(n c4 q v1 p1 (slur 1 start))(n e4 q v1 p1 (slur 1 stop))"
             "(n c4 q v1 p1 (tie 2 start))(n c4 q v1 p1 (tie 2 stop))"
-            "(n c4 q v1 p1 (lyric 1 \"This\" below)(lyric 2 \"A\" below))"
+            "(n c4 q v1 p1 (lyric 1 \"This\")(lyric 2 \"A\"))"
             "(n g5 s v1 p1 (beam 126 ++))(n f5 s v1 p1 (beam 126 =-))"
             "(n g5 e v1 p1 (beam 126 -)))";
 
         //cout << test_name() << endl << "\"" << source << "\"" << endl;
 
-        CHECK( source == expected );
+        CHECK( check_result(source, expected) );
     }
 
 };

--- a/test-scores/unit-tests/grace-notes/228-grace-slash.xml
+++ b/test-scores/unit-tests/grace-notes/228-grace-slash.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise>
+  <part-list>
+    <score-part id="P1">
+      <part-name/>
+      </score-part>
+    </part-list>
+    <!-- ======================================================================= -->
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>4</divisions>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <grace slash="yes"/>
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+          </pitch>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>8</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <!-- ======================================================================= -->
+    </part>
+  </score-partwise>

--- a/test-scores/unit-tests/xml-export/004-cue-note.xml
+++ b/test-scores/unit-tests/xml-export/004-cue-note.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise>
+  <part-list>
+    <score-part id="P2">
+      <part-name>1</part-name>
+      </score-part>
+    </part-list>
+  <part id="P2">
+    <measure number="1">
+      <attributes>
+        <divisions>4</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>3</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>percussion</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <cue/>
+        <unpitched>
+          <display-step>E</display-step>
+          <display-octave>5</display-octave>
+          </unpitched>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <dot/>
+        <stem>down</stem>
+        </note>
+      </measure>
+    </part>
+  </score-partwise>

--- a/test-scores/unit-tests/xml-export/005-octave-shift.xml
+++ b/test-scores/unit-tests/xml-export/005-octave-shift.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <direction placement="above">
+        <direction-type>
+          <octave-shift type="down" size="8" number="1"/>
+          </direction-type>
+        </direction>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <direction placement="above">
+        <direction-type>
+          <octave-shift type="stop" size="8" number="1"/>
+          </direction-type>
+        </direction>
+      </measure>
+    </part>
+  </score-partwise>

--- a/test-scores/unit-tests/xml-export/008-pedal-line.xml
+++ b/test-scores/unit-tests/xml-export/008-pedal-line.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+   <part-list>
+      <score-part id="P1">
+         <part-name/>
+         </score-part>
+      </part-list>
+   <part id="P1">
+      <measure number="1">
+         <direction>
+            <direction-type>
+               <pedal type="start" line="yes" sign="no"/>
+               </direction-type>
+            </direction>
+         <note>
+            <pitch><step>G</step><octave>5</octave></pitch>
+            <duration>4</duration><type>16th</type>
+            </note>
+         <direction>
+            <direction-type>
+               <pedal type="stop" line="yes" sign="no"/>
+               </direction-type>
+            </direction>
+      </measure>
+   </part>
+</score-partwise>
+

--- a/test-scores/unit-tests/xml-export/009-pedal-line-marks.xml
+++ b/test-scores/unit-tests/xml-export/009-pedal-line-marks.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+   <part-list>
+      <score-part id="P1">
+         <part-name/>
+         </score-part>
+      </part-list>
+   <part id="P1">
+      <measure number="1">
+         <direction>
+            <direction-type>
+               <pedal type="start" line="yes" sign="yes"/>
+               </direction-type>
+            </direction>
+         <note>
+            <pitch><step>G</step><octave>5</octave></pitch>
+            <duration>4</duration><type>16th</type>
+            </note>
+         <direction>
+            <direction-type>
+               <pedal type="stop" line="yes" sign="yes"/>
+               </direction-type>
+            </direction>
+      </measure>
+   </part>
+</score-partwise>
+

--- a/test-scores/unit-tests/xml-export/010-pedal-lines.xml
+++ b/test-scores/unit-tests/xml-export/010-pedal-lines.xml
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name/>
+      </score-part>
+    </part-list>
+  <part id="P1">
+   <measure number="1">
+      <attributes>
+         <divisions>8</divisions>
+         <key>
+            <fifths>0</fifths>
+            <mode>major</mode>
+         </key>
+         <time>
+            <beats>6</beats>
+            <beat-type>8</beat-type>
+         </time>
+         <clef>
+            <sign>F</sign>
+            <line>4</line>
+         </clef>
+      </attributes>
+      <direction>
+         <direction-type>
+            <pedal line="yes" type="start"/>
+         </direction-type>
+      </direction>
+      <note>
+         <pitch>
+            <step>D</step>
+            <octave>3</octave>
+         </pitch>
+         <duration>4</duration>
+         <voice>3</voice>
+         <type>eighth</type>
+         <stem>down</stem>
+         <beam number="1">begin</beam>
+      </note>
+      <note>
+         <pitch>
+            <step>D</step>
+            <octave>3</octave>
+         </pitch>
+         <duration>4</duration>
+         <voice>3</voice>
+         <type>eighth</type>
+         <stem>down</stem>
+         <beam number="1">continue</beam>
+      </note>
+      <note>
+         <pitch>
+            <step>D</step>
+            <octave>3</octave>
+         </pitch>
+         <duration>4</duration>
+         <voice>3</voice>
+         <type>eighth</type>
+         <stem>down</stem>
+         <beam number="1">end</beam>
+      </note>
+      <direction>
+         <direction-type>
+            <pedal line="yes" type="change"/>
+         </direction-type>
+      </direction>
+      <note>
+         <pitch>
+            <step>D</step>
+            <octave>3</octave>
+         </pitch>
+         <duration>4</duration>
+         <voice>3</voice>
+         <type>eighth</type>
+         <stem>down</stem>
+         <beam number="1">begin</beam>
+      </note>
+      <note>
+         <pitch>
+            <step>D</step>
+            <octave>3</octave>
+         </pitch>
+         <duration>4</duration>
+         <voice>3</voice>
+         <type>eighth</type>
+         <stem>down</stem>
+         <beam number="1">continue</beam>
+      </note>
+      <direction>
+         <direction-type>
+            <pedal line="yes" type="discontinue"/>
+         </direction-type>
+      </direction>
+      <note>
+         <pitch>
+            <step>D</step>
+            <octave>3</octave>
+         </pitch>
+         <duration>4</duration>
+         <voice>3</voice>
+         <type>eighth</type>
+         <stem>down</stem>
+         <beam number="1">end</beam>
+      </note>
+   </measure>
+   <measure number="2">
+      <note>
+         <pitch>
+            <step>D</step>
+            <octave>3</octave>
+         </pitch>
+         <duration>4</duration>
+         <voice>3</voice>
+         <type>eighth</type>
+         <stem>down</stem>
+         <beam number="1">begin</beam>
+      </note>
+      <note>
+         <pitch>
+            <step>D</step>
+            <octave>3</octave>
+         </pitch>
+         <duration>4</duration>
+         <voice>3</voice>
+         <type>eighth</type>
+         <stem>down</stem>
+         <beam number="1">continue</beam>
+      </note>
+      <direction>
+         <direction-type>
+            <pedal line="yes" type="resume"/>
+         </direction-type>
+      </direction>
+      <note>
+         <pitch>
+            <step>D</step>
+            <octave>3</octave>
+         </pitch>
+         <duration>4</duration>
+         <voice>3</voice>
+         <type>eighth</type>
+         <stem>down</stem>
+         <beam number="1">end</beam>
+      </note>
+      <direction>
+         <direction-type>
+            <pedal line="yes" type="change"/>
+         </direction-type>
+      </direction>
+      <note>
+         <pitch>
+            <step>D</step>
+            <octave>3</octave>
+         </pitch>
+         <duration>4</duration>
+         <voice>3</voice>
+         <type>eighth</type>
+         <stem>down</stem>
+         <beam number="1">begin</beam>
+      </note>
+      <note>
+         <pitch>
+            <step>D</step>
+            <octave>3</octave>
+         </pitch>
+         <duration>4</duration>
+         <voice>3</voice>
+         <type>eighth</type>
+         <stem>down</stem>
+         <beam number="1">continue</beam>
+      </note>
+      <direction>
+         <direction-type>
+            <pedal line="yes" type="stop"/>
+         </direction-type>
+      </direction>
+      <note>
+         <pitch>
+            <step>D</step>
+            <octave>3</octave>
+         </pitch>
+         <duration>4</duration>
+         <voice>3</voice>
+         <type>eighth</type>
+         <stem>down</stem>
+         <beam number="1">end</beam>
+      </note>
+   </measure>
+    </part>
+  </score-partwise>

--- a/test-scores/unit-tests/xml-export/011-sound-midi-info.xml
+++ b/test-scores/unit-tests/xml-export/011-sound-midi-info.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+  <part-list>
+    <score-part id="P3">
+      <part-name>violino II</part-name>
+      <score-instrument id="P3-I4">
+        <instrument-name>Violin II</instrument-name>
+        <instrument-sound>strings.violin</instrument-sound>
+        <solo/>
+      </score-instrument>
+      <midi-instrument id="P3-I4">
+        <midi-channel>4</midi-channel>
+        <midi-program>41</midi-program>
+        <volume>80</volume>
+        <pan>0</pan>
+      </midi-instrument>
+    </score-part>
+  </part-list>
+  <!--=========================================================-->
+   <part id="P3">
+    <measure number="1">
+      <direction placement="above">
+        <direction-type>
+          <words>pizz.</words>
+        </direction-type>
+        <sound>
+          <midi-instrument id="P3-I4">
+            <midi-program>46</midi-program>
+          </midi-instrument>
+        </sound>
+      </direction>
+      <note>
+         <pitch><step>G</step><octave>5</octave></pitch>
+         <duration>4</duration><type>16th</type>
+         </note>
+      </measure>
+   </part>
+</score-partwise>
+

--- a/test-scores/unit-tests/xml-export/012-directive-moved-to-note.xml
+++ b/test-scores/unit-tests/xml-export/012-directive-moved-to-note.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name/>
+    </score-part>
+  </part-list>
+  <!--=========================================================-->
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>96</divisions>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <direction placement="below">
+        <direction-type>
+          <dynamics>
+            <p/>
+          </dynamics>
+        </direction-type>
+        <sound dynamics="54"/>
+      </direction>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>96</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/test-scores/unit-tests/xml-export/013-key-number.xml
+++ b/test-scores/unit-tests/xml-export/013-key-number.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+	<part-list>
+		<score-part id="P1">
+			<part-name/>
+		</score-part>
+	</part-list>
+	<part id="P1">
+		<measure number="1">
+			<attributes>
+				<divisions>96</divisions>
+				<key number="1"><fifths>1</fifths></key>
+				<key number="2"><fifths>3</fifths></key>
+				<staves>2</staves>
+				<clef number="1"><sign>G</sign><line>2</line></clef>
+				<clef number="2"><sign>F</sign><line>4</line></clef>
+			</attributes>
+		</measure>
+	</part>
+</score-partwise>


### PR DESCRIPTION
This PR improves the MusicXML exporter and now exports all the Lomse supported notation. And after this PR the exporter will be totally usable and should produce good results.

Two things are left for the next iteration:

1. Some details related to attributes, such as those common to most elements, such as `%font;` or `%print-style-align;`, are not exported and require a systematic review of all elements.

2. For finishing the exporter I would like first to develop some "round-trip" import-export automatic tests so that I can easily spot issues to fix.