### PR TITLE
Add script for MusicXML exporter visual round-trip tests

### DIFF
--- a/scripts/musicxml-template.txt
+++ b/scripts/musicxml-template.txt
@@ -1,0 +1,25 @@
+<html>
+<!-- $Updated: ${today} -->
+
+<head>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<title>Lomse. MusicXML exporter visual regression tests</title>
+<link rel="stylesheet" media="all" href="musicxml.css" type="text/css" />
+</head>
+<body>
+
+
+<div id="main">
+<a name='top'> </a>
+
+<h1>Lomse. MusicXML exporter visual regression tests</h1>
+<!--====================================================-->
+
+<p>Be aware a <b>'test passed' does not mean that the rendered image is correct</b>. It only means
+that the rendered image using the exported MusicXML file is not different from the result obtained
+using the original file or, being different, it has been accepted as correct, by a human reviewer.
+</p>
+<ul>
+<li>Lomse version used: ${lomse-version}</li>
+<li>Test date: ${date-time}</li>
+


### PR DESCRIPTION
This PR adds a script for MusicXML exporter visual tests. The required sub-projects [vregress](https://github.com/lenmus/vregress) and [lclt](https://github.com/lenmus/lclt) have been previously updated for supporting these tests.

The tests go as follows :

* First, Lomse loads a test score and is exported to MusicXML.
* The exported file is then imported and Lomse renders it. 
* Then the generated image is compared with the expected blessed image that is in folder `lomse/vregress/target`.
* If there are differences, the test script generates a GIF image, which flips between the two images, so that any differences are easily spotted.
* Finally, an html page is automatically created with the failures, in `lomse/zz_musicxml/musicxml.html`. Any failure means than the exported file does not contain all the information imported by Lomse from the original file and, thus, the rendition has differences.