### PR TITLE
Improve MusicXML exporter (2)

### DIFF
--- a/include/lomse_mxl_exporter.h
+++ b/include/lomse_mxl_exporter.h
@@ -102,7 +102,7 @@ public:
     int close_slur_and_get_number(ImoId slurId);
 
     //the main method
-    std::string get_source(ImoObj* pImo);
+    std::string get_source(ImoObj* pImo, ImoObj* pParent=nullptr);
     std::string get_source(AScore score);
 
     //auxiliary
@@ -134,7 +134,7 @@ public:
 
 
 protected:
-    MxlGenerator* new_generator(ImoObj* pImo);
+    MxlGenerator* new_generator(ImoObj* pImo, ImoObj* pParent);
 
 };
 

--- a/include/lomse_shape_beam.h
+++ b/include/lomse_shape_beam.h
@@ -49,12 +49,12 @@ public:
     UPoint get_outer_right_reference_point();
 
     //layout
-    inline bool is_cross_staff() { return (m_BeamFlags & k_cross_staff) != 0; }
-    inline bool has_chords() { return (m_BeamFlags & k_has_chords) != 0; }
-    inline bool get_staff() { return m_staff; }
-    inline bool is_beam_below() { return (m_BeamFlags & k_beam_below) != 0; }
-    inline bool is_beam_above() { return (m_BeamFlags & k_beam_above) != 0; }
-    inline bool is_double_stemmed_beam() { return (m_BeamFlags & k_beam_double_stemmed) != 0; }
+    inline bool is_cross_staff() const { return (m_BeamFlags & k_cross_staff) != 0; }
+    inline bool has_chords() const { return (m_BeamFlags & k_has_chords) != 0; }
+    inline int get_staff() const { return m_staff; }
+    inline bool is_beam_below() const { return (m_BeamFlags & k_beam_below) != 0; }
+    inline bool is_beam_above() const { return (m_BeamFlags & k_beam_above) != 0; }
+    inline bool is_double_stemmed_beam() const { return (m_BeamFlags & k_beam_double_stemmed) != 0; }
 
 
 protected:

--- a/include/private/lomse_internal_model_p.h
+++ b/include/private/lomse_internal_model_p.h
@@ -1596,6 +1596,7 @@ public:
 
     //items
     inline bool is_anonymous_block() { return m_objtype == k_imo_anonymous_block; }
+    inline bool is_arpeggio() { return m_objtype == k_imo_arpeggio; }
     inline bool is_articulation_symbol() { return m_objtype == k_imo_articulation_symbol; }
     inline bool is_articulation_line() { return m_objtype == k_imo_articulation_line; }
     inline bool is_attachments() { return m_objtype == k_imo_attachments; }
@@ -3579,15 +3580,15 @@ public:
 
     //check if contains inherited/default values or a new value has been set
     inline bool only_contains_default_values()  { return m_modified == 0L; }
-    inline bool is_port_modified() { return m_modified & k_modified_port; }
-    inline bool is_name_modified() { return m_modified & k_modified_name; }
-    inline bool is_bank_modified() { return m_modified & k_modified_bank; }
-    inline bool is_channel_modified() { return m_modified & k_modified_channel; }
-    inline bool is_program_modified() { return m_modified & k_modified_program; }
-    inline bool is_unpitched_modified() { return m_modified & k_modified_unpitched; }
-    inline bool is_volume_modified() { return m_modified & k_modified_volume; }
-    inline bool is_pan_modified() { return m_modified & k_modified_pan; }
-    inline bool is_elevation_modified() { return m_modified & k_modified_elevation; }
+    inline bool is_port_modified() { return (m_modified & k_modified_port) != 0; }
+    inline bool is_name_modified() { return (m_modified & k_modified_name) != 0; }
+    inline bool is_bank_modified() { return (m_modified & k_modified_bank) != 0; }
+    inline bool is_channel_modified() { return (m_modified & k_modified_channel) != 0; }
+    inline bool is_program_modified() { return (m_modified & k_modified_program) != 0; }
+    inline bool is_unpitched_modified() { return (m_modified & k_modified_unpitched) != 0; }
+    inline bool is_volume_modified() { return (m_modified & k_modified_volume) != 0; }
+    inline bool is_pan_modified() { return (m_modified & k_modified_pan) != 0; }
+    inline bool is_elevation_modified() { return (m_modified & k_modified_elevation) != 0; }
 
     //setters
     inline void set_score_instr_id(const std::string& value) { m_soundId = value; }
@@ -3779,6 +3780,20 @@ protected:
     USize   m_uPageSize;
     bool    m_fPortrait;
 
+    //to control if variables contain inherited/default values or a new value has been set
+    long m_modified = 0L;
+    enum {
+        k_modified_left_margin_odd =    0x00000001,
+        k_modified_left_margin_even =   0x00000002,
+        k_modified_top_margin_odd =     0x00000004,
+        k_modified_top_margin_even =    0x00000008,
+        k_modified_right_margin_odd =   0x00000010,
+        k_modified_right_margin_even =  0x00000020,
+        k_modified_bottom_margin_odd =  0x00000040,
+        k_modified_bottom_margin_even = 0x00000080,
+        k_modified_page_size =          0x00000100,
+    };
+
     friend class ImFactory;
     friend class ImoDocument;
     friend class ImoScore;
@@ -3786,33 +3801,55 @@ protected:
 
 public:
 
+    //info about modified values (values imported from source file or modified by the user)
+    inline bool is_page_layout_modified() { return m_modified != 0L; }
+    inline bool is_left_margin_odd_modified() { return (m_modified & k_modified_left_margin_odd) != 0; }
+    inline bool is_left_margin_even_modified() { return (m_modified & k_modified_left_margin_even) != 0; }
+    inline bool is_top_margin_odd_modified() { return (m_modified & k_modified_top_margin_odd) != 0; }
+    inline bool is_top_margin_even_modified() { return (m_modified & k_modified_top_margin_even) != 0; }
+    inline bool is_right_margin_odd_modified() { return (m_modified & k_modified_right_margin_odd) != 0; }
+    inline bool is_right_margin_even_modified() { return (m_modified & k_modified_right_margin_even) != 0; }
+    inline bool is_bottom_margin_odd_modified() { return (m_modified & k_modified_bottom_margin_odd) != 0; }
+    inline bool is_bottom_margin_even_modified() { return (m_modified & k_modified_bottom_margin_even) != 0; }
+    inline bool is_page_size_modified() { return (m_modified & k_modified_page_size) != 0; }
+    inline bool are_odd_page_margins_modified() { return (m_modified & k_modified_left_margin_odd) != 0
+                                                         || (m_modified & k_modified_top_margin_odd) != 0
+                                                         || (m_modified & k_modified_right_margin_odd) != 0
+                                                         || (m_modified & k_modified_bottom_margin_odd) != 0; }
+    inline bool are_even_page_margins_modified() { return (m_modified & k_modified_left_margin_even) != 0
+                                                          || (m_modified & k_modified_top_margin_even) != 0
+                                                          || (m_modified & k_modified_right_margin_even) != 0
+                                                          || (m_modified & k_modified_bottom_margin_even) != 0; }
+    inline bool are_page_margins_modified() { return are_odd_page_margins_modified()
+                                                     || are_even_page_margins_modified(); }
+
     //margins, odd pages
     inline LUnits get_left_margin_odd() { return m_uLeftMarginOdd; }
     inline LUnits get_right_margin_odd() { return m_uRightMarginOdd; }
     inline LUnits get_top_margin_odd() { return m_uTopMarginOdd; }
     inline LUnits get_bottom_margin_odd() { return m_uBottomMarginOdd; }
-    inline void set_left_margin_odd(LUnits value) { m_uLeftMarginOdd = value; }
-    inline void set_right_margin_odd(LUnits value) { m_uRightMarginOdd = value; }
-    inline void set_top_margin_odd(LUnits value) { m_uTopMarginOdd = value; }
-    inline void set_bottom_margin_odd(LUnits value) { m_uBottomMarginOdd = value; }
+    inline void set_left_margin_odd(LUnits value) { m_uLeftMarginOdd = value; m_modified |= k_modified_left_margin_odd; }
+    inline void set_right_margin_odd(LUnits value) { m_uRightMarginOdd = value; m_modified |= k_modified_right_margin_odd; }
+    inline void set_top_margin_odd(LUnits value) { m_uTopMarginOdd = value; m_modified |= k_modified_top_margin_odd; }
+    inline void set_bottom_margin_odd(LUnits value) { m_uBottomMarginOdd = value; m_modified |= k_modified_bottom_margin_odd; }
 
     //margins, even pages
     inline LUnits get_left_margin_even() { return m_uLeftMarginEven; }
     inline LUnits get_right_margin_even() { return m_uRightMarginEven; }
     inline LUnits get_top_margin_even() { return m_uTopMarginEven; }
     inline LUnits get_bottom_margin_even() { return m_uBottomMarginEven; }
-    inline void set_left_margin_even(LUnits value) { m_uLeftMarginEven = value; }
-    inline void set_right_margin_even(LUnits value) { m_uRightMarginEven = value; }
-    inline void set_top_margin_even(LUnits value) { m_uTopMarginEven = value; }
-    inline void set_bottom_margin_even(LUnits value) { m_uBottomMarginEven = value; }
+    inline void set_left_margin_even(LUnits value) { m_uLeftMarginEven = value; m_modified |= k_modified_left_margin_even; }
+    inline void set_right_margin_even(LUnits value) { m_uRightMarginEven = value; m_modified |= k_modified_right_margin_even; }
+    inline void set_top_margin_even(LUnits value) { m_uTopMarginEven = value; m_modified |= k_modified_top_margin_even; }
+    inline void set_bottom_margin_even(LUnits value) { m_uBottomMarginEven = value; m_modified |= k_modified_bottom_margin_even; }
 
     //page size
     inline USize get_page_size() { return m_uPageSize; }
     inline LUnits get_page_width() { return m_uPageSize.width; }
     inline LUnits get_page_height() { return m_uPageSize.height; }
-    inline void set_page_size(USize uPageSize) { m_uPageSize = uPageSize; }
-    inline void set_page_width(LUnits value) { m_uPageSize.width = value; }
-    inline void set_page_height(LUnits value) { m_uPageSize.height = value; }
+    inline void set_page_size(USize uPageSize) { m_uPageSize = uPageSize; m_modified |= k_modified_page_size; }
+    inline void set_page_width(LUnits value) { m_uPageSize.width = value; m_modified |= k_modified_page_size; }
+    inline void set_page_height(LUnits value) { m_uPageSize.height = value; m_modified |= k_modified_page_size; }
 
     //page orientation
     inline bool is_portrait() { return m_fPortrait; }
@@ -4456,7 +4493,7 @@ public:
     ImoFermata& operator= (ImoFermata&&) = delete;
 
     enum { k_normal, k_short, k_long, k_henze_short, k_henze_long,
-           k_very_short, k_very_long,
+           k_very_short, k_very_long, k_curlew,
          };
 
     //getters
@@ -6107,11 +6144,27 @@ protected:
     LUnits   m_systemDistance;
     LUnits   m_topSystemDistance;
 
+    //to control if variables contain inherited/default values or a new value has been set
+    long m_modified = 0L;
+    enum {
+        k_modified_left_margin =    0x00000001,
+        k_modified_right_margin =   0x00000002,
+        k_modified_distance =       0x00000004,
+        k_modified_top_distance =   0x00000008,
+    };
+
     friend class ImFactory;
     friend class ImoScore;
     ImoSystemInfo();
 
 public:
+
+    //info about values modified (values imported from source file or modified by the user)
+    inline bool is_system_layout_modified() { return m_modified != 0L; }
+    inline bool is_left_margin_modified() { return (m_modified & k_modified_left_margin) != 0; }
+    inline bool is_right_margin_modified() { return (m_modified & k_modified_right_margin) != 0; }
+    inline bool is_system_distance_modified() { return (m_modified & k_modified_distance) != 0; }
+    inline bool is_top_system_distance_modified() { return (m_modified & k_modified_top_distance) != 0; }
 
     //getters
     inline bool is_first() { return m_fFirst; }
@@ -6122,17 +6175,18 @@ public:
 
     //setters
     inline void set_first(bool fValue) { m_fFirst = fValue; }
-    inline void set_left_margin(LUnits rValue) { m_leftMargin = rValue; }
-    inline void set_right_margin(LUnits rValue) { m_rightMargin = rValue; }
-    inline void set_system_distance(LUnits rValue) { m_systemDistance = rValue; }
-    inline void set_top_system_distance(LUnits rValue) { m_topSystemDistance = rValue; }
+    inline void set_left_margin(LUnits rValue) { m_leftMargin = rValue; m_modified |= k_modified_left_margin; }
+    inline void set_right_margin(LUnits rValue) { m_rightMargin = rValue; m_modified |= k_modified_right_margin; }
+    inline void set_system_distance(LUnits rValue) { m_systemDistance = rValue; m_modified |= k_modified_distance; }
+    inline void set_top_system_distance(LUnits rValue) { m_topSystemDistance = rValue; m_modified |= k_modified_top_distance; }
 };
 
 //---------------------------------------------------------------------------------------
 class ImoScore : public ImoBlockLevelObj      //ImoBlocksContainer
 {
 protected:
-    int m_version = 0;                      //LDP source file version
+    int m_version = 0;          //LDP source file version
+    int m_sourceFormat = 0;     //original source file format ; value from  enum
     int m_accidentalsModel = k_only_notation_provided;  //how pitch//accidentals are initialized
     ColStaffObjs* m_pColStaffObjs = nullptr;
     SoundEventsTable* m_pMidiTable = nullptr;
@@ -6142,6 +6196,12 @@ protected:
     std::list<ImoScoreTitle*> m_titles;     //titles are added as children nodes. This list is
                                             //  kept for quick access. Do not delete in destructor.
     std::map<string, ImoStyle*> m_nameToStyle;
+
+    //to control if variables contain inherited/default values or a new value has been set
+    long m_modified = 0L;
+    enum {
+        k_modified_scaling =    0x00000001,     //global scaling has been modified
+    };
 
     friend class ImFactory;
     ImoScore(Document* pDoc);
@@ -6167,16 +6227,29 @@ public:
     void set_staffobjs_table(ColStaffObjs* pColStaffObjs);
     void set_global_scaling(float millimeters, float tenths);
     inline void set_accidentals_model(int value) { m_accidentalsModel = value; }
+    inline void set_source_format(int format) { m_sourceFormat = format; }
+
+    enum { k_empty=0, k_ldp, k_musicxml, k_mnx, };
 
     //getters and info
     std::string get_version_string();
-    inline int get_version_major() { return m_version/100; }
-    inline int get_version_minor() { return m_version % 100; }
-    inline int get_version_number() { return m_version; }
-    inline int get_accidentals_model() { return m_accidentalsModel; }
-    inline ColStaffObjs* get_staffobjs_table() { return m_pColStaffObjs; }
+    inline int get_version_major() const { return m_version/100; }
+    inline int get_version_minor() const { return m_version % 100; }
+    inline int get_version_number() const { return m_version; }
+    inline int get_accidentals_model() const { return m_accidentalsModel; }
+    inline ColStaffObjs* get_staffobjs_table() const { return m_pColStaffObjs; }
     SoundEventsTable* get_midi_table();
-    inline LUnits tenths_to_logical(Tenths value) { return m_scaling * value; }
+    inline bool was_created_from_musicxml() const { return m_sourceFormat == k_musicxml; }
+    inline bool was_created_from_ldp() const { return m_sourceFormat == k_ldp; }
+    inline bool was_created_from_mnx() const { return m_sourceFormat == k_mnx; }
+    inline bool was_created_from_scratch() const { return m_sourceFormat == k_empty; }
+
+    //scaling
+    inline LUnits tenths_to_logical(Tenths value) const { return value * m_scaling; }
+    inline Tenths logical_to_tenths(LUnits value) const { return value / m_scaling; }
+    inline float get_global_scaling() const { return m_scaling; }
+    inline bool is_global_scaling_modified() { return (m_modified & k_modified_scaling) != 0; }
+
 
     //required by Visitable parent class
     void accept_visitor(BaseVisitor& v) override;
@@ -6431,6 +6504,7 @@ protected:
     bool m_fTablature = false;      //This staff is for tablature notation
     double m_notationScaling = 1.0;
 
+
     friend class ImFactory;
     friend class ImoInstrument;
     ImoStaffInfo(int numStaff=0, int lines=5, int type=k_staff_regular,
@@ -6453,11 +6527,16 @@ public:
            k_staff_alternate,
          };
 
+
+    bool has_default_values() const;
+    bool is_staff_size_modified() const { return m_uSpacing != LOMSE_STAFF_LINE_SPACING; }
+
     //staff number
     inline int get_staff_number() const { return m_numStaff; }
     inline void set_staff_number(int num) { m_numStaff = num; }
 
     //staff type
+    //TODO: Lomse accepts this but doesn't use it. Only for MusicXML import/export
     inline int get_staff_type() const { return m_staffType; }
     inline void set_staff_type(int type) { m_staffType = type; }
 
@@ -6469,6 +6548,7 @@ public:
     inline LUnits get_line_spacing() const { return m_uSpacing; }
     inline void set_line_spacing(LUnits uSpacing) { m_uSpacing = uSpacing; }
     LUnits get_height() const;
+    double get_applied_spacing_factor() const;
 
     //scaling
     inline double get_notation_scaling() const { return m_notationScaling; }

--- a/src/internal_model/lomse_internal_model.cpp
+++ b/src/internal_model/lomse_internal_model.cpp
@@ -3781,7 +3781,10 @@ void ImoScore::set_staffobjs_table(ColStaffObjs* pColStaffObjs)
 void ImoScore::set_global_scaling(float millimeters, float tenths)
 {
     if (millimeters > 0.0f && tenths > 0.0f)
+    {
         m_scaling = (millimeters * 100.0f) / tenths;
+        m_modified |= k_modified_scaling;
+    }
 }
 
 //---------------------------------------------------------------------------------------
@@ -5200,6 +5203,22 @@ bool ImoStaffInfo::is_line_visible(int iLine) const
         case 4:     return iLine <= 3;
         default:    return true;
     }
+}
+
+//---------------------------------------------------------------------------------------
+bool ImoStaffInfo::has_default_values() const
+{
+    return (m_nNumLines == 5
+            && m_staffType == k_staff_regular
+            && m_uSpacing == LOMSE_STAFF_LINE_SPACING
+            && m_uLineThickness == LOMSE_STAFF_LINE_THICKNESS
+            && m_uMarging == LOMSE_STAFF_TOP_MARGIN );
+}
+
+//---------------------------------------------------------------------------------------
+double ImoStaffInfo::get_applied_spacing_factor() const
+{
+    return double(m_uSpacing) / double(LOMSE_STAFF_LINE_SPACING);
 }
 
 

--- a/src/parser/ldp/lomse_ldp_analyser.cpp
+++ b/src/parser/ldp/lomse_ldp_analyser.cpp
@@ -4832,6 +4832,8 @@ protected:
         {
             //vers. 1.5, 1.6, 1.7, 2.0. Default values are ok
         }
+
+        pScore->set_source_format(ImoScore::k_ldp);
     }
 
 };

--- a/src/parser/mnx/lomse_mnx_analyser.cpp
+++ b/src/parser/mnx/lomse_mnx_analyser.cpp
@@ -3318,6 +3318,7 @@ protected:
         m_pAnchor = pScore;
 
         pScore->set_version(200);   //2.0
+        pScore->set_source_format(ImoScore::k_mnx);
         pScore->add_required_text_styles();
 
         return pScore;
@@ -3899,24 +3900,6 @@ public:
         set_result( LOMSE_NEW ImoData(pRest) );
         return true;    //success
     }
-};
-
-//@--------------------------------------------------------------------------------------
-//@ <score>
-//
-class ScoreMnxAnalyser : public MnxElementAnalyser
-{
-public:
-    ScoreMnxAnalyser(MnxAnalyser* pAnalyser, ostream& reporter,
-                     LibraryScope& libraryScope, ImoObj* pAnchor)
-        : MnxElementAnalyser(pAnalyser, reporter, libraryScope, pAnchor) {}
-
-    bool do_analysis() override
-    {
-        return false;   //failure
-    }
-
-protected:
 };
 
 //@--------------------------------------------------------------------------------------
@@ -5259,7 +5242,6 @@ MnxElementAnalyser* MnxAnalyser::new_analyser(const string& name, ImoObj* pAncho
         case k_mnx_tag_part_name:           return LOMSE_NEW PartNameMnxAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_mnx_tag_repeat:              return LOMSE_NEW RepeatMnxAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_mnx_tag_rest:                return LOMSE_NEW RestMnxAnalyser(this, m_reporter, m_libraryScope, pAnchor);
-        case k_mnx_tag_score:               return LOMSE_NEW ScoreMnxAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_mnx_tag_segno:               return LOMSE_NEW SegnoMnxAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_mnx_tag_sequence:            return LOMSE_NEW SequenceMnxAnalyser(this, m_reporter, m_libraryScope, pAnchor);
         case k_mnx_tag_sequence_content:    return LOMSE_NEW SequenceContentMnxAnalyser(this, m_reporter, m_libraryScope, pAnchor);

--- a/src/tests/lomse_test_ldp_analyser.cpp
+++ b/src/tests/lomse_test_ldp_analyser.cpp
@@ -72,6 +72,23 @@ public:
         return UnitTest::CurrentTest::Details()->testName;
     }
 
+    inline void failure_header()
+    {
+        cout << endl << "*** Failure in " << test_name() << ":" << endl;
+    }
+
+    bool check_errormsg(const stringstream& msg, const stringstream& expected)
+    {
+        if (msg.str() != expected.str())
+        {
+            failure_header();
+            cout << "     msg=[" << msg.str() << "]" << endl;
+            cout << "expected=[" << expected.str() << "]" << endl;
+            return false;
+        }
+        return true;
+    }
+
 };
 
 
@@ -95,7 +112,9 @@ SUITE(LdpAnalyserTest)
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
         CHECK( pRoot != nullptr );
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
+        CHECK( check_errormsg(errormsg, expected) );
+
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -115,10 +134,8 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
         //cout << score->get_root()->to_string() << endl;
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
         CHECK( pRoot != nullptr );
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -137,10 +154,8 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
         CHECK( pRoot != nullptr );
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -180,9 +195,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
         //cout << score->get_root()->to_string() << endl;
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         CHECK( pScore != nullptr );
         CHECK( pScore && pScore->get_num_instruments() == 0 );
@@ -203,9 +216,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         CHECK( pScore != nullptr );
         //CHECK( pScore && pScore->get_num_instruments() == 1 );
@@ -226,9 +237,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         CHECK( pScore != nullptr );
 
@@ -250,7 +259,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         CHECK( pScore != nullptr );
         if (pScore)
@@ -259,6 +268,29 @@ SUITE(LdpAnalyserTest)
             ImoInstrument* pInstr = pScore->get_instrument(1);
             CHECK( pScore->get_instr_number_for(pInstr) == 1 );
         }
+
+        delete tree->get_root();
+        // coverity[check_after_deref]
+        if (pRoot && !pRoot->is_document()) delete pRoot;
+    }
+
+    TEST_FIXTURE(LdpAnalyserTestFixture, score_09)
+    {
+        //@09. score. source format is ldp
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        LdpParser parser(errormsg, m_libraryScope.ldp_factory());
+        stringstream expected;
+        parser.parse_text("(score (vers 2.0)(instrument (musicData)))");
+        LdpTree* tree = parser.get_ldp_tree();
+        LdpAnalyser a(errormsg, m_libraryScope, &doc);
+        ImoObj* pRoot = a.analyse_tree(tree, "string:");
+
+        CHECK( check_errormsg(errormsg, expected) );
+        ImoScore* pScore = static_cast<ImoScore*>( pRoot );
+        CHECK( pScore != nullptr );
+        CHECK( pScore && pScore->was_created_from_ldp() );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -282,7 +314,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_articulation() == true );
         ImoArticulationSymbol* pImo = dynamic_cast<ImoArticulationSymbol*>( pRoot );
         CHECK( pImo != nullptr );
@@ -309,7 +341,7 @@ SUITE(LdpAnalyserTest)
 //        ImoObj* pRoot = a.analyse_tree(tree, "string:");
 ////        cout << "[" << errormsg.str() << "]" << endl;
 ////        cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
+//        CHECK( check_errormsg(errormsg, expected) );
 //        ImoArticulationSymbol* pImo = dynamic_cast<ImoArticulationSymbol*>( pRoot );
 //        CHECK( pImo != nullptr );
 //        CHECK( pImo && pImo->get_placement() == k_placement_default );
@@ -336,7 +368,7 @@ SUITE(LdpAnalyserTest)
 //        ImoObj* pRoot = a.analyse_tree(tree, "string:");
 ////        cout << "[" << errormsg.str() << "]" << endl;
 ////        cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
+//        CHECK( check_errormsg(errormsg, expected) );
 //        ImoArticulationSymbol* pImo = dynamic_cast<ImoArticulationSymbol*>( pRoot );
 //        CHECK( pImo != nullptr );
 //        CHECK( pImo && pImo->get_placement() == k_placement_above );
@@ -362,7 +394,7 @@ SUITE(LdpAnalyserTest)
 //        ImoObj* pRoot = a.analyse_tree(tree, "string:");
 ////        cout << "[" << errormsg.str() << "]" << endl;
 ////        cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
+//        CHECK( check_errormsg(errormsg, expected) );
 //        ImoArticulationSymbol* pImo = dynamic_cast<ImoArticulationSymbol*>( pRoot );
 //        CHECK( pImo != nullptr );
 //        CHECK( pImo && pImo->get_placement() == k_placement_above );
@@ -400,7 +432,7 @@ SUITE(LdpAnalyserTest)
 //        CHECK( pImo && pImo->get_user_location_y() == 0.0f );
 ////        cout << "[" << errormsg.str() << "]" << endl;
 ////        cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
+//        CHECK( check_errormsg(errormsg, expected) );
 //
 //        delete tree->get_root();
 //        // coverity[check_after_deref]
@@ -459,9 +491,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_barline() == true );
         ImoBarline* pBarline = dynamic_cast<ImoBarline*>( pRoot );
         CHECK( pBarline != nullptr );
@@ -520,9 +550,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoBarline* pBarline = dynamic_cast<ImoBarline*>( pRoot );
         CHECK( pBarline != nullptr );
         CHECK( pBarline && pBarline->get_type() == k_barline_double );
@@ -623,9 +651,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoBarline* pBarline = dynamic_cast<ImoBarline*>( pRoot );
         CHECK( pBarline != nullptr );
         CHECK( pBarline && pBarline->get_type() == k_barline_double );
@@ -649,9 +675,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoBarline* pBarline = dynamic_cast<ImoBarline*>( pRoot );
         CHECK( pBarline != nullptr );
         CHECK( pBarline && pBarline->get_type() == k_barline_double );
@@ -675,9 +699,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoBarline* pBarline = dynamic_cast<ImoBarline*>( pRoot );
         CHECK( pBarline != nullptr );
         CHECK( pBarline && pBarline->get_type() == k_barline_double );
@@ -720,9 +742,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
         CHECK( pRoot->is_music_data() == true );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -740,9 +760,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -760,9 +778,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -783,7 +799,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -804,7 +820,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_music_data() == true );
         ImoMusicData* pImo = static_cast<ImoMusicData*>( pRoot );
         CHECK( pImo && pImo->get_id() == 12L );
@@ -825,9 +841,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoInstrument* pInstr = static_cast<ImoInstrument*>( pRoot );
         CHECK( pInstr != nullptr );
         if (pInstr)
@@ -856,9 +870,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
         CHECK( pRoot->is_note() == true );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->get_notated_accidentals() == k_sharp );
@@ -887,9 +899,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->get_notated_accidentals() == k_no_accidentals );
@@ -914,9 +924,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->get_notated_accidentals() == k_no_accidentals );
@@ -941,9 +949,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->get_notated_accidentals() == k_no_accidentals );
@@ -968,9 +974,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->get_notated_accidentals() == k_no_accidentals );
@@ -996,9 +1000,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->get_staff() == 0 );
@@ -1022,9 +1024,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->get_notated_accidentals() == k_no_accidentals );
@@ -1051,9 +1051,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->get_voice() == 1 );
@@ -1080,7 +1078,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_note() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -1101,9 +1099,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->get_notated_accidentals() == k_no_accidentals );
@@ -1135,9 +1131,7 @@ SUITE(LdpAnalyserTest)
         CHECK( pNote && pNote->is_tied_next() == false );
         CHECK( pNote && pNote->is_tied_prev() == false );
         delete pAnalyser;
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -1157,9 +1151,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pNote && pNote->is_tied_next() == false );
         CHECK( pNote && pNote->is_tied_prev() == false );
 
@@ -1180,9 +1172,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
@@ -1217,9 +1207,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
@@ -1253,9 +1241,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
@@ -1286,9 +1272,7 @@ SUITE(LdpAnalyserTest)
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->is_stem_up() == true );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -1309,9 +1293,7 @@ SUITE(LdpAnalyserTest)
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->is_stem_down() == true );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -1332,9 +1314,7 @@ SUITE(LdpAnalyserTest)
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->is_stem_default() == true );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pNote && pNote->get_note_type() == k_eighth );
         CHECK( pNote && pNote->get_octave() == 4 );
         CHECK( pNote && pNote->get_step() == k_step_C );
@@ -1357,9 +1337,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
@@ -1397,7 +1375,7 @@ SUITE(LdpAnalyserTest)
         CHECK( pRoot->is_note() == true );
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->get_notated_accidentals() == k_sharp );
@@ -1427,9 +1405,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
@@ -1478,9 +1454,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
@@ -1514,9 +1488,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
@@ -1554,9 +1526,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
@@ -1596,9 +1566,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
@@ -1656,9 +1624,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
         CHECK( pRoot->is_tie_dto() == true );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoTieDto* pInfo = dynamic_cast<ImoTieDto*>( pRoot );
         CHECK( pInfo != nullptr );
         CHECK( pInfo && pInfo->is_start() == false );
@@ -1682,9 +1648,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoTieDto* pInfo = dynamic_cast<ImoTieDto*>( pRoot );
         CHECK( pInfo != nullptr );
         CHECK( pInfo && pInfo->is_start() == true );
@@ -1708,9 +1672,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoTieDto* pInfo = dynamic_cast<ImoTieDto*>( pRoot );
         CHECK( pInfo != nullptr );
         CHECK( pInfo && pInfo->is_start() == true );
@@ -1743,9 +1705,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -1764,9 +1724,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
         CHECK( pRoot->is_tie_dto() == true );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoTieDto* pInfo = dynamic_cast<ImoTieDto*>( pRoot );
         CHECK( pInfo != nullptr );
         CHECK( pInfo && pInfo->is_start() == false );
@@ -1793,9 +1751,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_bezier_info() == true );
         ImoBezierInfo* pBezier = dynamic_cast<ImoBezierInfo*>( pRoot );
         CHECK( pBezier != nullptr );
@@ -1833,9 +1789,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoBezierInfo* pBezier = dynamic_cast<ImoBezierInfo*>( pRoot );
         CHECK( pBezier != nullptr );
         //cout << "start.x = " << pBezier->get_point(ImoBezierInfo::k_start).x << endl;
@@ -1871,9 +1825,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_bezier_info() == true );
         ImoBezierInfo* pBezier = dynamic_cast<ImoBezierInfo*>( pRoot );
         CHECK( pBezier != nullptr );
@@ -1913,9 +1865,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
         CHECK( pRoot->is_slur_dto() == true );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoSlurDto* pInfo = dynamic_cast<ImoSlurDto*>( pRoot );
         CHECK( pInfo != nullptr );
         CHECK( pInfo && pInfo->is_start() == false );
@@ -1939,9 +1889,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoSlurDto* pInfo = dynamic_cast<ImoSlurDto*>( pRoot );
         CHECK( pInfo != nullptr );
         CHECK( pInfo && pInfo->is_start() == true );
@@ -1967,7 +1915,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoSlurDto* pInfo = dynamic_cast<ImoSlurDto*>( pRoot );
         CHECK( pInfo != nullptr );
         //TODO
@@ -1992,9 +1940,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoSlurDto* pInfo = dynamic_cast<ImoSlurDto*>( pRoot );
         CHECK( pInfo != nullptr );
         CHECK( pInfo && pInfo->is_start() == true );
@@ -2028,9 +1974,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
         CHECK( pRoot->is_slur_dto() == true );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoSlurDto* pInfo = dynamic_cast<ImoSlurDto*>( pRoot );
         CHECK( pInfo != nullptr );
         CHECK( pInfo && pInfo->is_start() == true );
@@ -2055,9 +1999,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -2076,9 +2018,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
@@ -2116,9 +2056,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_rest() == true );
         ImoRest* pRest = dynamic_cast<ImoRest*>( pRoot );
         CHECK( pRest != nullptr );
@@ -2142,9 +2080,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoRest* pRest = dynamic_cast<ImoRest*>( pRoot );
         CHECK( pRest != nullptr );
         CHECK( pRest->get_dots() == 1 );
@@ -2167,9 +2103,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoRest* pRest = dynamic_cast<ImoRest*>( pRoot );
         CHECK( pRest != nullptr );
         CHECK( pRest->get_dots() == 1 );
@@ -2192,9 +2126,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         LdpTree::iterator it = tree->begin();
         ++it;
         ImoRest* pRest = dynamic_cast<ImoRest*>( (*it)->get_imo() );
@@ -2238,7 +2170,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_rest() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -2259,9 +2191,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoRest* pRest = dynamic_cast<ImoRest*>( pRoot );
         CHECK( pRest != nullptr );
         CHECK( pRest->get_dots() == 1 );
@@ -2288,9 +2218,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_fermata() == true );
         ImoFermata* pFerm = static_cast<ImoFermata*>( pRoot );
         CHECK( pFerm != nullptr );
@@ -2316,7 +2244,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_fermata() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -2341,7 +2269,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_fermata() == true );
         ImoFermata* pFerm = static_cast<ImoFermata*>( pRoot );
         CHECK( pFerm != nullptr );
@@ -2367,7 +2295,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_fermata() == true );
         ImoFermata* pFerm = static_cast<ImoFermata*>( pRoot );
         CHECK( pFerm != nullptr );
@@ -2394,7 +2322,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_fermata() == true );
         ImoFermata* pFerm = static_cast<ImoFermata*>( pRoot );
         CHECK( pFerm != nullptr );
@@ -2421,7 +2349,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoFermata* pFerm = static_cast<ImoFermata*>( pRoot );
         CHECK( pFerm != nullptr );
         CHECK( pFerm->get_placement() == k_placement_default );
@@ -2444,9 +2372,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoFermata* pFerm = static_cast<ImoFermata*>( pRoot );
         CHECK( pFerm != nullptr );
         CHECK( pFerm->get_placement() == k_placement_above );
@@ -2471,9 +2397,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoFermata* pFerm = static_cast<ImoFermata*>( pRoot );
         CHECK( pFerm != nullptr );
         CHECK( pFerm->get_placement() == k_placement_above );
@@ -2507,9 +2431,7 @@ SUITE(LdpAnalyserTest)
         CHECK( pFerm->get_placement() == k_placement_above );
         CHECK( pFerm->get_user_location_x() == 70.0f );
         CHECK( pFerm->get_user_location_y() == 0.0f );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -2533,7 +2455,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_dynamics_mark() == true );
         ImoDynamicsMark* pImo = static_cast<ImoDynamicsMark*>( pRoot );
         CHECK( pImo != nullptr );
@@ -2560,7 +2482,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoDynamicsMark* pImo = static_cast<ImoDynamicsMark*>( pRoot );
         CHECK( pImo != nullptr );
         CHECK( pImo && pImo->get_placement() == k_placement_default );
@@ -2587,7 +2509,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoDynamicsMark* pImo = static_cast<ImoDynamicsMark*>( pRoot );
         CHECK( pImo != nullptr );
         CHECK( pImo && pImo->get_placement() == k_placement_above );
@@ -2613,7 +2535,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoDynamicsMark* pImo = static_cast<ImoDynamicsMark*>( pRoot );
         CHECK( pImo != nullptr );
         CHECK( pImo && pImo->get_placement() == k_placement_above );
@@ -2651,7 +2573,7 @@ SUITE(LdpAnalyserTest)
         CHECK( pImo && pImo->get_user_location_y() == 0.0f );
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -2672,9 +2594,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_go_back_fwd() == true );
         ImoGoBackFwd* pGBF = static_cast<ImoGoBackFwd*>( pRoot );
         CHECK( pGBF != nullptr );
@@ -2698,7 +2618,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_go_back_fwd() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -2719,9 +2639,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -2739,9 +2657,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoGoBackFwd* pGBF = static_cast<ImoGoBackFwd*>( pRoot );
         CHECK( pGBF != nullptr );
         CHECK( !pGBF->is_to_start() );
@@ -2764,9 +2680,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoGoBackFwd* pGBF = static_cast<ImoGoBackFwd*>( pRoot );
         CHECK( pGBF != nullptr );
         CHECK( pGBF->is_to_end() );
@@ -2789,7 +2703,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_go_back_fwd() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -2810,9 +2724,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -2830,9 +2742,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoGoBackFwd* pGBF = static_cast<ImoGoBackFwd*>( pRoot );
         CHECK( pGBF != nullptr );
         CHECK( !pGBF->is_to_start() );
@@ -2855,9 +2765,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoGoBackFwd* pGBF = static_cast<ImoGoBackFwd*>( pRoot );
         CHECK( pGBF != nullptr );
         CHECK( !pGBF->is_to_start() );
@@ -2880,9 +2788,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -2900,9 +2806,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoGoBackFwd* pGBF = static_cast<ImoGoBackFwd*>( pRoot );
         CHECK( pGBF != nullptr );
         CHECK( !pGBF->is_to_start() );
@@ -2929,9 +2833,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         a.set_score_version("2.0");
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_rest() == true );
         ImoRest* pImo = static_cast<ImoRest*>( pRoot );
         CHECK( pImo && pImo->is_go_fwd() == true );
@@ -2957,9 +2859,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_clef() == true );
         ImoClef* pClef = static_cast<ImoClef*>( pRoot );
         CHECK( pClef != nullptr );
@@ -2983,7 +2883,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_clef() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -3004,9 +2904,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoClef* pClef = static_cast<ImoClef*>( pRoot );
         CHECK( pClef != nullptr );
         CHECK( pClef->get_clef_type() == k_clef_G2 );
@@ -3116,7 +3014,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pClef != nullptr );
         CHECK( pClef->get_clef_type() == k_clef_C2 );
         CHECK( pClef->get_user_location_x() == 0.0f );
@@ -3144,9 +3042,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
         CHECK( pRoot->is_instrument() == true );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoInstrument* pInstrument = static_cast<ImoInstrument*>( pRoot );
         CHECK( pInstrument != nullptr );
         //cout << "num.staves=" << pInstrument->get_num_staves() << endl;
@@ -3170,7 +3066,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_instrument() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -3191,9 +3087,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoInstrument* pInstrument = static_cast<ImoInstrument*>( pRoot );
         CHECK( pInstrument != nullptr );
         //cout << "num.staves=" << pInstrument->get_num_staves() << endl;
@@ -3215,9 +3109,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_score() == true );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         CHECK( pScore != nullptr );
@@ -3243,9 +3135,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoInstrument* pInstr = static_cast<ImoInstrument*>( pRoot );
         CHECK( pInstr != nullptr );
@@ -3270,9 +3160,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoInstrument* pInstr = static_cast<ImoInstrument*>( pRoot );
         CHECK( pInstr != nullptr );
@@ -3297,9 +3185,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoInstrument* pInstr = static_cast<ImoInstrument*>( pRoot );
         CHECK( pInstr != nullptr );
@@ -3324,9 +3210,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoSoundInfo* pInfo = static_cast<ImoSoundInfo*>( pRoot );
         CHECK( pInfo == nullptr );
@@ -3348,9 +3232,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoSoundInfo* pInfo = static_cast<ImoSoundInfo*>( pRoot );
         CHECK( pInfo == nullptr );
@@ -3372,9 +3254,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_sound_info() == true );
         ImoSoundInfo* pInfo = static_cast<ImoSoundInfo*>( pRoot );
@@ -3400,9 +3280,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoSoundInfo* pInfo = static_cast<ImoSoundInfo*>( pRoot );
         CHECK( pInfo != nullptr );
@@ -3427,9 +3305,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoSoundInfo* pInfo = static_cast<ImoSoundInfo*>( pRoot );
         CHECK( pInfo != nullptr );
@@ -3454,9 +3330,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoInstrument* pInstr = static_cast<ImoInstrument*>( pRoot );
         CHECK( pInstr != nullptr );
@@ -3489,9 +3363,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
         CHECK( pRoot->is_key_signature() == true );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoKeySignature* pKeySignature = static_cast<ImoKeySignature*>( pRoot );
         CHECK( pKeySignature != nullptr );
         CHECK( pKeySignature->get_key_type() == k_key_G );
@@ -3515,7 +3387,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_key_signature() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -3536,9 +3408,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoKeySignature* pKeySignature = static_cast<ImoKeySignature*>( pRoot );
         CHECK( pKeySignature != nullptr );
         CHECK( pKeySignature->get_key_type() == k_key_C );
@@ -3607,7 +3477,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_lyric() == true );
         ImoLyric* pImo = static_cast<ImoLyric*>( pRoot );
         CHECK( pImo != nullptr );
@@ -3655,7 +3525,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_lyric() == true );
         ImoLyric* pImo = static_cast<ImoLyric*>( pRoot );
         CHECK( pImo != nullptr );
@@ -3681,7 +3551,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_lyric() == true );
         ImoLyric* pImo = static_cast<ImoLyric*>( pRoot );
         CHECK( pImo != nullptr );
@@ -3735,7 +3605,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot == nullptr );
 
         delete tree->get_root();
@@ -3758,7 +3628,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_lyric() == true );
         ImoLyric* pImo = static_cast<ImoLyric*>( pRoot );
         CHECK( pImo != nullptr );
@@ -3805,7 +3675,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_lyric() == true );
         ImoLyric* pImo = static_cast<ImoLyric*>( pRoot );
         CHECK( pImo != nullptr );
@@ -3852,7 +3722,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_lyric() == true );
         ImoLyric* pImo = static_cast<ImoLyric*>( pRoot );
         CHECK( pImo != nullptr );
@@ -3901,7 +3771,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         ImoMusicData* pMusic = pInstr->get_musicdata();
@@ -3941,7 +3811,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         ImoMusicData* pMusic = pInstr->get_musicdata();
@@ -4008,7 +3878,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         ImoMusicData* pMusic = pInstr->get_musicdata();
@@ -4092,7 +3962,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         ImoMusicData* pMusic = pInstr->get_musicdata();
@@ -4175,7 +4045,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         ImoMusicData* pMusic = pInstr->get_musicdata();
@@ -4232,7 +4102,7 @@ SUITE(LdpAnalyserTest)
 //        cout << test_name() << endl;
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         ImoMusicData* pMusic = pInstr->get_musicdata();
@@ -4263,9 +4133,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pRoot);
         CHECK( pMM != nullptr );
         CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
@@ -4292,7 +4160,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pRoot);
         CHECK( pMM->get_id() == 10L );
 
@@ -4312,9 +4180,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pRoot);
         CHECK( pMM != nullptr );
         CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
@@ -4338,9 +4204,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pRoot);
         CHECK( pMM != nullptr );
         CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_note_value );
@@ -4366,9 +4230,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pRoot);
         CHECK( pMM != nullptr );
         CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_note_note );
@@ -4395,9 +4257,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pRoot);
         CHECK( pMM != nullptr );
         CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
@@ -4488,9 +4348,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pRoot);
         CHECK( pMM != nullptr );
         CHECK( pMM->get_mark_type() == ImoMetronomeMark::k_value );
@@ -4518,7 +4376,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMetronomeMark* pMM = static_cast<ImoMetronomeMark*>(pRoot);
         CHECK( pMM != nullptr );
@@ -4549,7 +4407,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
@@ -4585,7 +4443,7 @@ SUITE(LdpAnalyserTest)
 //        cout << test_name() << endl;
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoDirection* pDir = static_cast<ImoDirection*>( pRoot );
         CHECK( pDir != nullptr );
@@ -4616,7 +4474,7 @@ SUITE(LdpAnalyserTest)
 //        cout << test_name() << endl;
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoDirection* pSp = static_cast<ImoDirection*>( pRoot );
         CHECK( pSp != nullptr );
@@ -4643,9 +4501,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_time_signature() == true );
         ImoTimeSignature* pTimeSignature = static_cast<ImoTimeSignature*>( pRoot );
         CHECK( pTimeSignature != nullptr );
@@ -4671,7 +4527,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_time_signature() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -4692,9 +4548,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoTimeSignature* pTimeSignature = static_cast<ImoTimeSignature*>( pRoot );
         CHECK( pTimeSignature != nullptr );
         CHECK( pTimeSignature->is_normal() );
@@ -4761,9 +4615,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_time_signature() == true );
         ImoTimeSignature* pTimeSignature = static_cast<ImoTimeSignature*>( pRoot );
         CHECK( pTimeSignature != nullptr );
@@ -4787,9 +4639,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_time_signature() == true );
         ImoTimeSignature* pTimeSignature = static_cast<ImoTimeSignature*>( pRoot );
         CHECK( pTimeSignature != nullptr );
@@ -4815,9 +4665,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_time_signature() == true );
         ImoTimeSignature* pTimeSignature = static_cast<ImoTimeSignature*>( pRoot );
         CHECK( pTimeSignature != nullptr );
@@ -4842,9 +4690,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_time_signature() == true );
         ImoTimeSignature* pTimeSignature = static_cast<ImoTimeSignature*>( pRoot );
         CHECK( pTimeSignature != nullptr );
@@ -4869,9 +4715,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_system_info() == true );
         ImoSystemInfo* pSI = static_cast<ImoSystemInfo*>( pRoot );
         CHECK( pSI != nullptr );
@@ -4897,9 +4741,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoSystemInfo* pSI = static_cast<ImoSystemInfo*>( pRoot );
         CHECK( pSI != nullptr );
         CHECK( !pSI->is_first() );
@@ -4924,9 +4766,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_system_info() == true );
         ImoSystemInfo* pSI = static_cast<ImoSystemInfo*>( pRoot );
         CHECK( pSI != nullptr );
@@ -4952,9 +4792,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoSystemInfo* pSL = static_cast<ImoSystemInfo*>( pRoot );
         CHECK( pSL != nullptr );
         CHECK( !pSL->is_first() );
@@ -4977,9 +4815,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_score_text() == true );
         ImoScoreText* pText = static_cast<ImoScoreText*>( pRoot );
         CHECK( pText != nullptr );
@@ -5003,7 +4839,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_score_text() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -5024,9 +4860,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoScoreText* pText = static_cast<ImoScoreText*>( pRoot );
         CHECK( pText == nullptr );
 
@@ -5047,9 +4881,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoScoreText* pText = static_cast<ImoScoreText*>( pRoot );
         CHECK( pText != nullptr );
@@ -5074,9 +4906,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoScoreText* pText = static_cast<ImoScoreText*>( pRoot );
         CHECK( pText != nullptr );
@@ -5105,9 +4935,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_option() == true );
         ImoOptionInfo* pOpt = static_cast<ImoOptionInfo*>( pRoot );
         CHECK( pOpt != nullptr );
@@ -5131,9 +4959,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -5151,9 +4977,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -5171,9 +4995,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoOptionInfo* pOpt = static_cast<ImoOptionInfo*>( pRoot );
         CHECK( pOpt != nullptr );
         CHECK( pOpt->get_name() == "StaffLines.Truncate" );
@@ -5196,9 +5018,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -5216,9 +5036,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoOptionInfo* pOpt = static_cast<ImoOptionInfo*>( pRoot );
         CHECK( pOpt != nullptr );
         CHECK( pOpt->get_name() == "Render.SpacingFactor" );
@@ -5241,9 +5059,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -5261,9 +5077,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -5281,9 +5095,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         CHECK( pScore != nullptr );
         CHECK( pScore && pScore->has_options() == true );
@@ -5312,9 +5124,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         CHECK( pScore != nullptr );
         CHECK( pScore && pScore->has_options() == true );
@@ -5349,9 +5159,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         CHECK( pScore != nullptr );
         CHECK( pScore && pScore->has_options() == true );
@@ -5380,9 +5188,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->get_note_type() == k_quarter );
@@ -5405,7 +5211,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -5425,9 +5231,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_spacer() == true );
         ImoDirection* pSp = static_cast<ImoDirection*>( pRoot );
         CHECK( pSp != nullptr );
@@ -5452,7 +5256,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_spacer() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -5473,9 +5277,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -5493,9 +5295,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoDirection* pSp = static_cast<ImoDirection*>( pRoot );
         CHECK( pSp != nullptr );
         CHECK( pSp && pSp->get_width() == 70.5f );
@@ -5517,9 +5317,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoDirection* pSp = static_cast<ImoDirection*>( pRoot );
         CHECK( pSp != nullptr );
         CHECK( pSp && pSp->get_width() == 70.5f );
@@ -5541,9 +5339,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoDirection* pSp = static_cast<ImoDirection*>( pRoot );
         CHECK( pSp != nullptr );
         CHECK( pSp && pSp->get_width() == 70.5f );
@@ -5565,9 +5361,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoDirection* pSp = static_cast<ImoDirection*>( pRoot );
         CHECK( pSp != nullptr );
         CHECK( pSp && pSp->get_width() == 70.0f );
@@ -5590,9 +5384,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoDirection* pSp = static_cast<ImoDirection*>( pRoot );
         CHECK( pSp != nullptr );
         CHECK( pSp && pSp->get_width() == 70.0f );
@@ -5615,9 +5407,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoDirection* pSp = static_cast<ImoDirection*>( pRoot );
         CHECK( pSp != nullptr );
         CHECK( pSp && pSp->get_width() == 70.0f );
@@ -5642,9 +5432,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot->is_document() == true );
         ImoDocument* pDoc = static_cast<ImoDocument*>( pRoot );
@@ -5669,7 +5457,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_document() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -5690,9 +5478,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoDocument* pDoc = static_cast<ImoDocument*>( pRoot );
         CHECK( pDoc != nullptr );
         //cout << "language='" << pDoc->get_language() << "'" << endl;
@@ -5714,9 +5500,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoDocument* pDoc = static_cast<ImoDocument*>( pRoot );
         CHECK( pDoc != nullptr );
         CHECK( pDoc && pDoc->get_num_content_items() == 1 );
@@ -5779,7 +5563,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoDocument* pDoc = static_cast<ImoDocument*>( pRoot );
         ImoObj* pImo = pDoc->get_content_item(0);
         CHECK( pImo && pImo->get_id() == 10L );
@@ -5802,7 +5586,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoDocument* pDoc = static_cast<ImoDocument*>( pRoot );
         ImoObj* pImo = pDoc->get_content();
         CHECK( pImo && pImo->get_id() == 60L );
@@ -5826,7 +5610,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoDocument* pDoc = static_cast<ImoDocument*>( pRoot );
         ImoStyle* pStyle = pDoc->find_style("Heading-1");
         CHECK( pStyle != nullptr );
@@ -5892,7 +5676,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
     }
 
     TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_TiesBuilder_ErrorNotesCanNotBeTied)
@@ -5925,9 +5709,7 @@ SUITE(LdpAnalyserTest)
         builder.add_item_info(pStartInfo);
         builder.add_item_info(pEndInfo);
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete startNote;
         delete endNote;
@@ -5948,9 +5730,7 @@ SUITE(LdpAnalyserTest)
         TiesBuilder builder(errormsg, &a);
         builder.add_item_info(pEndInfo);
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
     }
 
     TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_TiesBuilder_PendingTiesAtDeletion)
@@ -5976,9 +5756,7 @@ SUITE(LdpAnalyserTest)
 
         delete pBuilder;
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
     }
 
     TEST_FIXTURE(LdpAnalyserTestFixture, Analyser_TiesBuilder_InstrumentChangeError)
@@ -5994,9 +5772,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         ImoInstrument* pInstr = pScore->get_instrument(0);
@@ -6047,9 +5823,7 @@ SUITE(LdpAnalyserTest)
         CHECK( pInfo && pInfo->get_beam_number() == 12 );
         CHECK( pInfo && pInfo->get_beam_type(0) == ImoBeam::k_begin );
         CHECK( pInfo && pInfo->get_beam_type(1) == ImoBeam::k_none );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -6076,9 +5850,7 @@ SUITE(LdpAnalyserTest)
         CHECK( pInfo && pInfo->get_beam_type(3) == ImoBeam::k_none );
         CHECK( pInfo && pInfo->get_beam_type(4) == ImoBeam::k_none );
         CHECK( pInfo && pInfo->get_beam_type(5) == ImoBeam::k_none );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -6097,9 +5869,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
         CHECK( pRoot == nullptr );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -6118,9 +5888,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
         CHECK( pRoot == nullptr );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -6141,9 +5909,7 @@ SUITE(LdpAnalyserTest)
         delete pA;
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->is_beamed() == false );
         CHECK( pNote && pNote->get_beam_type(0) == ImoBeam::k_none );
@@ -6168,9 +5934,7 @@ SUITE(LdpAnalyserTest)
         delete pA;
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoObj::children_iterator it = pMusic->begin();
 
@@ -6204,9 +5968,7 @@ SUITE(LdpAnalyserTest)
         delete pA;
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoObj::children_iterator it = pMusic->begin();
 
@@ -6241,9 +6003,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         ImoInstrument* pInstr = pScore->get_instrument(0);
@@ -6279,9 +6039,7 @@ SUITE(LdpAnalyserTest)
         delete pA;
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoObj::children_iterator it = pMusic->begin();
 
@@ -6327,9 +6085,7 @@ SUITE(LdpAnalyserTest)
         ImoInstrument* pInstr = pScore->get_instrument(0);
         ImoMusicData* pMusic = pInstr->get_musicdata();
         CHECK( pMusic != nullptr );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoObj::children_iterator it = pMusic->begin();
 
@@ -6365,9 +6121,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
@@ -6391,9 +6145,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->get_octave() == 4 );
@@ -6420,9 +6172,7 @@ SUITE(LdpAnalyserTest)
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -6442,9 +6192,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = pA->analyse_tree(tree, "string:");
         delete pA;
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
@@ -6580,9 +6328,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot == nullptr );
 
         delete tree->get_root();
@@ -6602,9 +6348,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_tuplet_dto() == true );
         ImoTupletDto* pInfo = static_cast<ImoTupletDto*>( pRoot );
         CHECK( pInfo != nullptr );
@@ -6630,9 +6374,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot == nullptr );
 
         delete tree->get_root();
@@ -6652,9 +6394,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoTupletDto* pInfo = static_cast<ImoTupletDto*>( pRoot );
         CHECK( pInfo != nullptr );
         CHECK( pInfo && pInfo->is_start_of_tuplet() == true );
@@ -6680,9 +6420,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoTupletDto* pInfo = static_cast<ImoTupletDto*>( pRoot );
         CHECK( pInfo != nullptr );
         CHECK( pInfo && pInfo->is_start_of_tuplet() == true );
@@ -6708,9 +6446,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoTupletDto* pInfo = static_cast<ImoTupletDto*>( pRoot );
         CHECK( pInfo != nullptr );
         CHECK( pInfo && pInfo->is_start_of_tuplet() == true );
@@ -6738,7 +6474,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoTupletDto* pInfo = static_cast<ImoTupletDto*>( pRoot );
         CHECK( pInfo != nullptr );
         CHECK( pInfo && pInfo->is_start_of_tuplet() == true );
@@ -6774,7 +6510,7 @@ SUITE(LdpAnalyserTest)
         CHECK( pMusic != nullptr );
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoObj::children_iterator it = pMusic->begin();
 
@@ -6823,7 +6559,7 @@ SUITE(LdpAnalyserTest)
         CHECK( pMusic != nullptr );
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoObj::children_iterator it = pMusic->begin();
 
@@ -6882,7 +6618,7 @@ SUITE(LdpAnalyserTest)
 //        cout << test_name() << endl;
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoObj::children_iterator it = pMusic->begin();
 
@@ -6925,9 +6661,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot == nullptr );
 
         delete tree->get_root();
@@ -6947,9 +6681,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_tuplet_dto() == true );
         ImoTupletDto* pInfo = static_cast<ImoTupletDto*>( pRoot );
         CHECK( pInfo != nullptr );
@@ -6975,9 +6707,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot == nullptr );
 
         delete tree->get_root();
@@ -6997,9 +6727,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoTupletDto* pInfo = static_cast<ImoTupletDto*>( pRoot );
         CHECK( pInfo != nullptr );
         CHECK( pInfo && pInfo->is_start_of_tuplet() == true );
@@ -7024,9 +6752,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoTupletDto* pInfo = static_cast<ImoTupletDto*>( pRoot );
         CHECK( pInfo != nullptr );
         CHECK( pInfo && pInfo->is_start_of_tuplet() == true );
@@ -7051,9 +6777,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoTupletDto* pInfo = static_cast<ImoTupletDto*>( pRoot );
         CHECK( pInfo != nullptr );
         CHECK( pInfo && pInfo->is_start_of_tuplet() == true );
@@ -7078,9 +6802,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoTupletDto* pInfo = static_cast<ImoTupletDto*>( pRoot );
         CHECK( pInfo != nullptr );
         CHECK( pInfo && pInfo->is_start_of_tuplet() == true );
@@ -7109,7 +6831,7 @@ SUITE(LdpAnalyserTest)
         CHECK( pNote != nullptr );
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pNote && pNote->find_attachment(k_imo_tuplet) == nullptr );
 
         delete tree->get_root();
@@ -7133,7 +6855,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
@@ -7194,7 +6916,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         ImoInstrument* pInstr = pScore->get_instrument(0);
@@ -7226,9 +6948,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->get_octave() == 4 );
@@ -7251,9 +6971,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -7271,9 +6989,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser* pA = LOMSE_NEW LdpAnalyser(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = pA->analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete pA;
         delete tree->get_root();
@@ -7295,7 +7011,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
@@ -7324,7 +7040,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
@@ -7382,7 +7098,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot == nullptr );
 
         delete tree->get_root();
@@ -7402,9 +7118,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_time_modification_dto() == true );
         ImoTimeModificationDto* pInfo =
                 dynamic_cast<ImoTimeModificationDto*>( pRoot );
@@ -7433,9 +7147,7 @@ SUITE(LdpAnalyserTest)
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->get_voice() == 7 );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -7456,9 +7168,7 @@ SUITE(LdpAnalyserTest)
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->get_voice() == 1 );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -7481,9 +7191,7 @@ SUITE(LdpAnalyserTest)
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->get_staff() == 1 );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -7504,9 +7212,7 @@ SUITE(LdpAnalyserTest)
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
         CHECK( pNote && pNote->get_staff() == 0 );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -7530,7 +7236,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
@@ -7634,9 +7340,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
         CHECK( pRoot == nullptr );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -7660,9 +7364,7 @@ SUITE(LdpAnalyserTest)
         CHECK( pColor->green() == 69 );
         CHECK( pColor->blue() == 127 );
         CHECK( pColor->alpha() == 255 );
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -7681,9 +7383,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
@@ -7730,7 +7430,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_barline() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -7759,7 +7459,7 @@ SUITE(LdpAnalyserTest)
 //        cout << UnitTest::CurrentTest::Details()->testName << endl;
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_score() == true );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         CHECK( pScore && pScore->get_num_instruments() == 1 );
@@ -7787,7 +7487,7 @@ SUITE(LdpAnalyserTest)
 //        cout << UnitTest::CurrentTest::Details()->testName << endl;
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_score() == true );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
@@ -7817,7 +7517,7 @@ SUITE(LdpAnalyserTest)
 //        cout << UnitTest::CurrentTest::Details()->testName << endl;
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_score() == true );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
@@ -7847,7 +7547,7 @@ SUITE(LdpAnalyserTest)
 //        cout << UnitTest::CurrentTest::Details()->testName << endl;
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_score() == true );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
@@ -7876,7 +7576,7 @@ SUITE(LdpAnalyserTest)
 //        cout << UnitTest::CurrentTest::Details()->testName << endl;
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_score() == true );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
@@ -7907,7 +7607,7 @@ SUITE(LdpAnalyserTest)
 //        cout << UnitTest::CurrentTest::Details()->testName << endl;
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_score() == true );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
@@ -7948,7 +7648,7 @@ SUITE(LdpAnalyserTest)
 //        cout << UnitTest::CurrentTest::Details()->testName << endl;
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_score() == true );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
@@ -7990,7 +7690,7 @@ SUITE(LdpAnalyserTest)
 //        cout << UnitTest::CurrentTest::Details()->testName << endl;
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_score() == true );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
@@ -8038,7 +7738,7 @@ SUITE(LdpAnalyserTest)
 //        cout << UnitTest::CurrentTest::Details()->testName << endl;
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_score() == true );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
@@ -8088,7 +7788,7 @@ SUITE(LdpAnalyserTest)
 //        cout << UnitTest::CurrentTest::Details()->testName << endl;
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_score() == true );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
@@ -8129,9 +7829,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_score() == true );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
@@ -8175,9 +7873,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_score() == true );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
@@ -8222,9 +7918,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_score() == true );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
@@ -8269,9 +7963,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_score() == true );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
@@ -8316,9 +8008,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_score() == true );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
@@ -8361,9 +8051,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_score() == true );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
@@ -8395,9 +8083,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
@@ -8442,9 +8128,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
@@ -8491,9 +8175,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
@@ -8551,9 +8233,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoPageInfo* pInfo = static_cast<ImoPageInfo*>( pRoot );
         CHECK( pInfo != nullptr );
@@ -8587,9 +8267,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoDocument* pDoc = static_cast<ImoDocument*>( pRoot );
         CHECK( pDoc != nullptr );
@@ -8627,9 +8305,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoFontStyleDto* pFont = static_cast<ImoFontStyleDto*>( pRoot );
         CHECK( pFont != nullptr );
@@ -8655,9 +8331,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoFontStyleDto* pFont = static_cast<ImoFontStyleDto*>( pRoot );
         CHECK( pFont != nullptr );
@@ -8683,9 +8357,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoFontStyleDto* pFont = static_cast<ImoFontStyleDto*>( pRoot );
         CHECK( pFont != nullptr );
@@ -8711,9 +8383,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoFontStyleDto* pFont = static_cast<ImoFontStyleDto*>( pRoot );
         CHECK( pFont != nullptr );
@@ -8742,9 +8412,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoStyle* pStyle = static_cast<ImoStyle*>( pRoot );
         CHECK( pStyle != nullptr );
@@ -8772,9 +8440,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         CHECK( pScore != nullptr );
@@ -8807,7 +8473,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoStyle* pStyle = static_cast<ImoStyle*>( pRoot );
         CHECK( pStyle != nullptr );
@@ -8836,7 +8502,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoStyle* pStyle = static_cast<ImoStyle*>( pRoot );
         CHECK( pStyle != nullptr );
@@ -8867,7 +8533,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoStyle* pStyle = static_cast<ImoStyle*>( pRoot );
         CHECK( pStyle != nullptr );
@@ -8897,7 +8563,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoStyle* pStyle = static_cast<ImoStyle*>( pRoot );
         CHECK( pStyle != nullptr );
@@ -8927,7 +8593,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoStyle* pStyle = static_cast<ImoStyle*>( pRoot );
         CHECK( pStyle != nullptr );
@@ -8957,7 +8623,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoStyle* pStyle = static_cast<ImoStyle*>( pRoot );
         CHECK( pStyle != nullptr );
@@ -8986,7 +8652,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -9007,7 +8673,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete tree->get_root();
         // coverity[check_after_deref]
@@ -9026,9 +8692,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoScoreTitle* pTitle = static_cast<ImoScoreTitle*>( pRoot );
         CHECK( pTitle != nullptr );
@@ -9053,7 +8717,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_score_title() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -9075,9 +8739,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         CHECK( pScore != nullptr );
@@ -9106,9 +8768,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoScoreTitle* pTitle = static_cast<ImoScoreTitle*>( pRoot );
         CHECK( pTitle != nullptr );
@@ -9137,9 +8797,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         CHECK( pScore != nullptr );
@@ -9176,9 +8834,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoScoreTitle* pTitle = static_cast<ImoScoreTitle*>( pRoot );
         CHECK( pTitle != nullptr );
@@ -9210,9 +8866,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoScoreLine* pLine = static_cast<ImoScoreLine*>( pRoot );
         CHECK( pLine != nullptr );
@@ -9243,9 +8897,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoScoreLine* pLine = static_cast<ImoScoreLine*>( pRoot );
         CHECK( pLine != nullptr );
@@ -9277,7 +8929,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_score_line() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -9299,9 +8951,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoScoreLine* pLine = static_cast<ImoScoreLine*>( pRoot );
         CHECK( pLine != nullptr );
@@ -9332,9 +8982,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoScoreLine* pLine = static_cast<ImoScoreLine*>( pRoot );
         CHECK( pLine != nullptr );
@@ -9365,9 +9013,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoScoreLine* pLine = static_cast<ImoScoreLine*>( pRoot );
         CHECK( pLine != nullptr );
@@ -9403,9 +9049,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoTextBox* pTB = static_cast<ImoTextBox*>( pRoot );
         CHECK( pTB != nullptr );
@@ -9442,7 +9086,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_text_box() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -9471,9 +9115,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoTextBox* pTB = static_cast<ImoTextBox*>( pRoot );
         CHECK( pTB != nullptr );
@@ -9523,9 +9165,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoNote* pNote = static_cast<ImoNote*>( pRoot );
         CHECK( pNote != nullptr );
@@ -9566,9 +9206,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoCursorInfo* pInfo = static_cast<ImoCursorInfo*>( pRoot );
         CHECK( pInfo && pInfo->is_cursor_info() == true );
@@ -9594,9 +9232,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         CHECK( pScore && pScore->is_score() == true );
@@ -9623,7 +9259,7 @@ SUITE(LdpAnalyserTest)
 
     //    //cout << "[" << errormsg.str() << "]" << endl;
     //    //cout << "[" << expected.str() << "]" << endl;
-    //    CHECK( errormsg.str() == expected.str() );
+    //    CHECK( check_errormsg(errormsg, expected) );
 
     //    ImoDocument* pDoc = static_cast<ImoDocument*>( pRoot );
     //    CHECK( pDoc && pDoc->is_document() == true );
@@ -9650,9 +9286,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoFiguredBass* pFB = static_cast<ImoFiguredBass*>( pRoot );
         CHECK( pFB->is_figured_bass() == true );
@@ -9678,9 +9312,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot == nullptr );
 
         delete tree->get_root();
@@ -9700,9 +9332,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr );
         ImoStaffInfo* pInfo = static_cast<ImoStaffInfo*>( pRoot );
         CHECK( pInfo != nullptr );
@@ -9731,9 +9361,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr );
         ImoStaffInfo* pInfo = static_cast<ImoStaffInfo*>( pRoot );
         CHECK( pInfo != nullptr );
@@ -9763,9 +9391,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr );
         ImoStaffInfo* pInfo = static_cast<ImoStaffInfo*>( pRoot );
         CHECK( pInfo != nullptr );
@@ -9795,9 +9421,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr );
         ImoStaffInfo* pInfo = static_cast<ImoStaffInfo*>( pRoot );
         CHECK( pInfo != nullptr );
@@ -9827,9 +9451,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr );
         ImoStaffInfo* pInfo = static_cast<ImoStaffInfo*>( pRoot );
         CHECK( pInfo != nullptr );
@@ -9861,9 +9483,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr );
         ImoInstrument* pInstr = static_cast<ImoInstrument*>( pRoot );
         CHECK( pInstr != nullptr );
@@ -9895,9 +9515,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_text_item() == true );
         ImoTextItem* pText = static_cast<ImoTextItem*>( pRoot );
         CHECK( pText != nullptr );
@@ -9921,7 +9539,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_text_item() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -9942,7 +9560,7 @@ SUITE(LdpAnalyserTest)
     //    ImoObj* pRoot = a.analyse_tree(tree, "string:");
     //    //cout << "[" << errormsg.str() << "]" << endl;
     //    //cout << "[" << expected.str() << "]" << endl;
-    //    CHECK( errormsg.str() == expected.str() );
+    //    CHECK( check_errormsg(errormsg, expected) );
     //    ImoTextItem* pText = static_cast<ImoTextItem*>( pRoot );
     //    CHECK( pText == nullptr );
 
@@ -9962,9 +9580,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoTextItem* pText = static_cast<ImoTextItem*>( pRoot );
         CHECK( pText != nullptr );
@@ -10009,7 +9625,7 @@ SUITE(LdpAnalyserTest)
 
     //    //cout << "[" << errormsg.str() << "]" << endl;
     //    //cout << "[" << expected.str() << "]" << endl;
-    //    CHECK( errormsg.str() == expected.str() );
+    //    CHECK( check_errormsg(errormsg, expected) );
 
     //    ImoTextItem* pText = static_cast<ImoTextItem*>( pRoot );
     //    CHECK( pText != nullptr );
@@ -10037,9 +9653,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_paragraph() == true );
 
         delete tree->get_root();
@@ -10060,7 +9674,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_paragraph() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -10082,9 +9696,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoParagraph* pPara = static_cast<ImoParagraph*>( pRoot );
         CHECK( pPara->get_num_items() == 1 );
         ImoTextItem* pItem = dynamic_cast<ImoTextItem*>( pPara->get_first_item() );
@@ -10108,9 +9720,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoParagraph* pPara = static_cast<ImoParagraph*>( pRoot );
         CHECK( pPara->get_num_items() == 1 );
         ImoLink* pLink = dynamic_cast<ImoLink*>( pPara->get_first_item() );
@@ -10138,9 +9748,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoParagraph* pPara = static_cast<ImoParagraph*>( pRoot );
         CHECK( pPara->get_num_items() == 2 );
         TreeNode<ImoObj>::children_iterator it = pPara->begin();
@@ -10188,9 +9796,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
         ImoDocument* pDoc = static_cast<ImoDocument*>( pRoot );
@@ -10219,9 +9825,7 @@ SUITE(LdpAnalyserTest)
         doc.from_string("(lenmusdoc (vers 0.0) (content "
             "(para (txt \"Hello world!\")) ))");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoDocument* pDoc = doc.get_im_root();
         ImoParagraph* pPara = dynamic_cast<ImoParagraph*>( pDoc->get_content_item(0) );
         CHECK( pPara != nullptr );
@@ -10246,9 +9850,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_heading() == true );
 
         delete tree->get_root();
@@ -10269,7 +9871,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_heading() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -10291,9 +9893,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoHeading* pH = dynamic_cast<ImoHeading*>( pRoot );
         CHECK( pH->get_num_items() == 1 );
         ImoTextItem* pItem = dynamic_cast<ImoTextItem*>( pH->get_first_item() );
@@ -10317,9 +9917,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoHeading* pH = dynamic_cast<ImoHeading*>( pRoot );
         CHECK( pH->get_num_items() == 2 );
         TreeNode<ImoObj>::children_iterator it = pH->begin();
@@ -10367,9 +9965,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
         ImoDocument* pDoc = static_cast<ImoDocument*>( pRoot );
@@ -10395,9 +9991,7 @@ SUITE(LdpAnalyserTest)
         doc.from_string("(lenmusdoc (vers 0.0) (content "
             "(heading 1 (txt \"Hello world!\")) ))");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoDocument* pDoc = doc.get_im_root();
         ImoHeading* pH = dynamic_cast<ImoHeading*>( pDoc->get_content_item(0) );
         CHECK( pH != nullptr );
@@ -10426,9 +10020,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoStyles* pStyles = dynamic_cast<ImoStyles*>( pRoot );
         CHECK( pStyles != nullptr );
@@ -10461,9 +10053,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoDocument* pDoc = static_cast<ImoDocument*>( pRoot );
         ImoScoreText* pText = dynamic_cast<ImoScoreText*>( pDoc->get_content_item(0) );
@@ -10497,9 +10087,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoDocument* pDoc = static_cast<ImoDocument*>( pRoot );
         ImoScoreText* pText = dynamic_cast<ImoScoreText*>( pDoc->get_content_item(0) );
@@ -10548,9 +10136,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot == nullptr );
 
@@ -10575,7 +10161,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_dynamic() == true );
         ImoDynamic* pDyn = dynamic_cast<ImoDynamic*>( pRoot );
@@ -10601,7 +10187,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_dynamic() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -10657,7 +10243,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoDynamic* pDyn = dynamic_cast<ImoDynamic*>( pRoot );
         CHECK( pDyn->get_classid() == "test" );
@@ -10689,7 +10275,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_link() == true );
         ImoLink* pLink = dynamic_cast<ImoLink*>( pRoot );
@@ -10718,7 +10304,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_link() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -10743,7 +10329,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_link() == true );
         ImoLink* pLink = dynamic_cast<ImoLink*>( pRoot );
@@ -10779,7 +10365,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoImage* pImg = dynamic_cast<ImoImage*>( pRoot );
         CHECK( pImg != nullptr );
@@ -10807,7 +10393,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_listitem() == true );
         ImoListItem* pLI = dynamic_cast<ImoListItem*>( pRoot );
@@ -10835,7 +10421,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_listitem() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -10860,7 +10446,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_list() == true );
         ImoList* pList = dynamic_cast<ImoList*>( pRoot );
@@ -10892,7 +10478,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_list() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -10917,9 +10503,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot == nullptr );
 
@@ -10940,9 +10524,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot->is_score_line() == true );
         ImoScoreLine* pLine = static_cast<ImoScoreLine*>( pRoot );
@@ -10980,7 +10562,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_score_line() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -11002,9 +10584,7 @@ SUITE(LdpAnalyserTest)
         LdpTree* tree = parser.get_ldp_tree();
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
         CHECK( pMusic != nullptr );
@@ -11039,9 +10619,7 @@ SUITE(LdpAnalyserTest)
         doc.from_string("(lenmusdoc (vers 0.0) (content "
             "(scorePlayer) ))");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoDocument* pDoc = doc.get_im_root();
         ImoAnonymousBlock* pAB = dynamic_cast<ImoAnonymousBlock*>( pDoc->get_content_item(0) );
         CHECK( pAB != nullptr );
@@ -11065,7 +10643,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoDocument* pDoc = doc.get_im_root();
         ImoAnonymousBlock* pAB = dynamic_cast<ImoAnonymousBlock*>( pDoc->get_content_item(0) );
         CHECK( pAB != nullptr );
@@ -11085,9 +10663,7 @@ SUITE(LdpAnalyserTest)
         doc.from_string("(lenmusdoc (vers 0.0) (content "
             "(scorePlayer (mm 65)) ))");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoDocument* pDoc = doc.get_im_root();
         ImoAnonymousBlock* pAB = dynamic_cast<ImoAnonymousBlock*>( pDoc->get_content_item(0) );
         CHECK( pAB != nullptr );
@@ -11109,9 +10685,7 @@ SUITE(LdpAnalyserTest)
         doc.from_string("(lenmusdoc (vers 0.0) (content "
             "(scorePlayer (mm 65)(playLabel \"Tocar\")(stopLabel \"Parar\")) ))");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoDocument* pDoc = doc.get_im_root();
         ImoAnonymousBlock* pAB = dynamic_cast<ImoAnonymousBlock*>( pDoc->get_content_item(0) );
         CHECK( pAB != nullptr );
@@ -11142,9 +10716,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoTableCell* pCell = dynamic_cast<ImoTableCell*>( pRoot );
         CHECK( pCell->is_table_cell() == true );
         CHECK( pCell->get_num_content_items() == 1 );
@@ -11174,7 +10746,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_table_cell() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -11197,9 +10769,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoTableCell* pCell = dynamic_cast<ImoTableCell*>( pRoot );
         CHECK( pCell->is_table_cell() == true );
         CHECK( pCell->get_num_content_items() == 1 );
@@ -11228,9 +10798,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoTableCell* pCell = dynamic_cast<ImoTableCell*>( pRoot );
         CHECK( pCell->is_table_cell() == true );
         CHECK( pCell->get_num_content_items() == 1 );
@@ -11263,9 +10831,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoTableRow* pRow = dynamic_cast<ImoTableRow*>( pRoot );
         CHECK( pRow->is_table_row() == true );
         CHECK( pRow->get_num_cells() == 2 );
@@ -11293,7 +10859,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_table_row() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -11321,9 +10887,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoTableHead* pHead = dynamic_cast<ImoTableHead*>( pRoot );
         CHECK( pHead->is_table_head() == true );
         CHECK( pHead->get_num_items() == 2 );
@@ -11352,7 +10916,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_table_head() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -11380,9 +10944,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoTableBody* pBody = dynamic_cast<ImoTableBody*>( pRoot );
         CHECK( pBody->is_table_body() == true );
         CHECK( pBody->get_num_items() == 2 );
@@ -11410,7 +10972,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_table_body() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -11436,9 +10998,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoTable* pTable = dynamic_cast<ImoTable*>( pRoot );
         CHECK( pTable != nullptr );
 
@@ -11469,7 +11029,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot->is_table() == true );
         ImoObj* pImo = pRoot;
         CHECK( pImo && pImo->get_id() == 10L );
@@ -11508,7 +11068,7 @@ SUITE(LdpAnalyserTest)
 
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoDocument* pDoc = static_cast<ImoDocument*>( pRoot );
         ImoTable* pTable = dynamic_cast<ImoTable*>( pDoc->get_content_item(0) );
@@ -11555,9 +11115,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoDocument* pDoc = static_cast<ImoDocument*>( pRoot );
         ImoTable* pTable = dynamic_cast<ImoTable*>( pDoc->get_content_item(0) );
@@ -11603,7 +11161,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         CHECK( pInstr->get_last_measure_info() == nullptr );
@@ -11654,7 +11212,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         TypeMeasureInfo* pInfo = pInstr->get_last_measure_info();
@@ -11707,7 +11265,7 @@ SUITE(LdpAnalyserTest)
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //        cout << "[" << errormsg.str() << "]" << endl;
 //        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         TypeMeasureInfo* pInfo = pInstr->get_last_measure_info();
@@ -11743,9 +11301,7 @@ SUITE(LdpAnalyserTest)
         LdpAnalyser a(errormsg, m_libraryScope, &doc);
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        //cout << "[" << errormsg.str() << "]" << endl;
-        //cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoScore* pScore = static_cast<ImoScore*>( pRoot );
         ImoInstrument* pInstr = pScore->get_instrument(1);

--- a/src/tests/lomse_test_mnx_analyser.cpp
+++ b/src/tests/lomse_test_mnx_analyser.cpp
@@ -95,6 +95,23 @@ public:
         return UnitTest::CurrentTest::Details()->testName;
     }
 
+    inline void failure_header()
+    {
+        cout << endl << "*** Failure in " << test_name() << ":" << endl;
+    }
+
+    bool check_errormsg(const stringstream& msg, const stringstream& expected)
+    {
+        if (msg.str() != expected.str())
+        {
+            failure_header();
+            cout << "     msg=[" << msg.str() << "]" << endl;
+            cout << "expected=[" << expected.str() << "]" << endl;
+            return false;
+        }
+        return true;
+    }
+
 };
 
 
@@ -132,11 +149,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( doc.is_dirty() == true );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
@@ -214,11 +227,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( doc.is_dirty() == true );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
@@ -315,11 +324,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( doc.is_dirty() == true );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
@@ -416,11 +421,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( doc.is_dirty() == true );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
@@ -503,11 +504,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( doc.is_dirty() == true );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
@@ -565,11 +562,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( doc.is_dirty() == true );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
@@ -631,11 +624,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( doc.is_dirty() == true );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
@@ -695,11 +684,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -734,7 +719,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -765,7 +750,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
 
@@ -799,7 +784,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
 
@@ -842,7 +827,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
 
@@ -909,11 +894,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( doc.is_dirty() == true );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
@@ -999,7 +980,7 @@ SUITE(MnxAnalyserTest)
 ////        cout << test_name() << endl;
 ////        cout << "[" << errormsg.str() << "]" << endl;
 ////        cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
+//        CHECK( check_errormsg(errormsg, expected) );
 //        CHECK( pRoot != nullptr);
 //        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
 //        if (pDoc)
@@ -1077,7 +1058,7 @@ SUITE(MnxAnalyserTest)
 ////        cout << test_name() << endl;
 ////        cout << "[" << errormsg.str() << "]" << endl;
 ////        cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
+//        CHECK( check_errormsg(errormsg, expected) );
 //        CHECK( pRoot != nullptr);
 //        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
 //        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
@@ -1128,7 +1109,7 @@ SUITE(MnxAnalyserTest)
 ////        cout << test_name() << endl;
 ////        cout << "[" << errormsg.str() << "]" << endl;
 ////        cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
+//        CHECK( check_errormsg(errormsg, expected) );
 //        CHECK( pRoot != nullptr);
 //        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
 //        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
@@ -1179,7 +1160,7 @@ SUITE(MnxAnalyserTest)
 ////        cout << test_name() << endl;
 ////        cout << "[" << errormsg.str() << "]" << endl;
 ////        cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
+//        CHECK( check_errormsg(errormsg, expected) );
 //        CHECK( pRoot != nullptr);
 //        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
 //        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
@@ -1230,7 +1211,7 @@ SUITE(MnxAnalyserTest)
 //////        cout << test_name() << endl;
 //////        cout << "[" << errormsg.str() << "]" << endl;
 //////        cout << "[" << expected.str() << "]" << endl;
-////        CHECK( errormsg.str() == expected.str() );
+////        CHECK( check_errormsg(errormsg, expected) );
 ////        CHECK( pRoot != nullptr);
 ////        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
 ////        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
@@ -1281,7 +1262,7 @@ SUITE(MnxAnalyserTest)
 ////        cout << test_name() << endl;
 ////        cout << "[" << errormsg.str() << "]" << endl;
 ////        cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
+//        CHECK( check_errormsg(errormsg, expected) );
 //        CHECK( pRoot != nullptr);
 //        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
 //        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
@@ -1332,7 +1313,7 @@ SUITE(MnxAnalyserTest)
 ////        cout << test_name() << endl;
 ////        cout << "[" << errormsg.str() << "]" << endl;
 ////        cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
+//        CHECK( check_errormsg(errormsg, expected) );
 //        CHECK( pRoot != nullptr);
 //        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
 //        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
@@ -1395,11 +1376,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( doc.is_dirty() == true );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
@@ -1494,11 +1471,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -1567,10 +1540,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -1660,10 +1630,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -1719,11 +1686,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -1787,11 +1750,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -1843,11 +1802,8 @@ SUITE(MnxAnalyserTest)
 //        XmlNode* tree = parser.get_tree_root();
 //        ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 //
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 //
-//        CHECK( errormsg.str() == expected.str() );
+//        CHECK( check_errormsg(errormsg, expected) );
 //        CHECK( doc.is_dirty() == true );
 //        CHECK( pRoot != nullptr );
 //        CHECK( pRoot && pRoot->is_document() == true );
@@ -1930,11 +1886,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( doc.is_dirty() == true );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
@@ -1967,6 +1919,52 @@ SUITE(MnxAnalyserTest)
 //                pScore->end_of_changes();
 //                cout << test_name() << endl << pScore->to_string_with_ids() << endl;
             }
+        }
+
+        delete pRoot;
+    }
+
+
+    //@ score ---------------------------------------------------------------------------
+
+    TEST_FIXTURE(MnxAnalyserTestFixture, score_001)
+    {
+        //@001. score. source format is mnx
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        parser.parse_text(
+            "<mnx>"
+                "<global><measure>"
+                    "<directions><time signature='4/4'/><repeat type='end'/></directions>"
+                "</measure></global>"
+                "<part><part-name/>"
+                    "<measure>"
+                        "<directions><clef sign='G' line='2'/></directions>"
+                        "<sequence>"
+                            "<event value='/1'><note pitch='G4'/></event>"
+                        "</sequence>"
+                    "</measure>"
+                "</part>"
+            "</mnx>"
+        );
+        MnxAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot =  a.analyse_tree(tree, "string:");
+
+        CHECK( check_errormsg(errormsg, expected) );
+        CHECK( doc.is_dirty() == true );
+        CHECK( pRoot != nullptr );
+        CHECK( pRoot && pRoot->is_document() == true );
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
+        CHECK( pDoc && pDoc->get_num_content_items() == 1 );
+        if (pDoc)
+        {
+            ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+            CHECK( pScore && pScore->was_created_from_mnx() );
         }
 
         delete pRoot;
@@ -2010,11 +2008,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( doc.is_dirty() == true );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
@@ -2104,11 +2098,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( doc.is_dirty() == true );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
@@ -2175,9 +2165,7 @@ SUITE(MnxAnalyserTest)
 //        LdpAnalyser a(errormsg, m_libraryScope, &doc);
 //        ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //
-//        //cout << "[" << errormsg.str() << "]" << endl;
-//        //cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
+//        CHECK( check_errormsg(errormsg, expected) );
 //
 //        ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
 //        CHECK( pMusic != nullptr );
@@ -2212,9 +2200,7 @@ SUITE(MnxAnalyserTest)
 //        LdpAnalyser a(errormsg, m_libraryScope, &doc);
 //        ImoObj* pRoot = a.analyse_tree(tree, "string:");
 //
-//        //cout << "[" << errormsg.str() << "]" << endl;
-//        //cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
+//        CHECK( check_errormsg(errormsg, expected) );
 //
 //        ImoMusicData* pMusic = static_cast<ImoMusicData*>( pRoot );
 //        CHECK( pMusic != nullptr );
@@ -2271,11 +2257,7 @@ SUITE(MnxAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( doc.is_dirty() == true );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );

--- a/src/tests/lomse_test_mxl_analyser.cpp
+++ b/src/tests/lomse_test_mxl_analyser.cpp
@@ -189,6 +189,23 @@ public:
         return UnitTest::CurrentTest::Details()->testName;
     }
 
+    inline void failure_header()
+    {
+        cout << endl << "*** Failure in " << test_name() << ":" << endl;
+    }
+
+    bool check_errormsg(const stringstream& msg, const stringstream& expected)
+    {
+        if (msg.str() != expected.str())
+        {
+            failure_header();
+            cout << "     msg=[" << msg.str() << "]" << endl;
+            cout << "expected=[" << expected.str() << "]" << endl;
+            return false;
+        }
+        return true;
+    }
+
     list<ImoTuplet*> get_tuplets(ImoNoteRest* pNR)
     {
         list<ImoTuplet*> tuplets;
@@ -247,10 +264,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( a.get_musicxml_version() == 300 );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
@@ -274,13 +288,10 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
         CHECK( a.get_musicxml_version() == 100 );
         CHECK( pRoot != nullptr );
         CHECK( pRoot && pRoot->is_document() == true );
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         delete pRoot;
     }
@@ -298,10 +309,7 @@ SUITE(MxlAnalyserTest)
         MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -326,10 +334,7 @@ SUITE(MxlAnalyserTest)
         MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -363,10 +368,7 @@ SUITE(MxlAnalyserTest)
         MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -399,10 +401,7 @@ SUITE(MxlAnalyserTest)
         MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -429,10 +428,7 @@ SUITE(MxlAnalyserTest)
         MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -462,10 +458,7 @@ SUITE(MxlAnalyserTest)
         MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -500,10 +493,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -542,6 +532,33 @@ SUITE(MxlAnalyserTest)
         delete pRoot;
     }
 
+    TEST_FIXTURE(MxlAnalyserTestFixture, score_partwise_10)
+    {
+        //@10. score. source format is musicxml
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        stringstream expected;
+        //expected << "Line 0. <score-partwise>: missing mandatory element <part>." << endl;
+        parser.parse_text("<score-partwise version='4.0'><part-list>"
+                          "<score-part id='P1'><part-name>Music</part-name></score-part>"
+                          "</part-list><part id='P1'></part></score-partwise>");
+        MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot =  a.analyse_tree(tree, "string:");
+        CHECK( check_errormsg(errormsg, expected) );
+        CHECK( pRoot != nullptr);
+        CHECK( pRoot && pRoot->is_document() == true );
+        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
+        CHECK( pDoc != nullptr );
+        CHECK( pDoc && pDoc->get_num_content_items() == 1 );
+        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
+        CHECK( pScore && pScore->was_created_from_musicxml() );
+
+        delete pRoot;
+    }
+
 
     //@ score-part -------------------------------------------------------------
 
@@ -558,10 +575,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_instrument() == true );
         ImoInstrument* pInstr = dynamic_cast<ImoInstrument*>( pRoot );
@@ -603,10 +617,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -653,10 +664,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -696,10 +704,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -739,10 +744,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -788,10 +790,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -837,10 +836,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -888,10 +884,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -950,10 +943,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -1011,10 +1001,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -1071,10 +1058,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -1132,10 +1116,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -1197,10 +1178,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -1272,10 +1250,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         CHECK( pDoc != nullptr );
@@ -1332,10 +1307,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot );
         CHECK( a.current_divisions() == 7L );
 
@@ -1364,9 +1336,7 @@ SUITE(MxlAnalyserTest)
 
 //        cout << test_name() << endl;
 //        cout << "divisons:" << a.current_divisions() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( a.current_divisions() == 1L );
 
         delete pRoot;
@@ -1394,7 +1364,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         CHECK( pDoc );
@@ -1434,7 +1404,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         CHECK( pDoc );
@@ -1462,10 +1432,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_barline() == true );
         ImoBarline* pBarline = dynamic_cast<ImoBarline*>( pRoot );
@@ -1493,10 +1460,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_clef() == true );
         ImoClef* pClef = dynamic_cast<ImoClef*>( pRoot );
@@ -1522,10 +1486,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_clef() == true );
         ImoClef* pClef = dynamic_cast<ImoClef*>( pRoot );
@@ -1549,10 +1510,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_clef() == true );
         ImoClef* pClef = dynamic_cast<ImoClef*>( pRoot );
@@ -1583,10 +1541,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_clef() == true );
         ImoClef* pClef = dynamic_cast<ImoClef*>( pRoot );
@@ -1619,10 +1574,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_clef() == true );
         ImoClef* pClef = dynamic_cast<ImoClef*>( pRoot );
@@ -1654,10 +1606,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_clef() == true );
         ImoClef* pClef = dynamic_cast<ImoClef*>( pRoot );
@@ -1689,10 +1638,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_clef() == true );
         ImoClef* pClef = dynamic_cast<ImoClef*>( pRoot );
@@ -1724,10 +1670,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_clef() == true );
         ImoClef* pClef = dynamic_cast<ImoClef*>( pRoot );
@@ -1771,10 +1714,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         CHECK( pDoc );
@@ -1834,10 +1774,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         CHECK( pDoc );
@@ -1894,10 +1831,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         CHECK( pDoc );
@@ -1950,10 +1884,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         CHECK( pDoc );
@@ -2007,10 +1938,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         CHECK( pDoc );
@@ -2060,10 +1988,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         CHECK( pDoc );
@@ -2118,10 +2043,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         CHECK( pDoc );
@@ -2168,10 +2090,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot = a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         CHECK( pDoc );
@@ -2224,10 +2143,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_direction() == true );
         ImoDirection* pSO = dynamic_cast<ImoDirection*>( pRoot );
@@ -2261,10 +2177,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_direction() == true );
         ImoDirection* pSO = dynamic_cast<ImoDirection*>( pRoot );
@@ -2306,10 +2219,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_direction() == true );
         ImoDirection* pSO = dynamic_cast<ImoDirection*>( pRoot );
@@ -2460,10 +2370,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_direction() == true );
         ImoDirection* pSO = dynamic_cast<ImoDirection*>( pRoot );
@@ -2500,10 +2407,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_direction() == true );
         ImoDirection* pSO = dynamic_cast<ImoDirection*>( pRoot );
@@ -2543,10 +2447,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_direction() == true );
         ImoDirection* pSO = dynamic_cast<ImoDirection*>( pRoot );
@@ -2578,10 +2479,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_direction() == true );
         ImoDirection* pSO = dynamic_cast<ImoDirection*>( pRoot );
@@ -2614,10 +2512,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_direction() == true );
         ImoDirection* pSO = dynamic_cast<ImoDirection*>( pRoot );
@@ -2661,10 +2556,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -2735,10 +2627,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -2802,10 +2691,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_note() == true );
         ImoNote* pNote = dynamic_cast<ImoNote*>( pRoot );
@@ -2854,10 +2741,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_note() == true );
         ImoNote* pNote = dynamic_cast<ImoNote*>( pRoot );
@@ -2891,10 +2776,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_note() == true );
         ImoNote* pNote = dynamic_cast<ImoNote*>( pRoot );
@@ -2948,10 +2831,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_note() == true );
         ImoNote* pNote = dynamic_cast<ImoNote*>( pRoot );
@@ -3007,10 +2888,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_note() == true );
         ImoNote* pNote = dynamic_cast<ImoNote*>( pRoot );
@@ -3046,10 +2925,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_key_signature() == true );
         ImoKeySignature* pKey = dynamic_cast<ImoKeySignature*>( pRoot );
@@ -3077,10 +2953,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_key_signature() == true );
         ImoKeySignature* pKey = dynamic_cast<ImoKeySignature*>( pRoot );
@@ -3111,10 +2984,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot == nullptr);
 
         a.do_not_delete_instruments_in_destructor();
@@ -3142,10 +3012,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot && pRoot->is_key_signature() == true );
         ImoKeySignature* pKey = dynamic_cast<ImoKeySignature*>( pRoot );
         CHECK( pKey != nullptr );
@@ -3188,10 +3055,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot && pRoot->is_key_signature() == true );
         ImoKeySignature* pKey = dynamic_cast<ImoKeySignature*>( pRoot );
         CHECK( pKey != nullptr );
@@ -3257,10 +3121,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot && pRoot->is_key_signature() == true );
         ImoKeySignature* pKey = dynamic_cast<ImoKeySignature*>( pRoot );
         CHECK( pKey != nullptr );
@@ -3320,10 +3181,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_key_signature() == true );
         ImoKeySignature* pKey = dynamic_cast<ImoKeySignature*>( pRoot );
@@ -3369,10 +3227,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -3441,10 +3296,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -3541,10 +3393,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -3650,7 +3499,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         CHECK( pDoc != nullptr );
@@ -3723,10 +3572,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -3789,10 +3635,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -3858,10 +3701,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -3924,9 +3764,7 @@ SUITE(MxlAnalyserTest)
 //        ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 //
 ////        cout << test_name() << endl;
-////        cout << "[" << errormsg.str() << "]" << endl;
-////        cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
+//////        CHECK( check_errormsg(errormsg, expected) );
 //        CHECK( pRoot != nullptr);
 //        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
 //        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
@@ -3973,10 +3811,7 @@ SUITE(MxlAnalyserTest)
         MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -4050,10 +3885,7 @@ SUITE(MxlAnalyserTest)
         MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -4110,10 +3942,7 @@ SUITE(MxlAnalyserTest)
         MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -4192,10 +4021,7 @@ SUITE(MxlAnalyserTest)
         MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -4231,10 +4057,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_note() == true );
         ImoNote* pNote = dynamic_cast<ImoNote*>( pRoot );
@@ -4268,10 +4091,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_note() == true );
         ImoNote* pNote = dynamic_cast<ImoNote*>( pRoot );
@@ -4304,10 +4124,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_note() == true );
         ImoNote* pNote = dynamic_cast<ImoNote*>( pRoot );
@@ -4340,10 +4157,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_note() == true );
         ImoNote* pNote = dynamic_cast<ImoNote*>( pRoot );
@@ -4378,10 +4192,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_note() == true );
         ImoNote* pNote = dynamic_cast<ImoNote*>( pRoot );
@@ -4416,10 +4227,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_note() == true );
         ImoNote* pNote = dynamic_cast<ImoNote*>( pRoot );
@@ -4455,10 +4263,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_note() == true );
         ImoNote* pNote = dynamic_cast<ImoNote*>( pRoot );
@@ -4499,10 +4304,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -4558,10 +4360,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
@@ -4610,10 +4409,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_note() == true );
         ImoNote* pNote = dynamic_cast<ImoNote*>( pRoot );
@@ -4648,10 +4444,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_note() == true );
         ImoNote* pNote = dynamic_cast<ImoNote*>( pRoot );
@@ -4688,10 +4481,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_note() == true );
         ImoNote* pNote = dynamic_cast<ImoNote*>( pRoot );
@@ -4730,8 +4520,6 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
        //AWARE: initialy <divisions>==1
         CHECK( is_equal_time(a.get_current_time(), 3.0f*k_duration_quarter) );
@@ -4766,10 +4554,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -4840,10 +4625,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -4918,10 +4700,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
@@ -4969,10 +4748,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
@@ -5020,10 +4796,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
@@ -5072,9 +4845,7 @@ SUITE(MxlAnalyserTest)
 //        ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 //
 ////        cout << test_name() << endl;
-////        cout << "[" << errormsg.str() << "]" << endl;
-////        cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
+//////        CHECK( check_errormsg(errormsg, expected) );
 //        CHECK( pRoot != nullptr);
 //        ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
 //        ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
@@ -5122,10 +4893,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
@@ -5173,10 +4941,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
@@ -5234,10 +4999,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -5317,9 +5080,7 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
+//        CHECK( check_errormsg(errormsg, expected) );
 
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -5398,10 +5159,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -5498,10 +5257,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -5573,10 +5330,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -5670,10 +5425,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -5773,10 +5526,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -5863,10 +5614,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_rest() == true );
         ImoRest* pRest = dynamic_cast<ImoRest*>( pRoot );
@@ -5898,10 +5646,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_rest() == true );
         ImoRest* pRest = dynamic_cast<ImoRest*>( pRoot );
@@ -5935,10 +5681,7 @@ SUITE(MxlAnalyserTest)
         MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -5975,10 +5718,7 @@ SUITE(MxlAnalyserTest)
         MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -6017,10 +5757,7 @@ SUITE(MxlAnalyserTest)
         MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -6062,10 +5799,7 @@ SUITE(MxlAnalyserTest)
         MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -6108,10 +5842,7 @@ SUITE(MxlAnalyserTest)
         MxlAnalyser a(errormsg, m_libraryScope, &doc, &parser);
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_document() == true );
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
@@ -6165,10 +5896,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_note() == true );
         ImoNote* pNote = dynamic_cast<ImoNote*>( pRoot );
@@ -6222,10 +5950,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -6320,10 +6045,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot == nullptr);
 
         a.do_not_delete_instruments_in_destructor();
@@ -6343,10 +6065,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_sound_change() == true );
         ImoSoundChange* pSC = dynamic_cast<ImoSoundChange*>( pRoot );
@@ -6371,10 +6090,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_sound_change() == true );
         ImoSoundChange* pSC = dynamic_cast<ImoSoundChange*>( pRoot );
@@ -6399,10 +6115,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_sound_change() == true );
         ImoSoundChange* pSC = dynamic_cast<ImoSoundChange*>( pRoot );
@@ -6429,10 +6142,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_sound_change() == true );
         ImoSoundChange* pSC = dynamic_cast<ImoSoundChange*>( pRoot );
@@ -6461,10 +6171,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_direction() == true );
         ImoDirection* pSO = dynamic_cast<ImoDirection*>( pRoot );
@@ -6506,10 +6213,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -6581,10 +6285,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -6683,10 +6384,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -6759,10 +6457,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_staff_info() == true );
         ImoStaffInfo* pInfo = dynamic_cast<ImoStaffInfo*>( pRoot );
@@ -6796,10 +6491,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_staff_info() == true );
         ImoStaffInfo* pInfo = dynamic_cast<ImoStaffInfo*>( pRoot );
@@ -6834,10 +6526,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_time_signature() == true );
         ImoTimeSignature* pTimeSignature = dynamic_cast<ImoTimeSignature*>( pRoot );
@@ -6865,10 +6554,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_time_signature() == true );
         ImoTimeSignature* pTimeSignature = dynamic_cast<ImoTimeSignature*>( pRoot );
@@ -6901,10 +6587,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_note() == true );
         ImoNote* pNote = dynamic_cast<ImoNote*>( pRoot );
@@ -6941,10 +6624,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_transpose() == true );
         ImoTranspose* pSO = dynamic_cast<ImoTranspose*>( pRoot );
@@ -6979,10 +6659,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_transpose() == true );
         ImoTranspose* pSO = dynamic_cast<ImoTranspose*>( pRoot );
@@ -7016,10 +6693,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         CHECK( pRoot && pRoot->is_transpose() == true );
         ImoTranspose* pSO = dynamic_cast<ImoTranspose*>( pRoot );
@@ -7060,10 +6734,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         CHECK( pDoc != nullptr );
@@ -7140,10 +6811,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -7219,10 +6888,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         ImoScore* pScore = dynamic_cast<ImoScore*>( pDoc->get_content_item(0) );
@@ -7285,10 +6952,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         CHECK( pDoc != nullptr );
@@ -7396,10 +7061,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         CHECK( pDoc != nullptr );
@@ -7502,7 +7165,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         CHECK( pDoc != nullptr );
@@ -7575,10 +7238,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -7657,10 +7318,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -7739,10 +7398,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -7842,10 +7499,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -7986,9 +7641,7 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
+//        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -8069,9 +7722,7 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
+//        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -8152,9 +7803,7 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
+//        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -8235,9 +7884,7 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
+//        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -8317,9 +7964,7 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-//        CHECK( errormsg.str() == expected.str() );
+//        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         if (pDoc)
@@ -8385,10 +8030,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot == nullptr);
         //AWARE: initialy <divisions>==1
         CHECK( is_equal_time(a.get_current_time(), 0.0f) );
@@ -8425,10 +8067,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot && pRoot->is_document() );
 
         std::map<int, long>& voices = a.my_get_voice_times();
@@ -8485,10 +8125,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot && pRoot->is_document() );
 
         CHECK( a.my_get_num_voices() == 1 );
@@ -8543,10 +8181,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot && pRoot->is_document() );
 
         std::map<int, long>& voices = a.my_get_voice_times();
@@ -8613,10 +8249,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot && pRoot->is_document() );
 
         CHECK( a.my_get_num_voices() == 2 );
@@ -8683,10 +8317,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot && pRoot->is_document() );
 
         std::map<int, long>& voices = a.my_get_voice_times();
@@ -8756,10 +8388,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot && pRoot->is_document() );
 
         std::map<int, long>& voices = a.my_get_voice_times();
@@ -8830,10 +8460,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot && pRoot->is_document() );
 
         std::map<int, long>& voices = a.my_get_voice_times();
@@ -8901,10 +8529,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot && pRoot->is_document() );
 
         std::map<int, long>& voices = a.my_get_voice_times();
@@ -8974,10 +8600,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot && pRoot->is_document() );
 
         std::map<int, long>& voices = a.my_get_voice_times();
@@ -9047,10 +8671,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot && pRoot->is_document() );
 
         std::map<int, long>& voices = a.my_get_voice_times();
@@ -9128,11 +8750,9 @@ SUITE(MxlAnalyserTest)
                       Document::k_format_mxl);
         ImoScore* pScore = dynamic_cast<ImoScore*>( doc.get_content_item(0) );
         CHECK( pScore != nullptr );
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
         ImoInstrument* pInstr = pScore->get_instrument(0);
         ImoMusicData* pMD = pInstr->get_musicdata();
@@ -9165,15 +8785,13 @@ SUITE(MxlAnalyserTest)
                       Document::k_format_mxl);
         ImoScore* pScore = dynamic_cast<ImoScore*>( doc.get_content_item(0) );
         CHECK( pScore != nullptr );
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
 
 //        cout << test_name() << endl;
 //        ColStaffObjs* pTable = pScore->get_staffobjs_table();
 //        cout << pTable->dump();
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
         ImoInstrument* pInstr = pScore->get_instrument(0);
         ImoMusicData* pMD = pInstr->get_musicdata();
@@ -9238,10 +8856,8 @@ SUITE(MxlAnalyserTest)
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
 //        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot && pRoot->is_document() );
 
         std::map<int, long>& voices = a.my_get_voice_times();
@@ -9300,10 +8916,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-//        cout << test_name() << endl;
-//        cout << "[" << errormsg.str() << "]" << endl;
-//        cout << "[" << expected.str() << "]" << endl;
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         CHECK( pDoc != nullptr );
@@ -9357,7 +8970,7 @@ SUITE(MxlAnalyserTest)
         XmlNode* tree = parser.get_tree_root();
         ImoObj* pRoot =  a.analyse_tree(tree, "string:");
 
-        CHECK( errormsg.str() == expected.str() );
+        CHECK( check_errormsg(errormsg, expected) );
         CHECK( pRoot != nullptr);
         ImoDocument* pDoc = dynamic_cast<ImoDocument*>( pRoot );
         CHECK( pDoc != nullptr );

--- a/src/tests/lomse_test_mxl_exporter.cpp
+++ b/src/tests/lomse_test_mxl_exporter.cpp
@@ -78,10 +78,16 @@ public:
         return UnitTest::CurrentTest::Details()->testName;
     }
 
+    inline void failure_header()
+    {
+        cout << endl << "*** Failure in " << test_name() << ":" << endl;
+    }
+
     bool check_result(const string& ss, const string& expected)
     {
         if (ss != expected)
         {
+            failure_header();
             cout << "  result=[" << ss << "]" << endl;
             cout << "expected=[" << expected << "]" << endl;
             return false;
@@ -93,6 +99,7 @@ public:
     {
         if (ss.find(expected) == std::string::npos)
         {
+            failure_header();
             size_t iStart = ss.find("<"+tag);
             if(iStart == std::string::npos)
                 cout << "  result=[" << ss << "]" << endl;
@@ -113,11 +120,35 @@ public:
         return true;
     }
 
+    bool check_result_contains(const string& ss, const string& expected,
+                               const string& start, const string& stop)
+    {
+        if (ss.find(expected) == std::string::npos)
+        {
+            failure_header();
+            size_t iStart = ss.find(start);
+            if(iStart == std::string::npos)
+                cout << "  result=[" << ss << "]" << endl;
+            else
+            {
+                size_t iEnd = ss.find(stop, iStart);
+                if(iEnd == std::string::npos)
+                    cout << "  result=[" << ss.substr(iStart) << "]" << endl;
+                else
+                    cout << "  result=[" << ss.substr(iStart, iEnd-iStart) << "]" << endl;
+            }
+            cout << "expected=[" << expected << "]" << endl;
+            return false;
+        }
+        return true;
+    }
+
     bool check_errormsg_empty(const string& msg)
     {
         if (!msg.empty())
         {
-            cout << "Expected empty erro msg. but msg=[" << msg << "]" << endl;
+            failure_header();
+            cout << "Expected empty error msg. but msg=[" << msg << "]" << endl;
             return false;
         }
         return true;
@@ -159,15 +190,11 @@ SUITE(MxlExporterTest)
 //        //Lilypond tests
 //        //02b-Rests-PitchedRests.xml", Document::k_format_mxl);
 //        //12a-Clefs.xml", Document::k_format_mxl);
-//        //doc.from_file(m_scores_path + "unit-tests/xml-export/45e-Repeats-Nested-Alternatives.xml", Document::k_format_mxl);
-//        //doc.from_file(m_scores_path + "unit-tests/xml-export/MozartTrio.xml", Document::k_format_mxl);
-//        doc.from_file(m_scores_path + "unit-tests/xml-export/BeetAnGeSample.xml", Document::k_format_mxl);
-//        //doc.from_file(m_scores_path + "unit-tests/xml-export/61k-Lyrics.xml", Document::k_format_mxl);
-//        //doc.from_file(m_scores_path + "unit-tests/xml-export/003-slur.xml", Document::k_format_mxl);
 //        //doc.from_file(m_scores_path + "00205-multimetric.lmd", Document::k_format_lmd );
 //        //doc.from_file(m_scores_path + "00023-spacing-in-prolog-two-instr.lms" );
 ////        doc.from_file(m_scores_path + "50120-fermatas.lms" );
-////        doc.from_file(m_scores_path + "50051-tie-bezier.lms" );
+//        //doc.from_file(m_scores_path + "unit-tests/xml-export/018-clef-change-barline-double.xml", Document::k_format_mxl);
+//        doc.from_file("/datos/cecilio/lm/projects/lomse//vregress/scores/lilypond/01e-Pitches-ParenthesizedAccidentals.xml", Document::k_format_mxl);
 ////        doc.from_file(m_scores_path + "00110-triplet-against-5-tuplet-4.14.lms" );
 ////        doc.from_file(m_scores_path + "50130-metronome.lms" );
 ////        doc.from_file(m_scores_path + "50180-new-system-tag.lms" );
@@ -317,6 +344,42 @@ SUITE(MxlExporterTest)
         CHECK( check_result(source, expected) );
     }
 
+    TEST_FIXTURE(MxlExporterTestFixture, attributes_02)
+    {
+        //@02. attributes: staff-details
+
+        Document doc(m_libraryScope);
+        doc.from_string("<score-partwise version='3.0'><part-list>"
+            "<score-part id='P1'><part-name/></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "<attributes>"
+                "<clef><sign>G</sign><line>2</line></clef>"
+                "<staff-details>"
+                    "<staff-lines>1</staff-lines>"
+                    "<staff-size scaling=\"100\">167</staff-size>"
+                "</staff-details>"
+            "</attributes>"
+            "</measure>"
+            "</part></score-partwise>", Document::k_format_mxl );
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+
+        MxlExporter exporter(m_libraryScope);
+        exporter.set_remove_newlines(true);
+        exporter.set_current_score(pScore);
+        exporter.set_current_instrument(pInstr);
+        exporter.set_remove_separator_lines(true);
+        string source = exporter.get_source(pMD);
+        string expected =
+                "<staff-details>"
+                    "<staff-lines>1</staff-lines>"
+                    "<staff-size scaling=\"100\">167</staff-size>"
+                "</staff-details>";
+        CHECK( check_result_contains(source, expected, "staff-details") );
+    }
+
     //@ backup --------------------------------------------------------------------------
 
     TEST_FIXTURE(MxlExporterTestFixture, backup_01)
@@ -353,9 +416,9 @@ SUITE(MxlExporterTest)
 
     //@ barline -------------------------------------------------------------------------
 
-    TEST_FIXTURE(MxlExporterTestFixture, barline_00)
+    TEST_FIXTURE(MxlExporterTestFixture, barline_01)
     {
-        //@00. barline. end barline
+        //@01. barline. end barline
 
         Document doc(m_libraryScope);
         doc.from_string("(score (vers 2.0) (instrument (musicData (r q)(barline end))))");
@@ -378,9 +441,9 @@ SUITE(MxlExporterTest)
         CHECK( check_result(source, expected) );
     }
 
-    TEST_FIXTURE(MxlExporterTestFixture, barline_01)
+    TEST_FIXTURE(MxlExporterTestFixture, barline_02)
     {
-        //@01. barline. regular barline
+        //@02. barline. regular barline
 
         Document doc(m_libraryScope);
         doc.from_string("(score (vers 2.0) (instrument (musicData (r q)(barline))))");
@@ -402,9 +465,9 @@ SUITE(MxlExporterTest)
         CHECK( check_result(source, expected) );
     }
 
-    TEST_FIXTURE(MxlExporterTestFixture, barline_02)
+    TEST_FIXTURE(MxlExporterTestFixture, barline_03)
     {
-        //@02. barline. start repetition
+        //@03. barline. start repetition
 
         Document doc(m_libraryScope);
         doc.from_string("(score (vers 2.0) (instrument (musicData "
@@ -434,9 +497,9 @@ SUITE(MxlExporterTest)
         CHECK( check_result(source, expected) );
     }
 
-    TEST_FIXTURE(MxlExporterTestFixture, barline_03)
+    TEST_FIXTURE(MxlExporterTestFixture, barline_04)
     {
-        //@03. barline. double repetition
+        //@04. barline. double repetition
 
         Document doc(m_libraryScope);
         doc.from_string("(score (vers 2.0) (instrument (musicData "
@@ -474,9 +537,9 @@ SUITE(MxlExporterTest)
         CHECK( check_result(source, expected) );
     }
 
-    TEST_FIXTURE(MxlExporterTestFixture, barline_04)
+    TEST_FIXTURE(MxlExporterTestFixture, barline_05)
     {
-        //@04. barline. no visible
+        //@05. barline. no visible
 
         Document doc(m_libraryScope);
         doc.from_string("(score (vers 2.0) (instrument (musicData "
@@ -502,6 +565,83 @@ SUITE(MxlExporterTest)
             "<barline><bar-style>light-heavy</bar-style></barline>"
             "</measure>";
         CHECK( check_result(source, expected) );
+    }
+
+    TEST_FIXTURE(MxlExporterTestFixture, barline_06)
+    {
+        //@06. barline. end barline. multi-instrument
+
+        Document doc(m_libraryScope);
+        doc.from_file(m_scores_path + "unit-tests/xml-export/014-end-barlines.xml", Document::k_format_mxl);
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+        MxlExporter exporter(m_libraryScope);
+        exporter.set_remove_newlines(true);
+        exporter.set_current_score(pScore);
+        exporter.set_remove_separator_lines(true);
+
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+        exporter.set_current_instrument(pInstr);
+        string source = exporter.get_source(pMD);
+        string expected =
+            "<measure number=\"1\">"
+            "<attributes><divisions>480</divisions>"
+                "<clef><sign>G</sign><line>2</line></clef>"
+            "</attributes>"
+            "<note><pitch><step>D</step><octave>4</octave></pitch>"
+                "<duration>480</duration><voice>1</voice><type>quarter</type></note>"
+            "<barline><bar-style>light-heavy</bar-style></barline>"
+            "</measure>";
+        CHECK( check_result(source, expected) );
+
+        pInstr = pScore->get_instrument(1);
+        pMD = pInstr->get_musicdata();
+        exporter.set_current_instrument(pInstr);
+        source = exporter.get_source(pMD);
+        expected =
+            "<measure number=\"1\">"
+            "<attributes><divisions>480</divisions>"
+                "<clef><sign>F</sign><line>4</line></clef>"
+            "</attributes>"
+            "<note><pitch><step>A</step><octave>3</octave></pitch>"
+                "<duration>480</duration><voice>1</voice><type>quarter</type></note>"
+            "<barline><bar-style>light-heavy</bar-style></barline>"
+            "</measure>";
+        CHECK( check_result(source, expected) );
+    }
+
+    TEST_FIXTURE(MxlExporterTestFixture, barline_07)
+    {
+        //@07. barline. volta-bracket
+
+        Document doc(m_libraryScope);
+        doc.from_file(m_scores_path + "unit-tests/xml-export/015-volta-brackets.xml", Document::k_format_mxl);
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+        MxlExporter exporter(m_libraryScope);
+        exporter.set_remove_newlines(true);
+        exporter.set_current_score(pScore);
+        exporter.set_remove_separator_lines(true);
+
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+        exporter.set_current_instrument(pInstr);
+        string source = exporter.get_source(pMD);
+        string expected = "<measure number=\"2\">"
+            "<barline location=\"left\"><ending number=\"1\" type=\"start\"/></barline>";
+        CHECK( check_result_contains(source, expected, "<measure number=\"2\">", "</barline>") );
+
+        expected = "<barline>"
+            "<bar-style>light-heavy</bar-style><ending number=\"1\" type=\"stop\"/>"
+            "<repeat direction=\"backward\"/></barline>";
+        CHECK( check_result_contains(source, expected, "<barline>", "</barline>") );
+
+        expected = "<measure number=\"3\">"
+            "<barline location=\"left\"><ending number=\"2\" type=\"start\"/></barline>";
+        CHECK( check_result_contains(source, expected, "<measure number=\"3\">", "</barline>") );
+
+        expected = "<barline>"
+            "<ending number=\"2\" type=\"discontinue\"/></barline>";
+        CHECK( check_result_contains(source, expected, "<barline><ending number=\"2\"", "</barline>") );
     }
 
     // @ beam ---------------------------------------------------------------------------
@@ -677,6 +817,142 @@ SUITE(MxlExporterTest)
         CHECK( check_result(source, expected) );
     }
 
+    //@ defaults ------------------------------------------------------------------------
+
+    TEST_FIXTURE(MxlExporterTestFixture, defaults_01)
+    {
+        //@01. defaults not exported when not imported from MusicXML
+
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument (musicData"
+                "(clef G)(n c4 q) )))");
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+
+        MxlExporter exporter(m_libraryScope);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pScore);
+        string expected = "</identification><part-list>";
+        CHECK( check_result_contains(source, expected, "</identification>", "<score-part") );
+    }
+
+    TEST_FIXTURE(MxlExporterTestFixture, defaults_02)
+    {
+        //@02. scaling
+
+        Document doc(m_libraryScope);
+        doc.from_string("<score-partwise version='3.0'>"
+            "<defaults>"
+            "<scaling><millimeters>7.2</millimeters><tenths>40</tenths></scaling>"
+                "</defaults>"
+            "<part-list><score-part id='P1'><part-name>Music</part-name></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "</measure>"
+            "</part></score-partwise>", Document::k_format_mxl );
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+
+        MxlExporter exporter(m_libraryScope);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pScore);
+        string expected = "<defaults><scaling><millimeters>7.2</millimeters>"
+            "<tenths>40</tenths></scaling>";
+        CHECK( check_result_contains(source, expected, "<defaults>", "</scaling>") );
+    }
+
+    TEST_FIXTURE(MxlExporterTestFixture, defaults_03)
+    {
+        //@03. page layout
+
+        Document doc(m_libraryScope);
+        doc.from_string("<score-partwise version='3.0'>"
+            "<defaults>"
+            "<scaling><millimeters>3.7703</millimeters><tenths>40</tenths></scaling>"
+            "<page-layout>"
+                "<page-height>954</page-height><page-width>1804</page-width>"
+                "<page-margins type=\"both\">"
+                "<left-margin>318</left-margin><right-margin>212</right-margin>"
+                "<top-margin>53</top-margin><bottom-margin>74</bottom-margin>"
+                "</page-margins></page-layout></defaults>"
+            "<part-list><score-part id='P1'><part-name>Music</part-name></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "</measure>"
+            "</part></score-partwise>", Document::k_format_mxl );
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+
+        MxlExporter exporter(m_libraryScope);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pScore);
+        string expected =
+            "<scaling><millimeters>3.7703</millimeters><tenths>40</tenths></scaling>"
+            "<page-layout>"
+            "<page-height>954</page-height><page-width>1804</page-width>"
+            "<page-margins type=\"both\">"
+            "<left-margin>318</left-margin><right-margin>212</right-margin>"
+            "<top-margin>53</top-margin><bottom-margin>74</bottom-margin>"
+            "</page-margins></page-layout>";
+        CHECK( check_result_contains(source, expected, "<scaling>", "</page-layout>") );
+    }
+
+    TEST_FIXTURE(MxlExporterTestFixture, defaults_04)
+    {
+        //@04. system layout
+
+        Document doc(m_libraryScope);
+        doc.from_string("<score-partwise version='3.0'>"
+            "<defaults>"
+            "<scaling><millimeters>3.7703</millimeters><tenths>40</tenths></scaling>"
+            "<system-layout>"
+                "<system-margins><left-margin>248</left-margin>"
+                    "<right-margin>206</right-margin></system-margins>"
+                "<system-distance>561</system-distance>"
+                "<top-system-distance>436</top-system-distance>"
+            "</system-layout></defaults>"
+            "<part-list><score-part id='P1'><part-name>Music</part-name></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "</measure>"
+            "</part></score-partwise>", Document::k_format_mxl );
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+
+        MxlExporter exporter(m_libraryScope);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pScore);
+        string expected = "<system-layout>"
+                "<system-margins><left-margin>248</left-margin>"
+                    "<right-margin>206</right-margin></system-margins>"
+                "<system-distance>561</system-distance>"
+                "<top-system-distance>436</top-system-distance>"
+            "</system-layout>";
+        CHECK( check_result_contains(source, expected, "system-layout") );
+    }
+
+//    TEST_FIXTURE(MxlExporterTestFixture, defaults_05)
+//    {
+//        //@05. staff layout
+//
+//        Document doc(m_libraryScope);
+//        doc.from_string("<score-partwise version='3.0'>"
+//            "<defaults>"
+//            "<scaling><millimeters>3.7703</millimeters><tenths>40</tenths></scaling>"
+//            "<staff-layout>"
+//                "<staff-distance>90</staff-distance>"
+//            "</staff-layout></defaults>"
+//            "<part-list><score-part id='P1'><part-name>Music</part-name></score-part>"
+//            "</part-list><part id='P1'>"
+//            "<measure number='1'>"
+//            "</measure>"
+//            "</part></score-partwise>", Document::k_format_mxl );
+//        ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+//
+//        MxlExporter exporter(m_libraryScope);
+//        exporter.set_remove_newlines(true);
+//        string source = exporter.get_source(pScore);
+//        string expected = "<staff-layout>"
+//                "<staff-distance>90</staff-distance></staff-layout>";
+//        CHECK( check_result_contains(source, expected, "staff-layout") );
+//    }
+
     //@ direction -----------------------------------------------------------------------
 
     TEST_FIXTURE(MxlExporterTestFixture, direction_01)
@@ -745,7 +1021,7 @@ SUITE(MxlExporterTest)
 
         Document doc(m_libraryScope);
         doc.from_string("(score (vers 2.0) (instrument"
-                "(musicData (clef G)(metronome e. q)(n d4 q) )))");
+                "(musicData (clef G)(metronome l. q)(n d4 q) )))");
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
         ImoInstrument* pInstr = pScore->get_instrument(0);
         ImoMusicData* pMD = pInstr->get_musicdata();
@@ -757,7 +1033,7 @@ SUITE(MxlExporterTest)
         exporter.set_current_instrument(pInstr);
         string source = exporter.get_source(*it);
             string expected = "<direction><direction-type>"
-                "<metronome><beat-unit>eighth</beat-unit>"
+                "<metronome><beat-unit>long</beat-unit>"
                 "<beat-unit-dot/>"
                 "<beat-unit>quarter</beat-unit></metronome>"
                 "</direction-type></direction>";
@@ -1235,6 +1511,41 @@ SUITE(MxlExporterTest)
         CHECK( check_result(source, expected) );
     }
 
+    TEST_FIXTURE(MxlExporterTestFixture, direction_18)
+    {
+        //@18. direction. words placement
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        parser.parse_text(
+            "<direction><direction-type>"
+                "<words default-x=\"-1\" default-y=\"15\" "
+                "font-size=\"medium\" font-weight=\"bold\">Bold, Medium</words>"
+            "</direction-type></direction>");
+        MyMxlAnalyser2 a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot =  a.analyse_tree(tree, "string:");
+
+        CHECK( check_errormsg_empty(errormsg.str()) );
+        CHECK( pRoot && pRoot->is_direction() == true );
+        ImoDirection* pImo = dynamic_cast<ImoDirection*>( pRoot );
+        CHECK( pImo != nullptr );
+        if (pImo)
+        {
+            MxlExporter exporter(m_libraryScope);
+            exporter.set_remove_newlines(true);
+            string source = exporter.get_source(pImo);
+            string expected = "<direction><direction-type>"
+                "<words default-x=\"-1\" default-y=\"15\">Bold, Medium</words>"
+                "</direction-type></direction>";
+            CHECK( check_result(source, expected) );
+        }
+
+        a.do_not_delete_instruments_in_destructor();
+        delete pRoot;
+    }
+
     //@ key -----------------------------------------------------------------------------
 
     TEST_FIXTURE(MxlExporterTestFixture, key_01)
@@ -1339,6 +1650,50 @@ SUITE(MxlExporterTest)
         string expected = "<attributes><key relative-x=\"10\" print-object=\"no\">"
             "<fifths>3</fifths><mode>major</mode></key>";
         CHECK( check_result(source, expected) );
+    }
+
+    TEST_FIXTURE(MxlExporterTestFixture, key_05)
+    {
+        //@05 non-standard key. key-octave
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        parser.parse_text(
+            "<key>"
+                "<key-step>G</key-step>"
+                "<key-alter>-1.5</key-alter>"
+                "<key-step>A</key-step>"
+                "<key-alter>1.5</key-alter>"
+                "<key-octave number=\"1\">2</key-octave>"
+                "<key-octave number=\"2\">3</key-octave>"
+            "</key>"
+        );
+        MyMxlAnalyser2 a(errormsg, m_libraryScope, &doc, &parser);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot =  a.analyse_tree(tree, "string:");
+
+        CHECK( check_errormsg_empty(errormsg.str()) );
+        CHECK( pRoot && pRoot->is_key_signature() == true );
+        ImoKeySignature* pKey = dynamic_cast<ImoKeySignature*>( pRoot );
+        CHECK( pKey != nullptr );
+        if (pKey)
+        {
+            MxlExporter exporter(m_libraryScope);
+            exporter.set_remove_newlines(true);
+            string source = exporter.get_source(pKey);
+            string expected = "<attributes><key><key-step>G</key-step>"
+                "<key-alter>-1.5</key-alter>"
+                "<key-accidental>three-quarters-flat</key-accidental>"
+                "<key-step>A</key-step><key-alter>1.5</key-alter>"
+                "<key-accidental>three-quarters-sharp</key-accidental>"
+                "<key-octave number=\"1\">2</key-octave>"
+                "<key-octave number=\"2\">3</key-octave></key>";
+            CHECK( check_result(source, expected) );
+        }
+
+        a.do_not_delete_instruments_in_destructor();
+        delete pRoot;
     }
 
     //@ lyric ---------------------------------------------------------------------------
@@ -1584,6 +1939,108 @@ SUITE(MxlExporterTest)
         CHECK( check_result(source, expected) );
     }
 
+    //@ measure -------------------------------------------------------------------------
+
+    TEST_FIXTURE(MxlExporterTestFixture, measure_01)
+    {
+        //@01. measure. StaffObjs for start and end of measure correctly identified
+
+        Document doc(m_libraryScope);
+        doc.from_file(m_scores_path + "unit-tests/xml-export/017-clef-change-at-start-of-measure.xml",
+                      Document::k_format_mxl);
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+
+        MxlExporter exporter(m_libraryScope);
+        exporter.set_remove_newlines(true);
+        exporter.set_remove_separator_lines(true);
+        exporter.set_current_score(pScore);
+        exporter.set_current_instrument(pInstr);
+        string source = exporter.get_source(pMD);
+
+        string expected ="</note></measure>";
+        CHECK( check_result_contains(source, expected, "</note>", "<measure") );
+
+        expected = "<measure number=\"2\">"
+            "<attributes><clef><sign>F</sign><line>4</line></clef></attributes>"
+            "<note><pitch><step>D</step><octave>3</octave>";
+        CHECK( check_result_contains(source, expected, "<measure number=\"2\">", "</pitch>") );
+    }
+
+    TEST_FIXTURE(MxlExporterTestFixture, measure_02)
+    {
+        //@02. measure. as test 01 but with barline type=double
+
+        Document doc(m_libraryScope);
+        doc.from_file(m_scores_path + "unit-tests/xml-export/018-clef-change-barline-double.xml",
+                      Document::k_format_mxl);
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+
+        MxlExporter exporter(m_libraryScope);
+        exporter.set_remove_newlines(true);
+        exporter.set_remove_separator_lines(true);
+        exporter.set_current_score(pScore);
+        exporter.set_current_instrument(pInstr);
+
+        string source = exporter.get_source(pMD);
+        string expected = "<octave>4</octave></pitch>"
+            "<duration>480</duration><voice>1</voice><type>quarter</type></note>"
+            "<barline><bar-style>light-light</bar-style></barline>"
+            "</measure>";
+        CHECK( check_result_contains(source, expected, "<octave>4", "<measure") );
+
+        expected = "<measure number=\"2\">"
+            "<attributes><clef><sign>F</sign><line>4</line></clef></attributes>"
+            "<note><pitch><step>D</step><octave>3</octave></pitch>"
+            "<duration>480</duration><voice>1</voice><type>quarter</type></note>"
+            "</measure>";
+        CHECK( check_result_contains(source, expected, "<measure number=\"2\">", "</part") );
+    }
+
+    TEST_FIXTURE(MxlExporterTestFixture, measure_03)
+    {
+        //@03. measure. identify start/end of measure StaffObjs. Several clef changes
+
+        Document doc(m_libraryScope);
+        doc.from_file(m_scores_path + "unit-tests/xml-export/019-several-clef-changes.xml",
+                      Document::k_format_mxl);
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+
+        MxlExporter exporter(m_libraryScope);
+        exporter.set_remove_newlines(true);
+        exporter.set_remove_separator_lines(true);
+        exporter.set_current_score(pScore);
+        exporter.set_current_instrument(pInstr);
+
+        string source = exporter.get_source(pMD);
+        string expected = "<measure number=\"1\">"
+            "<attributes><divisions>480</divisions>"
+            "<clef><sign>G</sign><line>2</line></clef></attributes>"
+            "<note><pitch><step>C</step><octave>4</octave></pitch>"
+            "<duration>1920</duration><voice>1</voice><type>whole</type></note>"
+            "</measure>";
+        CHECK( check_result_contains(source, expected, " number=\"1\">", "<measure") );
+
+        expected = "<measure number=\"2\">"
+            "<attributes><clef><sign>C</sign><line>3</line></clef></attributes>"
+            "<note><pitch><step>C</step><octave>4</octave></pitch>"
+            "<duration>1920</duration><voice>1</voice><type>whole</type></note>"
+            "</measure>";
+        CHECK( check_result_contains(source, expected, "<measure number=\"2\">", "<measure") );
+
+        expected = "<measure number=\"3\">"
+            "<attributes><clef><sign>C</sign><line>4</line></clef></attributes>"
+            "<note><pitch><step>C</step><octave>4</octave></pitch>"
+            "<duration>1920</duration><voice>1</voice><type>whole</type></note>"
+            "</measure>";
+        CHECK( check_result_contains(source, expected, "<measure number=\"3\">", "</part") );
+    }
+
     //@ notations -----------------------------------------------------------------------
 
     TEST_FIXTURE(MxlExporterTestFixture, notations_01)
@@ -1593,7 +2050,7 @@ SUITE(MxlExporterTest)
         Document doc(m_libraryScope);
         doc.from_string("(score (vers 2.0)(instrument (musicData (clef G)"
             "(n e4 q (fermata above))"
-            "(r q (fermata below))"
+            "(r q (fermata very-short below))"
             ")))" );
         ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
         ImoInstrument* pInstr = pScore->get_instrument(0);
@@ -1607,14 +2064,14 @@ SUITE(MxlExporterTest)
         string source = exporter.get_source(*it);
         string expected = "<note><pitch><step>E</step><octave>4</octave></pitch>"
             "<duration>480</duration><voice>1</voice><type>quarter</type>"
-            "<notations><fermata/></notations></note>";
+            "<notations><fermata type=\"upright\"/></notations></note>";
         CHECK( check_result(source, expected) );
 
         ++it;   //rest
         source = exporter.get_source(*it);
         expected = "<note><rest/>"
             "<duration>480</duration><voice>1</voice><type>quarter</type>"
-            "<notations><fermata type=\"inverted\"/></notations></note>";
+            "<notations><fermata type=\"inverted\">double-angled</fermata></notations></note>";
         CHECK( check_result(source, expected) );
     }
 
@@ -1660,6 +2117,41 @@ SUITE(MxlExporterTest)
             "<notations><dynamics placement=\"above\"><sfz/></dynamics></notations>"
             "</note>";
         CHECK( check_result(source, expected) );
+    }
+
+    TEST_FIXTURE(MxlExporterTestFixture, notations_03)
+    {
+        //@03. notations. arpeggio
+
+        Document doc(m_libraryScope);
+        doc.from_file(m_scores_path + "unit-tests/xml-export/016-arpeggio.xml", Document::k_format_mxl);
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+        MxlExporter exporter(m_libraryScope);
+        exporter.set_remove_newlines(true);
+        exporter.set_current_score(pScore);
+        exporter.set_remove_separator_lines(true);
+
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+        exporter.set_current_instrument(pInstr);
+        string source = exporter.get_source(pMD);
+        string expected = "<note><pitch><step>C</step><octave>4</octave></pitch>"
+            "<duration>480</duration><voice>1</voice><type>quarter</type>"
+            "<notations><arpeggiate direction=\"up\"/></notations>"
+            "</note>";
+        CHECK( check_result_contains(source, expected, "<note><pitch><step>C", "</note>") );
+
+        expected = "<note><chord/><pitch><step>E</step><octave>5</octave></pitch>"
+            "<duration>480</duration><voice>1</voice><type>quarter</type>"
+            "<notations><arpeggiate/></notations>"
+            "</note>";
+        CHECK( check_result_contains(source, expected, "<note><chord/><pitch><step>E", "</note>") );
+
+        expected = "<note><chord/><pitch><step>G</step><octave>5</octave></pitch>"
+            "<duration>480</duration><voice>1</voice><type>quarter</type>"
+            "<notations><arpeggiate/></notations>"
+            "</note>";
+        CHECK( check_result_contains(source, expected, "<note><chord/><pitch><step>G", "</note>") );
     }
 
     //@ note ----------------------------------------------------------------------------
@@ -1872,6 +2364,27 @@ SUITE(MxlExporterTest)
         CHECK( check_result(source, expected) );
     }
 
+    TEST_FIXTURE(MxlExporterTestFixture, note_08)
+    {
+        //@08. note. attributes
+
+        Document doc(m_libraryScope);
+        doc.from_string("(score (vers 2.0) (instrument"
+                "(musicData (clef G)(n d4 q (visible no)) )))");
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+        ImoNote* pImo = static_cast<ImoNote*>(
+                                        pMD->get_child_of_type(k_imo_note_regular) );
+
+        MxlExporter exporter(m_libraryScope);
+        exporter.set_remove_newlines(true);
+        string source = exporter.get_source(pImo);
+        string expected = "<note print-object=\"no\"><pitch><step>D</step><octave>4</octave></pitch>"
+            "<duration>480</duration><voice>1</voice><type>quarter</type></note>";
+        CHECK( check_result(source, expected) );
+    }
+
     //@ ornaments -----------------------------------------------------------------------
 
     TEST_FIXTURE(MxlExporterTestFixture, ornaments_01)
@@ -2066,9 +2579,9 @@ SUITE(MxlExporterTest)
 
     //@ rest ----------------------------------------------------------------------------
 
-    TEST_FIXTURE(MxlExporterTestFixture, rest_00)
+    TEST_FIXTURE(MxlExporterTestFixture, rest_01)
     {
-        //@00. rest. minimal test
+        //@01. rest. minimal test
 
         Document doc(m_libraryScope);
         doc.from_string("(score (vers 2.0) (instrument"
@@ -2086,6 +2599,47 @@ SUITE(MxlExporterTest)
             "<duration>480</duration><voice>1</voice><type>quarter</type></note>";
         CHECK( exporter.get_divisions() == 480 );
         CHECK( check_result(source, expected) );
+    }
+
+    TEST_FIXTURE(MxlExporterTestFixture, rest_02)
+    {
+        //@02. rest. position on the staff
+
+        stringstream errormsg;
+        Document doc(m_libraryScope);
+        XmlParser parser;
+        parser.parse_text(
+            "<note>"
+                "<rest><display-step>E</display-step><display-octave>4</display-octave></rest>"
+                "<duration>96</duration>"
+                "<voice>1</voice>"
+                "<type>quarter</type>"
+            "</note>");
+        MyMxlAnalyser2 a(errormsg, m_libraryScope, &doc, &parser);
+        a.set_current_divisions(96);
+        XmlNode* tree = parser.get_tree_root();
+        ImoObj* pRoot =  a.analyse_tree(tree, "string:");
+
+        CHECK( check_errormsg_empty(errormsg.str()) );
+        CHECK( pRoot && pRoot->is_rest() == true );
+        ImoRest* pImo = dynamic_cast<ImoRest*>( pRoot );
+        CHECK( pImo != nullptr );
+        if (pImo)
+        {
+            MxlExporter exporter(m_libraryScope);
+            exporter.set_remove_newlines(true);
+            string source = exporter.get_source(pImo);
+            string expected = "<note>"
+                "<rest><display-step>E</display-step><display-octave>4</display-octave></rest>"
+                "<duration>480</duration>"
+                "<voice>1</voice>"
+                "<type>quarter</type>"
+                "</note>";
+            CHECK( check_result(source, expected) );
+        }
+
+        a.do_not_delete_instruments_in_destructor();
+        delete pRoot;
     }
 
     //@ slur ----------------------------------------------------------------------------
@@ -2184,6 +2738,40 @@ SUITE(MxlExporterTest)
             "<note><rest/><duration>960</duration><voice>2</voice><type>half</type><staff>2</staff></note>"
             "</measure>";
         CHECK( check_result(source, expected) );
+    }
+
+    TEST_FIXTURE(MxlExporterTestFixture, slur_03)
+    {
+        //@03. slur. placement
+
+        Document doc(m_libraryScope);
+        doc.from_string("<score-partwise version='3.0'><part-list>"
+            "<score-part id='P1'><part-name/></score-part>"
+            "</part-list><part id='P1'>"
+            "<measure number='1'>"
+            "<attributes><divisions>4</divisions><clef><sign>G</sign><line>2</line></clef></attributes>"
+            "<note><pitch><step>C</step><octave>4</octave></pitch>"
+            "<duration>4</duration><voice>1</voice><type>quarter</type>"
+            "<notations><slur number=\"1\" type=\"start\" placement=\"above\"/>"
+            "</notations></note>"
+            "<note><pitch><step>E</step><octave>4</octave></pitch><duration>4</duration>"
+            "<voice>1</voice><type>quarter</type>"
+            "<notations><slur number=\"1\" type=\"stop\"/>"
+            "</notations></note>"
+            "</measure>"
+            "</part></score-partwise>", Document::k_format_mxl );
+        ImoScore* pScore = static_cast<ImoScore*>( doc.get_im_root()->get_content_item(0) );
+        ImoInstrument* pInstr = pScore->get_instrument(0);
+        ImoMusicData* pMD = pInstr->get_musicdata();
+
+        MxlExporter exporter(m_libraryScope);
+        exporter.set_remove_newlines(true);
+        exporter.set_current_score(pScore);
+        exporter.set_current_instrument(pInstr);
+        exporter.set_remove_separator_lines(true);
+        string source = exporter.get_source(pMD);
+        string expected = "<slur number=\"1\" type=\"start\" placement=\"above\"/>";
+        CHECK( check_result_contains(source, expected, "slur") );
     }
 
     //@ technical -----------------------------------------------------------------------

--- a/test-scores/unit-tests/xml-export/006-pedal-lines.xml
+++ b/test-scores/unit-tests/xml-export/006-pedal-lines.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name/>
+      </score-part>
+    </part-list>
+  <part id="P1">
+   <measure number="1">
+      <attributes>
+         <divisions>8</divisions>
+         <key>
+            <fifths>0</fifths>
+            <mode>major</mode>
+         </key>
+         <time>
+            <beats>6</beats>
+            <beat-type>8</beat-type>
+         </time>
+         <clef>
+            <sign>F</sign>
+            <line>4</line>
+         </clef>
+      </attributes>
+      <direction>
+         <direction-type>
+            <pedal line="yes" type="start"/>
+         </direction-type>
+      </direction>
+      <note>
+         <pitch>
+            <step>D</step>
+            <octave>3</octave>
+         </pitch>
+         <duration>4</duration>
+         <voice>3</voice>
+         <type>eighth</type>
+         <stem>down</stem>
+         <beam number="1">begin</beam>
+      </note>
+      <note>
+         <pitch>
+            <step>D</step>
+            <octave>3</octave>
+         </pitch>
+         <duration>4</duration>
+         <voice>3</voice>
+         <type>eighth</type>
+         <stem>down</stem>
+         <beam number="1">continue</beam>
+      </note>
+      <note>
+         <pitch>
+            <step>D</step>
+            <octave>3</octave>
+         </pitch>
+         <duration>4</duration>
+         <voice>3</voice>
+         <type>eighth</type>
+         <stem>down</stem>
+         <beam number="1">end</beam>
+      </note>
+      <direction>
+         <direction-type>
+            <pedal line="yes" type="change"/>
+         </direction-type>
+      </direction>
+      <note>
+         <pitch>
+            <step>D</step>
+            <octave>3</octave>
+         </pitch>
+         <duration>4</duration>
+         <voice>3</voice>
+         <type>eighth</type>
+         <stem>down</stem>
+         <beam number="1">begin</beam>
+      </note>
+      <note>
+         <pitch>
+            <step>D</step>
+            <octave>3</octave>
+         </pitch>
+         <duration>4</duration>
+         <voice>3</voice>
+         <type>eighth</type>
+         <stem>down</stem>
+         <beam number="1">continue</beam>
+      </note>
+      <direction>
+         <direction-type>
+            <pedal line="yes" type="discontinue"/>
+         </direction-type>
+         <direction-type>
+            <words default-y="-79" font-size="7.2" font-style="italic">simile</words>
+         </direction-type>
+      </direction>
+      <note>
+         <pitch>
+            <step>D</step>
+            <octave>3</octave>
+         </pitch>
+         <duration>4</duration>
+         <voice>3</voice>
+         <type>eighth</type>
+         <stem>down</stem>
+         <beam number="1">end</beam>
+      </note>
+   </measure>
+    </part>
+  </score-partwise>

--- a/test-scores/unit-tests/xml-export/007-pedal-marks.xml
+++ b/test-scores/unit-tests/xml-export/007-pedal-marks.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name/>
+      </score-part>
+    </part-list>
+  <part id="P1">
+   <measure number="1">
+      <attributes>
+         <divisions>8</divisions>
+         <key>
+            <fifths>0</fifths>
+            <mode>major</mode>
+         </key>
+         <time>
+            <beats>6</beats>
+            <beat-type>8</beat-type>
+         </time>
+         <clef>
+            <sign>F</sign>
+            <line>4</line>
+         </clef>
+      </attributes>
+   <note default-x="16">
+      <rest/>
+      <duration>96</duration>
+      <voice>3</voice>
+      <type>quarter</type>
+   </note>
+   <direction placement="below">
+      <direction-type>
+         <pedal line="no" type="start" halign="left"/>
+      </direction-type>
+<!--      <offset sound="yes">-22</offset>
+      <sound damper-pedal="yes"/>   -->
+   </direction>
+   <note>
+      <pitch>
+         <step>C</step>
+         <octave>3</octave>
+      </pitch>
+      <duration>96</duration>
+      <voice>3</voice>
+      <type>quarter</type>
+      <stem>up</stem>
+   </note>
+   <direction placement="below">
+      <direction-type>
+         <pedal line="no" type="stop" halign="left"/>
+      </direction-type>
+<!--      <sound damper-pedal="no"/> -->
+   </direction>
+   <note>
+      <rest/>
+      <duration>48</duration>
+      <voice>3</voice>
+      <type>eighth</type>
+   </note>
+   <note>
+      <pitch>
+         <step>B</step>
+         <octave>2</octave>
+      </pitch>
+      <duration>48</duration>
+      <voice>3</voice>
+      <type>eighth</type>
+      <stem>up</stem>
+   </note>
+      </measure>
+    </part>
+  </score-partwise>

--- a/test-scores/unit-tests/xml-export/014-end-barlines.xml
+++ b/test-scores/unit-tests/xml-export/014-end-barlines.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 1.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name>P1</part-name>
+    </score-part>
+    <score-part id="P2">
+      <part-name>P2</part-name>
+    </score-part>
+  </part-list>
+  <!--=========================================================-->
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+  <!--=========================================================-->
+  <part id="P2">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+  <!--=========================================================-->
+</score-partwise>

--- a/test-scores/unit-tests/xml-export/015-volta-brackets.xml
+++ b/test-scores/unit-tests/xml-export/015-volta-brackets.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 1.0 Partwise//EN"
+                                "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise>
+  <identification>
+    <miscellaneous>
+      <miscellaneous-field name="description">A simple repeat with two 
+          alternative endings (volta brackets).</miscellaneous-field>
+    </miscellaneous>
+  </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>MusicXML Part</part-name>
+    </score-part>
+  </part-list>
+  <!--=========================================================-->
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          <mode>major</mode>
+        </key>
+        <time symbol="common">
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="2">
+      <barline location="left">
+        <ending number="1" type="start"/>
+      </barline>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        <ending number="1" type="stop"/>
+        <repeat direction="backward"/>
+      </barline>
+    </measure>
+    <!--=======================================================-->
+    <measure number="3">
+      <barline location="left">
+        <ending number="2" type="start"/>
+      </barline>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <barline location="right">
+        <ending number="2" type="discontinue"/>
+      </barline>
+    </measure>
+    <!--=======================================================-->
+    <measure number="4">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+  <!--=========================================================-->
+</score-partwise>

--- a/test-scores/unit-tests/xml-export/016-arpeggio.xml
+++ b/test-scores/unit-tests/xml-export/016-arpeggio.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 2.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name/>
+    </score-part>
+  </part-list>
+  <!--=========================================================-->
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>C</step><octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+        <notations><arpeggiate direction="up"/></notations>
+      </note>
+      <note>
+        <chord/>
+        <pitch>
+          <step>E</step><octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+        <notations><arpeggiate/></notations>
+      </note>
+      <note>
+        <chord/>
+        <pitch>
+          <step>G</step><octave>5</octave>
+        </pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+        <notations><arpeggiate/></notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/test-scores/unit-tests/xml-export/017-clef-change-at-start-of-measure.xml
+++ b/test-scores/unit-tests/xml-export/017-clef-change-at-start-of-measure.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 1.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name>P1</part-name>
+    </score-part>
+  </part-list>
+  <!--=========================================================-->
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+    </measure>
+    <measure number="2">
+      <attributes>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/test-scores/unit-tests/xml-export/018-clef-change-barline-double.xml
+++ b/test-scores/unit-tests/xml-export/018-clef-change-barline-double.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 1.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name>P1</part-name>
+    </score-part>
+  </part-list>
+  <!--=========================================================-->
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <barline location="right">
+        <bar-style>light-light</bar-style>
+      </barline>
+    </measure>
+    <measure number="2">
+      <attributes>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>D</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/test-scores/unit-tests/xml-export/019-several-clef-changes.xml
+++ b/test-scores/unit-tests/xml-export/019-several-clef-changes.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 1.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise>
+  <part-list>
+    <score-part id="P1">
+      <part-name/>
+    </score-part>
+  </part-list>
+  <!--=========================================================-->
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="2">
+      <attributes>
+        <clef>
+          <sign>C</sign>
+          <line>3</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="3">
+      <attributes>
+        <clef>
+          <sign>C</sign>
+          <line>4</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
+    </measure>
+  </part>
+  <!--=========================================================-->
+</score-partwise>


### PR DESCRIPTION
This PR fixes a lot of issues detected in MusicXML import/export round-trip automated tests:
- Staff position for rests (`<display-step>, <display-octave>`).
- Position for key accidentals (`<key-octave>`).
- Number of staff lines and scaling `<staff-details>`.
- Position for fermata (above, below) and symbol.
- Dynamic marks not exported in certain conditions.
- Hidden notes.
- Position (above, below) for slurs.
- Position for word directions.
- Issue with octave shifts.
- Final barline when several parts.
- Crash in multi-part scores when more than 16 parts.
- Volta brackets: `<ending>` not exported in barlines.
- Arpeggios not exported.
- defaults: not exported.
- Sometimes barline is duplicated.
- Strong accent & detached legato not exported.
- direction: staff not exported.

There are more issues pending to be solved, but this is left for a next PR.
