### PR TITLE
Fix bug in FreeFlowView when zooming

### DIFF
--- a/examples/samples/viewtypes/README.md
+++ b/examples/samples/viewtypes/README.md
@@ -9,3 +9,11 @@ This sample is a test for displaying and playing back scores using the different
 g++ -std=c++11 viewtypes-wx.cpp ../../tutorials/wxMidi/wxMidi.cpp ../../tutorials/wxMidi/wxMidiDatabase.cpp -o viewtypes `pkg-config --cflags liblomse` `wx-config --cflags` -I ../../tutorials/wxMidi/ `pkg-config --libs liblomse` `wx-config --libs` -lstdc++ -lportmidi -lporttime
 ```
 
+## Running
+
+```
+.\viewtypes
+```
+
+Please note that when selecting a new view type the window is not updated automatically. It is necessary to re-open the document, as the `Presenter` is tied to the old view type and a new view must be created.
+

--- a/examples/samples/viewtypes/viewtypes-wx.cpp
+++ b/examples/samples/viewtypes/viewtypes-wx.cpp
@@ -5,7 +5,7 @@
 // distribute this software, either in source code form or as a compiled
 // binary, for any purpose, commercial or non-commercial, and by any
 // means.
-// 
+//
 // In jurisdictions that recognize copyright laws, the author or authors
 // of this software dedicate any and all copyright interest in the
 // software to the public domain. We make this dedication for the benefit
@@ -13,7 +13,7 @@
 // successors. We intend this dedication to be an overt act of
 // relinquishment in perpetuity of all present and future rights to this
 // software under copyright law.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -21,7 +21,7 @@
 // OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
-// 
+//
 // For more information, please refer to <http:unlicense.org>
 //---------------------------------------------------------------------------------------
 
@@ -371,8 +371,8 @@ IMPLEMENT_APP(MyApp)
 bool MyApp::OnInit()
 {
     //DEBUG -----------------------------------------------------------------------------
-    logger.set_logging_mode(Logger::k_debug_mode);
-    logger.set_logging_areas(Logger::k_events | Logger::k_score_player);
+    glogger.set_logging_mode(Logger::k_debug_mode);
+    glogger.set_logging_areas(Logger::k_events | Logger::k_score_player);
 
 	// For debugging: send wxWidgets log messages to a file
     wxString sUserId = ::wxGetUserId();

--- a/src/mvc/lomse_graphic_view.cpp
+++ b/src/mvc/lomse_graphic_view.cpp
@@ -2220,8 +2220,7 @@ void FreeFlowView::zoom_in(Pixels UNUSED(x), Pixels UNUSED(y))
     //increase scale
     m_transform *= agg::trans_affine_scaling(1.05);
 
-    //invalidate view width
-    m_viewportSize.width = 0;
+    m_fUpdateGModel = true;
 }
 
 //---------------------------------------------------------------------------------------
@@ -2230,8 +2229,7 @@ void FreeFlowView::zoom_out(Pixels UNUSED(x), Pixels UNUSED(y))
     //decrease scale
     m_transform *= agg::trans_affine_scaling(1.0/1.05);
 
-    //invalidate view width
-    m_viewportSize.width = 0;
+    m_fUpdateGModel = true;
 }
 
 //---------------------------------------------------------------------------------------
@@ -2259,8 +2257,7 @@ void FreeFlowView::set_scale(double scale, Pixels UNUSED(x), Pixels UNUSED(y))
     double factor = scale / m_transform.scale();
     m_transform *= agg::trans_affine_scaling(factor);
 
-    //invalidate view width
-    m_viewportSize.width = 0;
+    m_fUpdateGModel = true;
 }
 
 


### PR DESCRIPTION
This PR fixes a bug in `FreeFlowView` which caused the rendering buffer to be painted white when the scale factor (zoom) was changed.

It also updates the sample `viewtypes` that could not be built after PR #371