### PR TITLE
Add method get_num_measures() and more documentation

### DIFF
--- a/docs/api/doxyfile
+++ b/docs/api/doxyfile
@@ -637,11 +637,13 @@ WARN_LOGFILE           = ../../zz_build-api/doxygen.log
 # with spaces.
 
 INPUT     = mainpages \
+			../../include/lomse_box_system.h \
 			../../include/lomse_command.h \
 			../../include/lomse_doorway.h \
 			../../include/lomse_drawer.h \
 			../../include/lomse_events.h \
 			../../include/lomse_fragment_mark.h \
+			../../include/lomse_gm_basic.h \
 			../../include/lomse_graphical_model.h \
 			../../include/lomse_graphic_view.h \
 			../../include/lomse_half_page_view.h \
@@ -657,6 +659,8 @@ INPUT     = mainpages \
 			../../include/lomse_pixel_formats.h \
 			../../include/lomse_presenter.h \
 			../../include/lomse_score_player.h \
+			../../include/lomse_shape_base.h \
+			../../include/lomse_shape_staff.h \
 			../../include/lomse_tempo_line.h \
 			../../include/lomse_view.h \
 			../../include/lomse_visual_effect.h \

--- a/docs/api/mainpages/overview.h
+++ b/docs/api/mainpages/overview.h
@@ -32,7 +32,6 @@ If you are new to Lomse, @b please read the @subpage page-introduction and then 
 - @subpage page-sound-generation
 - @subpage page-tasks
 - @subpage page-api-internal-model
-- @subpage page-graphical-model
 
 
 ## Other topics

--- a/include/lomse_box_system.h
+++ b/include/lomse_box_system.h
@@ -15,8 +15,10 @@
 
 //using namespace std;
 
+///@cond INTERNALS
 namespace lomse
 {
+///@endcond
 
 //forward declarations
 class GmoBoxScorePage;
@@ -26,7 +28,27 @@ class GmoBoxSliceStaff;
 class SystemLayouter;
 
 //---------------------------------------------------------------------------------------
-/** GmoBoxSystem represents a line of music in the printed score.
+/** %GmoBoxSystem is a container for all boxes and shapes that represents a line of music
+    in the printed score. Its bounding box encloses all the notation for the system.
+
+    %GmoBoxSystem is also responsible for storing and managing a table with
+    the relation timepos --> position for all occupied timepos in the score.
+
+    The recorded positions are for the center of note heads or rests. The last position
+    is for the barline (if exists).
+
+    This object is responsible for supplying all valid timepos and their positions
+    so that other objects could, for instance:
+        a) Determine the timepos to assign to a mouse click in a certain position.
+        b) Draw a grid of valid timepos
+        c) To determine the position for a beat.
+
+    Important: There can exist many entries for a given timepos, the first ones are the
+    x position for the non-timed staffobjs, and the last one is
+    the x position for the notes/rests at that timepos. For example,
+    a barline and the next note do have the same timepos, but they are placed at
+    different positions. This also happens when there exist non-timed staffobjs, such as
+    clefs, key  signatures and time signatures.
 */
 class GmoBoxSystem : public GmoBox
 {
@@ -46,8 +68,137 @@ protected:
     LUnits m_uFreeAtBottom = 0.0f;
 
 public:
+    ///@cond INTERNALS
+    //excluded from public API. Only for internal use.
     GmoBoxSystem(ImoScore* pScore);
     ~GmoBoxSystem();
+    ///@endcond
+
+
+	//measures info
+    /// @name Information about measures
+    //@{
+
+	/** Returns the index (0..n-1) for the measure that starts in this system, or
+	    -1 if no measures in this instrument.
+	    This index has nothing to do with the displayed measure number. First measure
+	    has always index 0 regardless of whether the first measure is measure number 1
+	    or is an incomplete measure (the score begins on pickup).
+
+	    @param iInstr The index (0..n-1), in current layout, for instrument to which this
+	        request refer to. Take into account that in polymetric music (music in which
+	        not all instruments have the same time signature) the measure number is not
+	        a common value for all instruments and, thus measure numbers in a system
+	        will depend on which instrument you refer to. Thus, it is necessary to
+	        specify an instrument.
+    */
+	int get_first_measure(int iInstr);
+
+	/** Returns the number of measures in this system for an instrument.
+
+	    @param iInstr The index (0..n-1), in current layout, for instrument to which this
+	        request refer to. Take into account that in polymetric music (music in which
+	        not all instruments have the same time signature) the number of measures is
+	        not a common value for all instruments and, thus the number of measures in
+	        a system will depend on which instrument you refer to. Thus, it is necessary
+	        to specify an instrument.
+    */
+	int get_num_measures(int iInstr);
+
+	/** Lomse considers two positions for barlines when they are at the end of a system:
+	    - the real position at end of a system, and
+	    - the virtual position at start of next system (the first
+          available position after prolog).
+
+        This method returns the virtual start position for the measure starting
+        the system.
+	*/
+    inline LUnits get_start_measure_xpos() { return m_origin.x + m_dxFirstMeasure; }
+
+    //@}    //measures info
+
+
+	//staves
+    /// @name Information about staves
+    //@{
+
+    /** Returns the shape object representing an staff.
+        @param absStaff Absolute index (0..n-1) to the desired staff. The top staff
+            in a system has index 0, the next one below it has index 1, and so on.
+    */
+    GmoShapeStaff* get_staff_shape(int absStaff);
+
+    /** Returns the shape object representing an staff.
+	    @param iInstr The index (0..n-1), in current layout, for the instrument to which
+	        this request refer to.
+        @param iStaff The index (0..n-1) to the desired staff referred to the instrument
+            iInstr. The top staff in an instrument has index 0, the next one below it has
+            index 1, and so on.
+    */
+    GmoShapeStaff* get_staff_shape(int iInstr, int iStaff);
+
+    /** Returns the instrument index (0..n-1), in current layout, to which a staff
+        belongs.
+        @param absStaff Absolute index (0..n-1) of the staff to which this request refer
+            to. The top staff in a system has index 0, the next one below it has index
+            1, and so on.
+    */
+    int instr_number_for_staff(int absStaff);
+
+    /** Helper method to convert absolute staff index into a relative one.
+        Once you know the instrument to which a staff belongs (by using method
+        instr_number_for_staff() ) this method allows to determine the relative staff
+        index (0..n-1) referred to the instrument.
+    */
+    int staff_number_for(int absStaff, int iInstr);
+
+    //@}    //staves
+
+
+	//timepos
+    /// @name Information about time positions and coordiantes
+    //@{
+
+    /** Returns the timepos at start of this system. */
+    TimeUnits start_time();
+
+    /** Returns the timepos at end of this system. */
+    TimeUnits end_time();
+
+    /** Returns the x position for the given timepos. This method only takes notes and
+        rests into account, ignoring other staff objects that could exist
+        at the same timepos in different locations, such as a barline or a clef before
+        the note/rest. The returned value is the x position at which notes/rests are
+        vertically aligned with notes/rests at the same timepos in other staves.
+        If there are no notes/rests at the requested timepos, this method provides an
+        approximated interpolated value.
+
+        The returned value is in logical units, relative to GmoDocPage origin.
+
+        @param timepos Absolute time units for the requested position.
+
+        See get_x_for_barline_at_time()
+    */
+    LUnits get_x_for_note_rest_at_time(TimeUnits timepos);
+
+    /** Returns the x position for the given timepos. This method takes only barlines
+        into account, ignoring other staff objects that could exist at the same timepos
+        (e.g. any staffobj after the barline). Therefore, the returned value is the x
+        position of the first barline found at the provided @c timepos.
+
+        The returned value is in logical units, relative to GmoDocPage origin.
+
+        @param timepos Absolute time units for the requested position.
+
+        See get_x_for_note_rest_at_time()
+    */
+    LUnits get_x_for_barline_at_time(TimeUnits timepos);
+
+    //@}    //timepos
+
+
+///@cond INTERNALS
+//excluded from public API. Only for internal use.
 
     //helpers for layout
     inline void set_top_limit(LUnits minLimit) { m_uFreeAtTop = minLimit - get_top(); }
@@ -77,51 +228,29 @@ public:
     //grid table: xPositions/timepos
     inline void set_time_grid_table(TimeGridTable* pGridTable) { m_pGridTable = pGridTable; }
     inline TimeGridTable* get_time_grid_table() { return m_pGridTable; }
-    TimeUnits start_time();
-    TimeUnits end_time();
-    LUnits get_x_for_note_rest_at_time(TimeUnits timepos);
-    LUnits get_x_for_barline_at_time(TimeUnits timepos);
 
 	//miscellaneous info
 	inline int get_system_number() { return m_iSystem; }
-    GmoShapeStaff* get_staff_shape(int absStaff);
-    GmoShapeStaff* get_staff_shape(int iInstr, int iStaff);
-    int instr_number_for_staff(int absStaff);
-    int staff_number_for(int absStaff, int iInstr);
     inline void set_page_number(int iPage) { m_iPage = iPage; }
 	inline int get_page_number() { return m_iPage; }
-
-	//measures info
-	/** Returns the index (0..n-1) for the measure that starts in this system, or
-	    -1 if no measures in this instrument
-    */
-	int get_first_measure(int iInstr);
-
-	/** Lomse considers two positions for barlines at the end of a system:
-	    - the real position at end of previous system, and
-	    - the virtual position at start of next system (the first
-          available position after prolog).
-
-        This method returns the virtual start position for the mesaure starting
-        the system.
-	*/
-    inline LUnits get_start_measure_xpos() { return m_origin.x + m_dxFirstMeasure; }
 
     //Staff shapes
     GmoShapeStaff* add_staff_shape(GmoShapeStaff* pShape);
     void add_num_staves_for_instrument(int staves);
     inline vector<GmoShapeStaff*>& get_staff_shapes() { return m_staffShapes; }
 
-    //hit tests related
-    int staff_at(LUnits y);
-
     //helper. User API related
     int get_num_instruments();
     LUnits tenths_to_logical(Tenths value, int iInstr=0, int iStaff=0);
 
+    //hit tests related
+    int staff_at(LUnits y);
+
     //debug
     string dump_timegrid_table();
     string dump_measures_info();
+
+///@endcond
 
 protected:
     //building measures table

--- a/include/lomse_shape_base.h
+++ b/include/lomse_shape_base.h
@@ -15,8 +15,10 @@
 #include <list>
 using namespace std;
 
+///@cond INTERNALS
 namespace lomse
 {
+///@endcond
 
 ////---------------------------------------------------------------------------------------
 ////level of shape
@@ -38,25 +40,50 @@ namespace lomse
 // enums for common values: aligment, justification, placement, etc.
 
 //line styles
+/** @ingroup enumerations
+
+	This enum describes the different supported styles for lines.
+
+	@#include <lomse_shape_base.h>
+*/
 enum ELineStyle { k_line_none=0, k_line_solid, k_line_long_dash,
                   k_line_short_dash, k_line_dot, k_line_dot_dash, };
 
 //line termination styles
+/** @ingroup enumerations
+
+	This enum describes the different terminal symbols for lines.
+
+	@#include <lomse_shape_base.h>
+*/
 enum ELineCap { k_cap_none = 0, k_cap_arrowhead, k_cap_arrowtail,
                 k_cap_circle, k_cap_square, k_cap_diamond, };
 
 //line edges
+/** @ingroup enumerations
+
+	This enum describes the different possibilities for ending a line stroke.
+
+	@#include <lomse_shape_base.h>
+*/
 enum ELineEdge
 {
-    k_edge_normal = 0,        // edge is perpendicular to line
-    k_edge_vertical,          // edge is always a vertical line
-    k_edge_horizontal         // edge is always a horizontal line
+    k_edge_normal = 0,        ///< Edge is perpendicular to line
+    k_edge_vertical,          ///< Edge is always a vertical line
+    k_edge_horizontal         ///< Edge is always a horizontal line
 };
 
 
 //---------------------------------------------------------------------------------------
 //EVAlign is used to indicate vertical alignment within a block: to the top,
 //middle or bottom
+/** @ingroup enumerations
+
+	This enum describes the different possibilities for vertical alignment of an object
+	within a block.
+
+	@#include <lomse_shape_base.h>
+*/
 enum EVAlign
 {
     k_valign_default = 0,   //alignment is not specified
@@ -67,16 +94,23 @@ enum EVAlign
 
 //---------------------------------------------------------------------------------------
 // EHAlign is used to indicate object justification
+/** @ingroup enumerations
+
+	This enum describes the different object justification possibilities.
+
+	@#include <lomse_shape_base.h>
+*/
 enum EHAlign
 {
-    k_halign_default = 0,   //alignment is not specified
-    k_halign_left,          //object aligned on left side
-    k_halign_right,         //object aligned on right side
-    k_halign_justify,       //object justified on both sides
-    k_halign_center,        //object centered
+    k_halign_default = 0,   ///< Alignment is not specified
+    k_halign_left,          ///> Object aligned on left side
+    k_halign_right,         ///> Object aligned on right side
+    k_halign_justify,       ///> Object justified on both sides
+    k_halign_center,        ///> Object centered
 };
 
 //---------------------------------------------------------------------------------------
+///@cond INTERNALS
 enum ELinkType
 {
 	k_link_simple = 0,
@@ -84,9 +118,11 @@ enum ELinkType
 	k_link_middle,
 	k_link_end,
 };
+///@endcond
 
 
 
+///@cond INTERNALS
 //---------------------------------------------------------------------------------------
 // auxiliary, to identify staffobjs associated to a voice and manage voice data
 class VoiceRelatedShape
@@ -105,27 +141,47 @@ public:
     inline void set_voice(int voice) { m_voice = voice; }
     inline int get_voice() { return m_voice; }
 };
+///@endcond
 
 
 
 //---------------------------------------------------------------------------------------
+/** %GmoSimpleShape is a basic shape that is not made made by combining other GmoShape
+    objects. Represents an <i>atomic</i> shape object, e.g. a line, a rectangle or
+    a glyph. See @ref GmoCompositeShape
+*/
 class GmoSimpleShape : public GmoShape
 {
-public:
-    virtual ~GmoSimpleShape();
-
 protected:
     GmoSimpleShape(ImoObj* pCreatorImo, int objtype, ShapeId idx, Color color);
+
+public:
+///@cond INTERNALS
+    virtual ~GmoSimpleShape();
+///@endcond
+
 };
 
 //---------------------------------------------------------------------------------------
+/** %GmoCompositeShape is a shape that is made from a combination of other GmoShape
+    objects. It is just a container for other GmoShape objects.
+    Its bounding box is the union of contained shapes bounding boxes.
+*/
 class GmoCompositeShape : public GmoShape
 {
 protected:
 	std::list<GmoShape*> m_components;	//constituent shapes
 
+    GmoCompositeShape(ImoObj* pCreatorImo, int objtype, ShapeId idx, Color color);
+
 public:
+///@cond INTERNALS
     ~GmoCompositeShape() override;
+///@endcond
+
+
+///@cond INTERNALS
+    //excluded from public API. Only for internal use.
 
     virtual int add(GmoShape* pShape);
 
@@ -141,8 +197,9 @@ public:
     inline std::list<GmoShape*>& get_components() { return m_components; }
     void set_color(Color color) override;
 
+///@endcond
+
 protected:
-    GmoCompositeShape(ImoObj* pCreatorImo, int objtype, ShapeId idx, Color color);
 	void recompute_bounds();
 };
 

--- a/include/lomse_shape_staff.h
+++ b/include/lomse_shape_staff.h
@@ -12,14 +12,20 @@
 
 #include "lomse_shape_base.h"
 
+///@cond INTERNALS
 namespace lomse
 {
+///@endcond
 
 //forward declarations
 class ImoStaffInfo;
 
 
 //---------------------------------------------------------------------------------------
+/** %GmoShapeStaff represents the staff lines for an staff in a system. Its bounding box
+    origin is at top-left of upper most staff line. The bottom of its bounding box is
+    the lower most staff line.
+*/
 class GmoShapeStaff : public GmoSimpleShape
 {
 protected:
@@ -28,9 +34,18 @@ protected:
     LUnits m_lineThickness;
 
 public:
+
+    ///@cond INTERNALS
+    //excluded from public API. Only for internal use.
     GmoShapeStaff(ImoObj* pCreatorImo, ShapeId idx, ImoStaffInfo* m_pStaff, int iStaff,
                   LUnits width, Color color);
     ~GmoShapeStaff();
+
+    ///@endcond
+
+
+///@cond INTERNALS
+//excluded from public API. Only for internal use.
 
 	//implementation of pure virtual methods in base class
     void on_draw(Drawer* pDrawer, RenderOptions& opt) override;
@@ -62,6 +77,8 @@ public:
 //    int         m_nOldSteps;		//to clear leger lines while dragging
 //    LUnits    m_uxOldPos;
 //    int         m_nPosOnStaff;		//line/space on staff on which this note is placed
+
+///@endcond
 
 };
 

--- a/src/graphic_model/lomse_box_system.cpp
+++ b/src/graphic_model/lomse_box_system.cpp
@@ -276,6 +276,12 @@ int GmoBoxSystem::get_first_measure(int iInstr)
 }
 
 //---------------------------------------------------------------------------------------
+int GmoBoxSystem::get_num_measures(int iInstr)
+{
+    return m_nMeasures[iInstr];
+}
+
+//---------------------------------------------------------------------------------------
 string GmoBoxSystem::dump_measures_info()
 {
     stringstream s;

--- a/src/tests/lomse_test_graphic_model.cpp
+++ b/src/tests/lomse_test_graphic_model.cpp
@@ -1149,6 +1149,31 @@ SUITE(GraphicModelTest)
         delete pIntor;
     }
 
+    TEST_FIXTURE(GraphicModelTestFixture, gm_api_002)
+    {
+        //@002. System: get num. measures and measure number
+
+        MyDoorway doorway;
+        LibraryScope libraryScope(cout, &doorway);
+        libraryScope.set_default_fonts_path(TESTLIB_FONTS_PATH);
+        SpDocument spDoc( new Document(libraryScope) );
+        spDoc->from_file(m_scores_path + "unit-tests/other/04-multimetric.lms",
+                         Document::k_format_ldp);
+        VerticalBookView* pView = static_cast<VerticalBookView*>(
+        Injector::inject_View(libraryScope, k_view_vertical_book) );
+        Interactor* pIntor = Injector::inject_Interactor(libraryScope, WpDocument(spDoc), pView, nullptr);
+        GraphicModel* pGModel = pIntor->get_graphic_model();
+        ImoId scoreId = spDoc->get_im_root()->get_content_item(0)->get_id();
+
+        GmoBoxSystem* pBSys = pGModel->get_system_box(1, scoreId);
+        CHECK( pBSys->get_first_measure(0) == 4 );
+        CHECK( pBSys->get_first_measure(1) == 6 );
+        CHECK( pBSys->get_num_measures(0) == 4 );
+        CHECK( pBSys->get_num_measures(1) == 6 );
+
+        delete pIntor;
+    }
+
 };
 
 

--- a/test-scores/unit-tests/other/04-multimetric.lms
+++ b/test-scores/unit-tests/other/04-multimetric.lms
@@ -1,0 +1,197 @@
+(score (vers 2.0)
+(opt Score.JustifyLastSystem 3)  //3 = always
+(instrument 
+   (name "Viol.")
+   (staves 1)
+   (musicData 
+
+      /* measure 1 */
+      (clef G p1 )
+      (key G)
+      (time 3 4)
+      (chord 
+         (n g3 q v1  p1 )
+         (n d4 q v1  p1 )
+      )
+      (r e v1  p1 )
+      (n g5 e v1  p1 )
+      (n g5 s v1  p1 (beam 35 ++))
+      (n f5 s v1  p1 (beam 35 =-))
+      (n g5 e v1  p1 (beam 35 -))
+      (barline simple)
+
+      /* measure 2 */
+      (r h. v1  p1 )
+      (barline simple)
+
+      /* measure 3 */
+      (chord 
+         (n g3 h v1  p1 )
+         (n d4 h v1  p1 )
+      )
+      (chord 
+         (n g3 q v1  p1 )
+         (n d4 q v1  p1 )
+      )
+      (barline simple)
+
+      /* measure 4 */
+      (chord 
+         (n a4 q v1  p1 )
+         (n e5 q v1  p1 )
+      )
+      (r q v1  p1 )
+      (chord 
+         (n d4 q v1  p1 )
+         (n g4 q v1  p1 )
+         (n f5 q v1  p1 )
+      )
+      (barline simple)
+
+      /* measure 5 */
+      (chord 
+         (n g3 q v1  p1 )
+         (n d4 q v1  p1 )
+      )
+      (r e v1  p1 )
+      (n g5 e v1  p1 )
+      (n g5 s v1  p1 (beam 35 ++))
+      (n f5 s v1  p1 (beam 35 =-))
+      (n g5 e v1  p1 (beam 35 -))
+      (barline simple)
+
+      /* measure 6 */
+      (r h. v1  p1 )
+      (barline simple)
+
+      /* measure 7 */
+      (chord 
+         (n g3 h v1  p1 )
+         (n d4 h v1  p1 )
+      )
+      (chord 
+         (n g3 q v1  p1 )
+         (n d4 q v1  p1 )
+      )
+      (barline simple)
+
+      /* measure 8 */
+      (chord 
+         (n a4 q v1  p1 )
+         (n e5 q v1  p1 )
+      )
+      (r q v1  p1 )
+      (chord 
+         (n d4 q v1  p1 )
+         (n g4 q v1  p1 )
+         (n f5 q v1  p1 )
+      )
+      (barline simple)
+   )
+)
+(instrument 
+   (name "Viol.")
+   (staves 1)
+   (musicData 
+
+      /* measure 1 */
+      (clef G p1 )
+      (key G)
+      (time 2 4)
+      (n g4 q v1  p1 )
+      (n d5 e v1  p1 (beam 79 +))
+      (n d5 e v1  p1 (beam 79 -))
+      (barline simple)
+
+      /* measure 2 */
+      (n b5 e v1  p1 (beam 88 +))
+      (n a5 s v1  p1 (beam 88 =+))
+      (n g5 s v1  p1 (beam 88 --))
+      (n g5 e v1  p1 (beam 97 +))
+      (n g5 e v1  p1 (beam 97 -))
+      (barline simple)
+
+      /* measure 3 */
+      (n e5 e v1  p1 (beam 106 +))
+      (n d5 s v1  p1 (beam 106 =+))
+      (n c5 s v1  p1 (beam 106 --))
+      (n e5 e v1  p1 (beam 115 +))
+      (n e5 e v1  p1 (beam 115 -))
+      (barline simple)
+
+      /* measure 4 */
+      (n d5 e v1  p1 (beam 125 +))
+      (n g5 e v1  p1 (beam 125 =))
+      (n g5 e v1  p1 (beam 125 =))
+      (n g5 e v1  p1 (beam 125 -))
+      (barline simple)
+
+      /* measure 5 */
+      (n b5 e v1  p1 (beam 137 +))
+      (n g5 e v1  p1 (beam 137 -))
+      (n e5 s v1  p1 (beam 146 ++))
+      (n c5 s v1  p1 (beam 146 ==))
+      (n e5 s v1  p1 (beam 146 ==))
+      (n c5 s v1  p1 (beam 146 --))
+      (barline simple)
+
+      /* measure 6 */
+      (n b4 s v1  p1 (beam 160 ++))
+      (n d5 s v1  p1 (beam 160 ==))
+      (n b4 s v1  p1 (beam 160 ==))
+      (n d5 s v1  p1 (beam 160 --))
+      (n c5 e v1  p1 (beam 172 +))
+      (n b4 s v1  p1 (beam 172 =+))
+      (n a4 s v1  p1 (beam 172 --))
+      (barline simple)
+
+      /* measure 7 */
+      (n g4 q v1  p1 )
+      (n d5 e v1  p1 (beam 79 +))
+      (n d5 e v1  p1 (beam 79 -))
+      (barline simple)
+
+      /* measure 8 */
+      (n b5 e v1  p1 (beam 88 +))
+      (n a5 s v1  p1 (beam 88 =+))
+      (n g5 s v1  p1 (beam 88 --))
+      (n g5 e v1  p1 (beam 97 +))
+      (n g5 e v1  p1 (beam 97 -))
+      (barline simple)
+
+      /* measure 9 */
+      (n e5 e v1  p1 (beam 106 +))
+      (n d5 s v1  p1 (beam 106 =+))
+      (n c5 s v1  p1 (beam 106 --))
+      (n e5 e v1  p1 (beam 115 +))
+      (n e5 e v1  p1 (beam 115 -))
+      (barline simple)
+
+      /* measure 10 */
+      (n d5 e v1  p1 (beam 125 +))
+      (n g5 e v1  p1 (beam 125 =))
+      (n g5 e v1  p1 (beam 125 =))
+      (n g5 e v1  p1 (beam 125 -))
+      (barline simple)
+
+      /* measure 11 */
+      (n b5 e v1  p1 (beam 137 +))
+      (n g5 e v1  p1 (beam 137 -))
+      (n e5 s v1  p1 (beam 146 ++))
+      (n c5 s v1  p1 (beam 146 ==))
+      (n e5 s v1  p1 (beam 146 ==))
+      (n c5 s v1  p1 (beam 146 --))
+      (barline simple)
+
+      /* measure 12 */
+      (n b4 s v1  p1 (beam 160 ++))
+      (n d5 s v1  p1 (beam 160 ==))
+      (n b4 s v1  p1 (beam 160 ==))
+      (n d5 s v1  p1 (beam 160 --))
+      (n c5 e v1  p1 (beam 172 +))
+      (n b4 s v1  p1 (beam 172 =+))
+      (n a4 s v1  p1 (beam 172 --))
+      (barline simple)
+   )
+))
+


### PR DESCRIPTION
This PR adds a new method `GmoBoxSystem::get_num_measures()` and also adds more API documentation for `GmoBoxSystem` and some other `GmoObj` objects .