### PR TITLE
Add missing include for limits

### DIFF
--- a/src/graphic_model/engravers/lomse_wedge_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_wedge_engraver.cpp
@@ -19,6 +19,8 @@
 #include "lomse_aux_shapes_aligner.h"
 #include "lomse_vertical_profile.h"
 
+#include <limits>
+
 
 namespace lomse
 {


### PR DESCRIPTION
Without this the following error occurs when compiling with gcc 12.2.0:

```
src/graphic_model/engravers/lomse_wedge_engraver.cpp:
  In member function 'lomse::LUnits lomse::WedgeEngraver::determine_default_shape_position_left(bool) const':
src/graphic_model/engravers/lomse_wedge_engraver.cpp:242:39: error: 'numeric_limits' is not a member of 'std'
  242 |     constexpr LUnits xMaxValue = std::numeric_limits<LUnits>::max();
      |                                       ^~~~~~~~~~~~~~
src/graphic_model/engravers/lomse_wedge_engraver.cpp:242:60: error: expected primary-expression before '>' token
  242 |     constexpr LUnits xMaxValue = std::numeric_limits<LUnits>::max();
      |                                                            ^
src/graphic_model/engravers/lomse_wedge_engraver.cpp:242:66: error: no matching function for call to 'max()'
  242 |     constexpr LUnits xMaxValue = std::numeric_limits<LUnits>::max();
      |                                                             ~~~~~^~
```