### PR TITLE
Fix importing and rendering cross-system beams

### DIFF
--- a/include/lomse_beam_engraver.h
+++ b/include/lomse_beam_engraver.h
@@ -82,6 +82,7 @@ protected:
     bool m_fCrossStaff;         //the flag notes are on both staves
     bool m_fGraceNotes;         //it is a beam with grace notes
     bool m_fChord;              //it is a beam with chords
+    size_t m_firstNoteRestIndex; //index of the first note/rest to consider. May be nonzero if beam is split across systems
     int m_numNotes;             //total number of notes
     int m_maxStaff;     //for cross-staff beams, the highest staff. For normal beams, just the staff
     int m_minStaff;     //for cross-staff beams, the lowest staff. For normal beams, just the staff
@@ -125,6 +126,7 @@ protected:
             void add_segment(LUnits uxStart, LUnits uyStart, LUnits uxEnd, LUnits uyEnd);
             void make_segments_relative();
 
+    GmoShapeBeam* create_beam_shape();
     void create_shape();
     void add_shape_to_noterests();
     void add_stroke_for_graces();


### PR DESCRIPTION
This pull request contains patches necessary to support cross-system beams, which fixes #388 and other similar crashes. With these patches the relevant systems from the score referenced in #388 looks like this (note the beam between the last note of the first system and the first note of the second system):
![изображение](https://user-images.githubusercontent.com/6000747/216393064-582139da-9a09-40e7-a430-fe612ee156fd.png)

Apart from the changes that implement rendering cross-system beams, this pull request also improves importing cross-measure beams from MusicXML. Presence of cross-measure beams may lead to having multiple beams simultaneously open when parsing a MusicXML document, which can lead, without these changes, to some beams being mixed up:
![изображение](https://user-images.githubusercontent.com/6000747/216394404-e918c4da-d9ac-40f0-9f9c-2c0586b054c6.png)