### PR TITLE
Fix color inheritance for stems, flags and beams

### DIFF
--- a/.github/workflows/build-PR.yml
+++ b/.github/workflows/build-PR.yml
@@ -33,7 +33,7 @@ jobs:
             elif [ "$RUNNER_OS" == "macOS" ]; then
                 brew install unittest-cpp
                 brew tap homebrew/cask-fonts
-                brew install --cask font-noto-sans-cjk 
+                brew install font-noto-sans-cjk 
             else
                 echo "$RUNNER_OS not supported"
                 exit 1

--- a/.github/workflows/build-PR.yml
+++ b/.github/workflows/build-PR.yml
@@ -32,8 +32,8 @@ jobs:
                 sudo apt-get install --yes fonts-noto-cjk
             elif [ "$RUNNER_OS" == "macOS" ]; then
                 brew install unittest-cpp
-                brew tap homebrew/cask-fonts
-                brew install font-noto-sans-cjk 
+                brew tap homebrew/cask
+                brew install --cask font-noto-sans-cjk 
             else
                 echo "$RUNNER_OS not supported"
                 exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ##### COMPATIBLE CHANGES
 
-- None.
+- Color inheritance for stems, flags and beams when color has not been
+  explicitly specified for them in the source file(any source format, LDP, 
+  MusicXML,...) has been defined and implemented.
 
 
 

--- a/cmake-modules/FindUnitTest++.cmake
+++ b/cmake-modules/FindUnitTest++.cmake
@@ -5,10 +5,18 @@
 # 	UNITTEST++_FOUND
 # 	UNITTEST++_INCLUDE_DIR
 #
+include(FindPkgConfig)
+include(FindPackageHandleStandardArgs)
+
+# Use pkg-config to get hints about paths
+pkg_check_modules(UnitTest++_PKGCONF QUIET unittest++)
+
 find_path(UNITTEST++_INCLUDE_DIR 
 	NAME
 		UnitTest++.h
 	PATHS
+	    ${UnitTest++_PKGCONF_INCLUDE_DIRS}
+  	    ${CMAKE_SOURCE_DIR}/tests/UnitTest++/src
 		/usr/local/include
 		/usr/include
 		/usr/include/unittest++
@@ -25,12 +33,23 @@ find_path(UNITTEST++_INCLUDE_DIR
 		$ENV{UnitTest++_DIR}/include/UnitTest++						#Windows
 		"C:/Program Files (x86)/UnitTest++/include/UnitTest++"		#Windows
 		"C:/Program Files/UnitTest++/include/UnitTest++"		    #Windows
+        /usr/local/Cellar/                      # for macOS when UnitTest++ is installed using Homebrew
+        /usr/local/Cellar/include               # for macOS when UnitTest++ is installed using Homebrew
+        /usr/local/Cellar/include/unittest++    # for macOS when UnitTest++ is installed using Homebrew
+        /usr/local/Cellar/include/UnitTest++    # for macOS when UnitTest++ is installed using Homebrew
+    #By default, Homebrew will install all packages in the directory /usr/local/Cellar/ ,
+    #and also creates symbolic links at /usr/local/opt/ and /usr/local/bin/ (for executable files).
+    PATH_SUFFIXES
+	    unittest++
+	    UnitTest++
 )
 
 FIND_LIBRARY (UNITTEST++_LIBRARY
 	NAMES
-		UnitTest++
+		unittest++ UnitTest++
 	PATHS 
+  	    ${UnitTest++_PKGCONF_LIBRARY_DIRS}
+  	    ${CMAKE_SOURCE_DIR}/tests/UnitTest++
 		/usr/lib
 		/usr/local/lib
 		/usr/lib64/ 		# Fedora
@@ -41,6 +60,10 @@ FIND_LIBRARY (UNITTEST++_LIBRARY
 		$ENV{UnitTest++_DIR}/lib					#Windows
 		"C:/Program Files (x86)/UnitTest++/lib"		#Windows
 		"C:/Program Files/UnitTest++/lib"			#Windows
+        /usr/local/Cellar/          # for macOS when UnitTest++ is installed using Homebrew
+        /usr/local/Cellar/lib       # for macOS when UnitTest++ is installed using Homebrew
+    #By default, Homebrew will install all packages in the directory /usr/local/Cellar/ ,
+    #and also creates symbolic links at /usr/local/opt/ and /usr/local/bin/ (for executable files).
 )
 
 SET (UNITTEST++_FOUND FALSE)

--- a/include/lomse_beam_engraver.h
+++ b/include/lomse_beam_engraver.h
@@ -110,6 +110,7 @@ public:
 protected:
     void add_note_rest(ImoStaffObj* pSO, GmoShape* pStaffObjShape);
     void determine_number_of_beam_levels();
+    void determine_beam_color();
     void decide_stems_direction();
         void decide_stems_direction_for_beams_with_chords();
         void decide_stems_direction_for_beams_without_chords();

--- a/include/lomse_chord_engraver.h
+++ b/include/lomse_chord_engraver.h
@@ -108,6 +108,7 @@ protected:
     void layout_accidentals();
     void layout_arpeggio();
     void determine_stem_x_left();
+    void determine_stem_flag_color();
     void add_stem_and_flag();
     void add_stem_flag_segment(StemFlagEngraver* engrv);
     void add_stem_link_segment();

--- a/src/graphic_model/engravers/lomse_beam_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_beam_engraver.cpp
@@ -138,6 +138,7 @@ GmoShape* BeamEngraver::create_last_shape(const RelObjEngravingContext& ctx)
 //---------------------------------------------------------------------------------------
 GmoShapeBeam* BeamEngraver::create_beam_shape()
 {
+    determine_beam_color();
     decide_stems_direction();
     determine_number_of_beam_levels();
 
@@ -473,6 +474,39 @@ void BeamEngraver::decide_beam_position()
         }
     }
 
+}
+
+//---------------------------------------------------------------------------------------
+void BeamEngraver::determine_beam_color()
+{
+    Color color = m_color;
+
+    //find first stem
+    std::list< pair<ImoNoteRest*, GmoShape*> >::iterator it;
+    for(it=m_noteRests.begin(); it != m_noteRests.end(); ++it)
+    {
+        if ((it->first)->is_note())      //ignore rests
+        {
+            GmoShapeNote* pNoteShape = static_cast<GmoShapeNote*>(it->second);
+	        GmoShapeStem* pStemShape = pNoteShape->get_stem_shape();
+            color = pStemShape->get_normal_color();
+            ++it;
+            break;
+        }
+    }
+
+    //process all other stems
+    for (; it != m_noteRests.end(); ++it)
+    {
+        if ((it->first)->is_note())      //ignore rests
+        {
+            GmoShapeNote* pNoteShape = static_cast<GmoShapeNote*>(it->second);
+	        GmoShapeStem* pStemShape = pNoteShape->get_stem_shape();
+            if (!is_equal(color, pStemShape->get_normal_color()))
+                return;
+        }
+    }
+    m_color = color;
 }
 
 //---------------------------------------------------------------------------------------
@@ -1862,9 +1896,9 @@ void BeamEngraver::position_segments(std::vector<SegmentData>* pSegs)
         if (sgd.position == k_beam_above)
             yShift = - yShift;
 
-        LUnits yStart = sgd.yStart + yShift;
-        LUnits yEnd = sgd.yEnd + yShift;
-        add_segment(sgd.xStart, yStart, sgd.xEnd, yEnd);
+        LUnits yStart2 = sgd.yStart + yShift;
+        LUnits yEnd2 = sgd.yEnd + yShift;
+        add_segment(sgd.xStart, yStart2, sgd.xEnd, yEnd2);
 
         //increment stem lenght of start note
         if (sgd.pStartNote)

--- a/src/graphic_model/engravers/lomse_chord_engraver.cpp
+++ b/src/graphic_model/engravers/lomse_chord_engraver.cpp
@@ -674,6 +674,8 @@ void ChordEngraver::add_stem_and_flag()
     if (!has_stem())
         return;
 
+    determine_stem_flag_color();
+
     ImoNote* pNoteFlag = m_pFlagNoteData->pNote;
     int instr = m_pFlagNoteData->iInstr;
     int staff = pNoteFlag->get_staff();
@@ -685,6 +687,24 @@ void ChordEngraver::add_stem_and_flag()
     add_stem_link_segment();
     add_stem_extensible_segment_if_required();
     add_stroke_for_graces_if_required(&engrv);
+}
+
+//---------------------------------------------------------------------------------------
+void ChordEngraver::determine_stem_flag_color()
+{
+    Color color = m_color;
+    std::list<ChordNoteData*>::iterator it = m_notes.begin();
+    if (it != m_notes.end())
+    {
+        color = (*it)->pNoteShape->get_normal_color();
+        ++it;
+    }
+    for (; it != m_notes.end(); ++it)
+    {
+        if (!is_equal(color, (*it)->pNoteShape->get_normal_color()))
+            return;
+    }
+    m_color = color;
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -234,7 +234,7 @@ void ScoreLayouter::layout_in_box()
                 set_layout_result(k_layout_success);
                 delete_system();
                 return;
-            #elseif (0)
+            #elif (0)
                 //Overrun paper
                 add_system_to_page();
                 fSystemsAdded = true;

--- a/src/graphic_model/layouters/lomse_score_layouter.cpp
+++ b/src/graphic_model/layouters/lomse_score_layouter.cpp
@@ -1167,18 +1167,18 @@ GmoShape* ShapesCreator::create_staffobj_shape(ImoStaffObj* pSO, int iInstr, int
         }
         case k_imo_clef:
         {
-            ImoClef* pClef = static_cast<ImoClef*>(pSO);
-            if (pClef->get_clef_type() == k_clef_none)
+            ImoClef* pClefSO = static_cast<ImoClef*>(pSO);
+            if (pClefSO->get_clef_type() == k_clef_none)
             {
                 return create_invisible_shape(pSO, iInstr, iStaff, pos, 0.0f);
             }
             else
             {
                 bool fSmallClef = flags & k_flag_small_clef;
-                int clefSize = pClef->get_symbol_size();
+                int clefSize = pClefSO->get_symbol_size();
                 if (clefSize == k_size_default)
                     clefSize = fSmallClef ? k_size_cue : k_size_full;
-                Color color = pClef->get_color();
+                Color color = pClefSO->get_color();
                 ClefEngraver engrv(m_libraryScope, m_pScoreMeter, iInstr, iStaff);
                 return engrv.create_shape(pClef, pos, clefType, clefSize, color);
             }

--- a/src/tests/lomse_test_beam_engraver.cpp
+++ b/src/tests/lomse_test_beam_engraver.cpp
@@ -145,7 +145,7 @@ public:
         ImoInstrument* pInstr = m_pScore->get_instrument(0);
         ImoMusicData* pMD = pInstr->get_musicdata();
         ImoNote* pNote1 = static_cast<ImoNote*>( pMD->get_child(1) );
-        return dynamic_cast<ImoBeam*>( pNote1->get_relation(0) );
+        return dynamic_cast<ImoBeam*>( pNote1->find_relation(k_imo_beam) );
     }
 
     //-----------------------------------------------------------------------------------
@@ -188,7 +188,9 @@ public:
             ImoNote* pNote = static_cast<ImoNote*>( (*it).first );
             GmoShapeNote* pShape = dynamic_cast<GmoShapeNote*>(
                 m_pNoteEngrv->create_shape(pNote, k_clef_G2, 0,
-                                           UPoint(10.0f, 15.0f)) );
+                                           UPoint(10.0f, 15.0f),
+                                           nullptr,
+                                           pNote->get_color()) );
             m_shapes.push_back(pShape);
         }
 
@@ -742,7 +744,41 @@ SUITE(BeamEngraverTest)
     }
 
 
+    // 04x. Tests for beam color --------------------------------------------------------
 
+    TEST_FIXTURE(BeamEngraverTestFixture, beam_engraver_040)
+    {
+        //@040 - beam color same than stem color when all stems have the same color
+        Document doc(m_libraryScope);
+        ImoBeam* pBeam = create_beam(doc,
+            "(n e4 e g+ (color #ff00ff))(n g3 e g- (color #ff00ff))");
+        prepare_to_engrave_beam(pBeam);
+
+        RelObjEngravingContext ctx;
+        m_pBeamShape = dynamic_cast<GmoShapeBeam*>( m_pBeamEngrv->create_last_shape(ctx) );
+        CHECK( m_pBeamShape != nullptr );
+        Color colorBeam = m_pBeamShape->get_normal_color();
+        CHECK( is_equal(colorBeam, Color(255,0,255)) );
+
+        delete_test_data();
+    }
+
+    TEST_FIXTURE(BeamEngraverTestFixture, beam_engraver_041)
+    {
+        //@041 - beam color black when not all stems have the same color
+        Document doc(m_libraryScope);
+        ImoBeam* pBeam = create_beam(doc,
+            "(n e4 e g+ (color #ff00ff))(n g3 e g- (color #0000ff))");
+        prepare_to_engrave_beam(pBeam);
+
+        RelObjEngravingContext ctx;
+        m_pBeamShape = dynamic_cast<GmoShapeBeam*>( m_pBeamEngrv->create_last_shape(ctx) );
+        CHECK( m_pBeamShape != nullptr );
+        Color colorBeam = m_pBeamShape->get_normal_color();
+        CHECK( is_equal(colorBeam, Color(0,0,0)) );
+
+        delete_test_data();
+    }
 
 
     // 05x. Tests for stem length -------------------------------------------------------

--- a/src/tests/lomse_test_chord_engraver.cpp
+++ b/src/tests/lomse_test_chord_engraver.cpp
@@ -60,6 +60,18 @@ public:
     inline void my_set_anchor_offset() { set_anchor_offset(); }
     inline void my_find_reference_notes() { find_reference_notes(); }
 
+    GmoShapeStem* get_flag_stem_shape() const
+    {
+        GmoShapeNote* pFlagNoteShape = m_pFlagNoteData->pNoteShape;
+        return pFlagNoteShape->get_stem_shape();
+    }
+    GmoShapeStem* get_link_stem_shape() const
+    {
+        GmoShapeNote* pLinkNoteShape = m_pLinkNoteData->pNoteShape;
+        return pLinkNoteShape->get_stem_shape();
+    }
+    inline GmoShapeNote* get_base_note_shape() const { return m_pBaseNoteData->pNoteShape; }
+
 };
 
 
@@ -175,12 +187,17 @@ public:
         m_pStorage = LOMSE_NEW EngraversMap();
         m_pNoteEngrv = LOMSE_NEW NoteEngraver(m_libraryScope, m_pMeter, m_pStorage, 0, 0);
         m_pShape1 =
-            dynamic_cast<GmoShapeNote*>(m_pNoteEngrv->create_shape(m_pNote1, k_clef_G2, 0, UPoint(10.0f, 15.0f)) );
+            dynamic_cast<GmoShapeNote*>(m_pNoteEngrv->create_shape(m_pNote1, k_clef_G2, 0,
+                UPoint(10.0f, 15.0f), nullptr, m_pNote1->get_color()) );
         m_pShape2 =
-            dynamic_cast<GmoShapeNote*>(m_pNoteEngrv->create_shape(m_pNote2, k_clef_G2, 0, UPoint(10.0f, 15.0f)) );
+            dynamic_cast<GmoShapeNote*>(m_pNoteEngrv->create_shape(m_pNote2, k_clef_G2, 0,
+                UPoint(10.0f, 15.0f), nullptr, m_pNote2->get_color()) );
         if (m_pNote3)
+        {
             m_pShape3 =
-                dynamic_cast<GmoShapeNote*>(m_pNoteEngrv->create_shape(m_pNote3, k_clef_G2, 0, UPoint(10.0f, 15.0f)) );
+                dynamic_cast<GmoShapeNote*>(m_pNoteEngrv->create_shape(m_pNote3, k_clef_G2, 0,
+                    UPoint(10.0f, 15.0f), nullptr, m_pNote3->get_color()) );
+        }
 
         //engrave the chord
         load_notes_in_chord_engraver();
@@ -732,7 +749,7 @@ SUITE(ChordEngraverTest)
         delete_chord();
     }
 
-    //@4xx - beamed chords --------------------------------------------------------------
+    //@4xx - chords ---------------------------------------------------------------------
 
 
     TEST_FIXTURE(ChordEngraverTestFixture, chord_engraver_401)
@@ -797,6 +814,36 @@ SUITE(ChordEngraverTest)
 //
 //        delete_chord();
 //    }
+
+    TEST_FIXTURE(ChordEngraverTestFixture, chord_engraver_405)
+    {
+        //@405 - stem color same than all noteheads when colored noteheads
+
+        Document doc(m_libraryScope);
+        doc.from_string(
+            "(score (vers 2.1)(instrument (musicData (clef G)"
+            "(chord (n a4 q (color #ff0000))(n e5 q (color #ff0000)))"
+            ")))", Document::k_format_ldp);
+        ImoChord* pChord = get_imochord_for_chord(0, &doc);
+        CHECK( pChord != nullptr );
+
+        load_notes_in_chord_engraver(pChord);
+        m_pChordEngrv->create_shapes();
+        Color colorNote = m_pChordEngrv->get_base_note_shape()->get_normal_color();
+        CHECK ( is_equal(colorNote, Color(255,0,0)) );
+        CHECK ( is_equal(m_pShape1->get_normal_color(), Color(255,0,0)) );
+        CHECK ( is_equal(m_pShape2->get_normal_color(), Color(255,0,0)) );
+
+        GmoShapeStem* pStem = m_pChordEngrv->get_flag_stem_shape();
+        Color colorStem = pStem->get_normal_color();
+        CHECK( is_equal(colorStem, Color(255,0,0)) );
+
+        pStem = m_pChordEngrv->get_link_stem_shape();
+        colorStem = pStem->get_normal_color();
+        CHECK( is_equal(colorStem, Color(255,0,0)) );
+
+        delete_chord();
+    }
 
     TEST_FIXTURE(ChordEngraverTestFixture, chord_engraver_410)
     {

--- a/src/tests/lomse_test_chord_engraver.cpp
+++ b/src/tests/lomse_test_chord_engraver.cpp
@@ -845,6 +845,36 @@ SUITE(ChordEngraverTest)
         delete_chord();
     }
 
+    TEST_FIXTURE(ChordEngraverTestFixture, chord_engraver_406)
+    {
+        //@406 - stem color black when noteheads with different colors
+
+        Document doc(m_libraryScope);
+        doc.from_string(
+            "(score (vers 2.1)(instrument (musicData (clef G)"
+            "(chord (n a4 q (color #ff0000))(n e5 q (color #00ff00)))"
+            ")))", Document::k_format_ldp);
+        ImoChord* pChord = get_imochord_for_chord(0, &doc);
+        CHECK( pChord != nullptr );
+
+        load_notes_in_chord_engraver(pChord);
+        m_pChordEngrv->create_shapes();
+        Color colorNote = m_pChordEngrv->get_base_note_shape()->get_normal_color();
+        CHECK ( is_equal(colorNote, Color(255,0,0)) );
+        CHECK ( is_equal(m_pShape1->get_normal_color(), Color(255,0,0)) );
+        CHECK ( is_equal(m_pShape2->get_normal_color(), Color(0,255,0)) );
+
+        GmoShapeStem* pStem = m_pChordEngrv->get_flag_stem_shape();
+        Color colorStem = pStem->get_normal_color();
+        CHECK( is_equal(colorStem, Color(0,0,0)) );
+
+        pStem = m_pChordEngrv->get_link_stem_shape();
+        colorStem = pStem->get_normal_color();
+        CHECK( is_equal(colorStem, Color(0,0,0)) );
+
+        delete_chord();
+    }
+
     TEST_FIXTURE(ChordEngraverTestFixture, chord_engraver_410)
     {
         //@410 - collect_chord_notes()

--- a/test-scores/00301-color-inheritance-stems-beams.lms
+++ b/test-scores/00301-color-inheritance-stems-beams.lms
@@ -1,0 +1,15 @@
+(score (vers 2.0) 
+(instrument (musicData 
+    (clef F4)(key C)
+    (n e3 q)(n g3 q)
+    (chord (n b3 q (stem down)(color #ff0000))(n +d4 q (color #ff0000))(n +f4 q (color #ff0000)))
+    (n e4 q)(n g3 q (color #0000ff))
+    (chord (n b3 q (stem down)(color #ff0000))(n +d4 q (color #00ff00))(n +f4 q (color #0000ff)))
+    (n e4 e g+)(n g3 e g- (color #ff00ff))
+    (n e4 e g+ (color #ff00ff))(n g3 e g- (color #ff00ff))
+    (chord (n b3 e (stem down)(beam 1 +))(n +d4 e (color #ff0000))(n +f4 e))
+    (chord (n b3 e (stem down)(beam 1 -))(n +d4 e )(n +f4 e))
+    (chord (n b3 e (stem down)(beam 2 +)(color #ff0000))(n +d4 e (color #ff0000))(n +f4 e (color #ff0000)))
+    (chord (n b3 e (stem down)(beam 2 -)(color #ff0000))(n +d4 e (color #ff0000))(n +f4 e (color #ff0000)))
+)))
+


### PR DESCRIPTION
This PR implements color inheritance for stems, flags and beams (any source format, LDP, MusicXML,...), and closes #393. It also clarifies the color inheritance criteria for stems, flags and beams when color has not been explicitly specified for them in the source file:

_Stems and flags are always rendered in the default color (black) unless the source file specifies a color. When the stem color has not been explicitly specified, the stem and the flag are rendered in the same color as the notehead._

_For a chord, when color has not been explicitly defined in the source file for the stem and flag, they are rendered in the same color as all the noteheads, but if the noteheads do not all have the same color, stem and flag are rendered in the default color (black)._

_For the beam that joins a group of notes or chords, the rule is similar: if the beam color has not been specified in the source file, it will be drawn in the same color as all the stems only if they all have the same color; otherwise, in the default color (black)._

The following image is the rendering of the LDP code in test score '00301-color-inheritance-stems-beams.lms':


![image](https://github.com/lenmus/lomse/assets/5238679/4b15d08d-db7c-4d70-8808-560fcead1a20)

