### PR TITLE
Support include through CMake Package Manager + Fix recent breaking change in freetype

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,9 @@ cmake_policy(SET CMP0042 NEW)   #MACOSX_RPATH is enabled by default
 #Windows 10 camplains 
 cmake_policy(SET CMP0054 NEW)   # quoted arguments will not be further dereferenced
 
+# project name
+project(lomse)
+
 #prevent in-source builds
   # make sure the user doesn't play dirty with symlinks
   get_filename_component(srcdir "${PROJECT_SOURCE_DIR}" REALPATH)
@@ -232,10 +235,6 @@ cmake_policy(SET CMP0054 NEW)   # quoted arguments will not be further dereferen
     message("**********************************************************")
     message(FATAL_ERROR "Quitting configuration")
   endif()
-
-
-# project name
-project(lomse)
 
 # uncomment for debugging
 #set(CMAKE_VERBOSE_MAKEFILE on)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,8 +211,8 @@ cmake_policy(SET CMP0054 NEW)   # quoted arguments will not be further dereferen
 
 #prevent in-source builds
   # make sure the user doesn't play dirty with symlinks
-  get_filename_component(srcdir "${CMAKE_SOURCE_DIR}" REALPATH)
-  get_filename_component(bindir "${CMAKE_BINARY_DIR}" REALPATH)
+  get_filename_component(srcdir "${PROJECT_SOURCE_DIR}" REALPATH)
+  get_filename_component(bindir "${PROJECT_BINARY_DIR}" REALPATH)
 
   # disallow in-source builds
   if("${srcdir}" STREQUAL "${bindir}")
@@ -419,8 +419,8 @@ message(STATUS "")
 include( ${LOMSE_ROOT_DIR}/build-version.cmake )
 
 add_custom_target (build-version ALL
-  COMMAND ${CMAKE_COMMAND} -D LOMSE_ROOT_DIR=${CMAKE_SOURCE_DIR} -P ${CMAKE_SOURCE_DIR}/build-version.cmake
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMAND ${CMAKE_COMMAND} -D LOMSE_ROOT_DIR=${PROJECT_SOURCE_DIR} -P ${PROJECT_SOURCE_DIR}/build-version.cmake
+  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
   COMMENT "setting Lomse version information ...")
 
 # identify platform and compiler

--- a/src/render/lomse_font_freetype.cpp
+++ b/src/render/lomse_font_freetype.cpp
@@ -158,7 +158,7 @@ bool decompose_ft_outline(const FT_Outline& outline, bool flip_y, const trans_af
 
     FT_Vector*  point;
     FT_Vector*  limit;
-    char*       tags;
+    unsigned char*       tags;
 
     int   n;         // index of contour in outline
     int   first;     // index of first point in contour

--- a/src/render/lomse_font_freetype.cpp
+++ b/src/render/lomse_font_freetype.cpp
@@ -158,7 +158,13 @@ bool decompose_ft_outline(const FT_Outline& outline, bool flip_y, const trans_af
 
     FT_Vector*  point;
     FT_Vector*  limit;
+    // Freetype version 2.13.3 and later uses unsigned char for tags
+#if (FREETYPE_MAJOR > 2) || (FREETYPE_MAJOR == 2 && FREETYPE_MINOR > 13) || \
+    (FREETYPE_MAJOR == 2 && FREETYPE_MINOR == 13 && FREETYPE_PATCH >= 3)
     unsigned char*       tags;
+#else
+    char*       tags;
+#endif
 
     int   n;         // index of contour in outline
     int   first;     // index of first point in contour


### PR DESCRIPTION
2 small fixes:

- In order to include the library through CMake package managers such as [CPM](https://github.com/cpm-cmake/CPM.cmake), the `CMakeLists.txt` should use `${PROJECT_SOURCE_DIR}` and `${PROJECT_BINARY_DIR}` instead of `${CMAKE_SOURCE_DIR}` and `${CMAKE_BINARY_DIR}` respectively.

- Since commit [`044d142`](https://github.com/freetype/freetype/commit/044d142be7b6a93b6940367a1bc5847451ff4775) of freetype, the tags in `FT_Outline` are now of type `unsigned char*`, which should be echoed in `lomse_font_freetype.cpp`. 